### PR TITLE
A mangled encoding is three defects

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1059,8 +1059,20 @@ severity = "warn"
 # Authentication scheme holds a character outside token
 severity = "warn"
 
+[violations.base64_character_forbidden]
+# Value holds an octet outside the base64 alphabet
+severity = "warn"
+
 [violations.base64_malformed]
 # Value is not a base64 encoding
+severity = "warn"
+
+[violations.base64_pad_bits_invalid]
+# Final base64 symbol carries bits a conforming encoder zeroes
+severity = "info"
+
+[violations.base64_quantum_malformed]
+# Value is not a whole number of base64 groups
 severity = "warn"
 
 [violations.basic_credentials_control_character_forbidden]

--- a/docs/rules/sec_websocket_headers_consistent.md
+++ b/docs/rules/sec_websocket_headers_consistent.md
@@ -28,7 +28,9 @@ Only HTTP/1.x messages are measured. Over HTTP/2 and HTTP/3 the opening handshak
 - [RFC 6455 §4.4](https://www.rfc-editor.org/rfc/rfc6455.html#section-4.4): Supporting Multiple Versions — why a `Sec-WebSocket-Version` other than 13 is a version advertisement rather than a malformed value, and what a server owes it
 - [RFC 8441 §5](https://www.rfc-editor.org/rfc/rfc8441.html#section-5): Updates RFC 6455: over HTTP/2 the handshake is an extended CONNECT, `Connection` and `Upgrade` MUST NOT be included, and `Sec-WebSocket-Key` is not processed — the sentences behind this rule's version gate
 - [RFC 9220 §3](https://www.rfc-editor.org/rfc/rfc9220.html#section-3): Carries RFC 8441's mechanism to HTTP/3 with identical semantics
-- [RFC 4648 §3.3](https://www.rfc-editor.org/rfc/rfc4648.html#section-3.3): The instruction to reject encoded data holding a character outside the base alphabet, which is what makes a malformed `Sec-WebSocket-Key` reportable rather than merely unusual
+- [RFC 4648 §3.3](https://www.rfc-editor.org/rfc/rfc4648.html#section-3.3): Interpretation of non-alphabet characters — a MUST to reject data outside the base alphabet, unless the referring specification says otherwise
+- [RFC 4648 §4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4): Base 64 Encoding — the 24-bit group written as four characters, and the padding that completes a final group of fewer bits
+- [RFC 4648 §3.5](https://www.rfc-editor.org/rfc/rfc4648.html#section-3.5): Canonical encoding — the discarded bits of a final symbol MUST be zero in what an encoder writes, and a decoder MAY reject an encoding where they are not
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
+++ b/lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
@@ -9,8 +9,63 @@ use crate::helpers::shown::{describe_octet, shown_in_finding};
 use crate::helpers::websocket::{sec_websocket_key_defect, version_production_defect};
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::base64::{
+    sec_websocket_key_defect as key_violation, BASE64_CHARACTER_FORBIDDEN, BASE64_PAD_BITS_INVALID,
+    BASE64_QUANTUM_MALFORMED, RFC_4648_3_3, RFC_4648_3_5, RFC_4648_4,
+};
+use crate::violations::ViolationDef;
 
 pub struct SecWebsocketHeadersConsistent;
+
+/// The three ways a `Sec-WebSocket-Key` can fail to be an encoding, none of
+/// which is a fact about WebSockets.
+///
+/// `Sec-WebSocket-Key = base64-value-non-empty`, and RFC 6455 hands the
+/// encoding to RFC 4648 without restating a character of it — so an octet
+/// outside the alphabet, a symbol count no group of twenty-four bits accounts
+/// for, and a final symbol whose discarded bits are not zero are the same three
+/// defects an `Authorization: Basic` value can have. What is left is the
+/// field's own sentence — the nonce is sixteen octets, and the field has to be
+/// there at all — and both of those stay in this rule's words: they belong to a
+/// `sec_websocket_key` subject nothing has written, and a subject with one
+/// reader is written when it is read twice.
+///
+/// The other three readings this rule makes — `Connection`, the version, the
+/// subprotocol list — are untouched here and say so through their type: an
+/// unnamed [`Defect`] is a finding no subject has claimed.
+static DECLARED: &[&ViolationDef] = &[
+    &BASE64_CHARACTER_FORBIDDEN,
+    &BASE64_QUANTUM_MALFORMED,
+    &BASE64_PAD_BITS_INVALID,
+];
+
+/// One finding from the reading, and the defect it reports as where the
+/// catalogue names that defect.
+///
+/// The shape `expect_header_valid` settled and `warning_header_syntax` reused: a
+/// judge that is half converted says so in its type rather than being split in
+/// two. Here the unnamed half is everything this rule reads that is not an
+/// encoding.
+struct Defect {
+    def: Option<&'static ViolationDef>,
+    message: String,
+}
+
+impl Defect {
+    /// A defect the catalogue names.
+    fn named(def: &'static ViolationDef, message: String) -> Self {
+        Self {
+            def: Some(def),
+            message,
+        }
+    }
+
+    /// A defect no subject has claimed yet, reported at the rule's severity the
+    /// way every finding here was before the catalogue existed.
+    fn unnamed(message: String) -> Self {
+        Self { def: None, message }
+    }
+}
 
 impl SecWebsocketHeadersConsistent {
     /// The `Connection` half of the handshake: the field has to be there and it has
@@ -87,17 +142,29 @@ impl SecWebsocketHeadersConsistent {
     /// What is wrong with the value is asked of the production's owner, which is
     /// also what `Sec-WebSocket-Accept` is derived through -- so the handshake is
     /// judged from one reading of the key rather than two.
+    ///
+    /// Three of the four verdicts are the encoding's and carry its ids; the
+    /// fourth is a well-formed encoding of the wrong number of octets, which is
+    /// this field's own sentence and is left unnamed. The field being absent
+    /// altogether is the same field's sentence and is left unnamed beside it —
+    /// one commit will write both, or neither.
     // cite(RFC 6455 § 4.1): "The request MUST include a header field with the name |Sec-WebSocket-Key|."
-    fn key_defect(headers: &hyper::HeaderMap) -> Option<String> {
+    fn key_defect(headers: &hyper::HeaderMap) -> Option<Defect> {
         let Some(raw) = combined_field_value_as_written(headers, "sec-websocket-key") else {
-            return Some("the request carries no Sec-WebSocket-Key header field".into());
+            return Some(Defect::unnamed(
+                "the request carries no Sec-WebSocket-Key header field".into(),
+            ));
         };
         let defect = sec_websocket_key_defect(&raw)?;
-        Some(format!(
+        let message = format!(
             "its Sec-WebSocket-Key is `{}`, which is not the nonce the field is defined as: {}",
             shown_in_finding(trim_ows(&raw)),
             defect
-        ))
+        );
+        Some(match key_violation(&defect) {
+            Some(def) => Defect::named(def, message),
+            None => Defect::unnamed(message),
+        })
     }
 
     /// The optional `Sec-WebSocket-Protocol`, which is two MUSTs about its members
@@ -200,12 +267,6 @@ const RFC_9220_3: crate::rules::SpecRef = crate::rules::SpecRef {
     url: "https://www.rfc-editor.org/rfc/rfc9220.html#section-3",
     note: "Carries RFC 8441's mechanism to HTTP/3 with identical semantics",
 };
-const RFC_4648_3_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 4648",
-    section: Some("3.3"),
-    url: "https://www.rfc-editor.org/rfc/rfc4648.html#section-3.3",
-    note: "The instruction to reject encoded data holding a character outside the base alphabet, which is what makes a malformed `Sec-WebSocket-Key` reportable rather than merely unusual",
-};
 
 impl RuleMeta for SecWebsocketHeadersConsistent {
     fn id(&self) -> &'static str {
@@ -231,7 +292,13 @@ severity = "warn"
             RFC_8441_5,
             RFC_9220_3,
             RFC_4648_3_3,
+            RFC_4648_4,
+            RFC_4648_3_5,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -317,18 +384,23 @@ impl Rule for SecWebsocketHeadersConsistent {
             // taking the document's order rather than a convenient one means the finding
             // an operator sees first is the one the list reaches first.
             let defect = [
-                Self::connection_defect(&req.headers),
+                Self::connection_defect(&req.headers).map(Defect::unnamed),
                 Self::key_defect(&req.headers),
-                Self::version_defect(&req.headers),
-                Self::subprotocol_defect(&req.headers),
+                Self::version_defect(&req.headers).map(Defect::unnamed),
+                Self::subprotocol_defect(&req.headers).map(Defect::unnamed),
             ]
             .into_iter()
             .flatten()
             .next()?;
 
-            violation(format!(
-                "This request asks to be upgraded to the WebSocket Protocol, but {defect}"
-            ))
+            let message = format!(
+                "This request asks to be upgraded to the WebSocket Protocol, but {}",
+                defect.message
+            );
+            match defect.def {
+                Some(def) => Some(ctx.report_with(def, message)),
+                None => violation(message),
+            }
         };
         Vec::from_iter(finding())
     }

--- a/lint-http-rules/src/violations/base64.rs
+++ b/lint-http-rules/src/violations/base64.rs
@@ -6,22 +6,34 @@
 //!
 //! RFC 4648's encoding is read in at least three places here: the
 //! `basic-credentials` of an `Authorization`, the `Sec-WebSocket-Key` of a
-//! handshake, and its `Sec-WebSocket-Accept` answer. The sentence that makes a
-//! bad one a finding is one sentence — § 3.3's MUST — so the defect is one
-//! defect and an operator who does not care about a mangled encoding says so
-//! once.
+//! handshake, and its `Sec-WebSocket-Accept` answer. None of those fields
+//! restates a character of it, so what is wrong with a mangled value is never a
+//! fact about credentials or about WebSockets, and an operator who does not
+//! care about a mangled encoding says so in one place for all of them.
 //!
-//! One entry today, and it is deliberately coarse: `base64::DecodeError` is
-//! what the `Basic` reader has, and it distinguishes nothing this catalogue
-//! could name. The WebSocket reader *does* split the same failure three ways —
-//! alphabet, shape, and pad bits a conforming encoder zeroes — so when it
-//! converts, its defects join this subject beside this one rather than
-//! replacing it. A coarse def and a fine one in the same subject are two
-//! readers, not two vocabularies.
+//! **Four entries, and one of them is deliberately coarse.**
+//! `base64::DecodeError` is what the `Basic` reader has, and it distinguishes
+//! nothing this catalogue could name, so `base64_malformed` answers for all of
+//! it. The WebSocket reader splits the same failure three ways — the alphabet,
+//! the quantum, and pad bits a conforming encoder zeroes — and those three sit
+//! *beside* the coarse one rather than replacing it. **A coarse def and a fine
+//! one in the same subject are two readers, not two vocabularies**, and an
+//! operator who wants the whole encoding quiet raises four entries rather than
+//! one. Say so here, because the next commit's instinct is to collapse them.
+//!
+//! **The whitespace/control split `docs/development.md` mandates is declined,
+//! and the reason is that no second sentence draws it.** Where a subject
+//! separates the octets nobody typed from the ones a sender chose, it does so
+//! because two different sentences refuse them — a field value's grammar
+//! excludes the control octet, the production's alphabet excludes the rest.
+//! RFC 4648 § 3.3 is one MUST over every character outside the sixty-four, and
+//! it does not care which one; the message names the octet, and the catalogue
+//! does not pretend to a distinction the specification declines to make.
 
+use crate::helpers::websocket::SecWebSocketKeyDefect;
 use crate::lint::Severity;
 use crate::rules::SpecRef;
-use crate::violations::defects;
+use crate::violations::{defects, ViolationDef};
 
 /// The instruction that makes a malformed encoding a finding rather than a
 /// judgment call — and it is addressed to the *decoder*, which is what a proxy
@@ -31,6 +43,24 @@ pub const RFC_4648_3_3: SpecRef = SpecRef {
     section: Some("3.3"),
     url: "https://www.rfc-editor.org/rfc/rfc4648.html#section-3.3",
     note: "Interpretation of non-alphabet characters — a MUST to reject data outside the base alphabet, unless the referring specification says otherwise",
+};
+
+/// The shape of an encoding, stated as arithmetic: four characters per
+/// twenty-four bits, and a final group padded out to them.
+pub const RFC_4648_4: SpecRef = SpecRef {
+    spec: "RFC 4648",
+    section: Some("4"),
+    url: "https://www.rfc-editor.org/rfc/rfc4648.html#section-4",
+    note: "Base 64 Encoding — the 24-bit group written as four characters, and the padding that completes a final group of fewer bits",
+};
+
+/// The one requirement here that a decoder is free to ignore, which is why the
+/// defect it names defaults below the other three.
+pub const RFC_4648_3_5: SpecRef = SpecRef {
+    spec: "RFC 4648",
+    section: Some("3.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc4648.html#section-3.5",
+    note: "Canonical encoding — the discarded bits of a final symbol MUST be zero in what an encoder writes, and a decoder MAY reject an encoding where they are not",
 };
 
 defects! {
@@ -45,5 +75,175 @@ defects! {
         message: "",
         default_severity: Severity::Warn,
         spec: Some(RFC_4648_3_3),
+    }
+
+    /// An octet the sixty-four characters do not hold. The finer half of
+    /// [`BASE64_MALFORMED`], reported where the reader knows *which* octet —
+    /// and § 3.3's MUST is the whole of what makes it a finding rather than a
+    /// curiosity, since the encoding itself has no opinion about what a decoder
+    /// does with a stray byte.
+    ///
+    // cite(RFC 4648 § 3.3): "Implementations MUST reject the encoded data if it contains characters outside the base alphabet when interpreting base-encoded data, unless the specification referring to this document explicitly states otherwise."
+    BASE64_CHARACTER_FORBIDDEN = {
+        id: "base64_character_forbidden",
+        title: "Value holds an octet outside the base64 alphabet",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_4648_3_3),
+    }
+
+    /// Every character is one the alphabet holds, and the sequence of them is
+    /// still not one the encoding produces: a symbol count no group of
+    /// twenty-four bits accounts for, or a pad character somewhere other than
+    /// the end. **The arithmetic, rather than the alphabet** — which is why it
+    /// is a separate entry from the one above and not a severity of it: the
+    /// fix is a different fix, and the encoder that produced it failed at a
+    /// different step.
+    ///
+    // cite(RFC 4648 § 4): "The encoding process represents 24-bit groups of input bits as output strings of 4 encoded characters."
+    BASE64_QUANTUM_MALFORMED = {
+        id: "base64_quantum_malformed",
+        title: "Value is not a whole number of base64 groups",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_4648_4),
+    }
+
+    /// A final symbol carrying bits a conforming encoder sets to zero. The
+    /// value decodes, and to exactly the octets it meant; what is wrong is that
+    /// the same octets have a canonical spelling and this is not it.
+    ///
+    /// **`info`, and the ranking is 2.28's read through the recipient again.**
+    /// The other three entries name values a decoder is instructed to reject;
+    /// § 3.5 leaves a decoder a choice in the same breath it states the
+    /// requirement — *"MAY chose to reject an encoding if the pad bits have not
+    /// been set to zero"* — and the document defining the field this is first
+    /// reported for prints such a value in its own NOTE. So the message
+    /// arrives, the octets are the right octets, and the finding is addressed
+    /// to whoever wrote the encoder.
+    ///
+    /// `_invalid` rather than `_malformed` for the same reason: the value
+    /// derives from the production, and what refuses it is a sentence past the
+    /// grammar.
+    ///
+    // cite(RFC 4648 § 3.5): "These pad bits MUST be set to zero by conforming encoders, which is described in the descriptions on padding below."
+    BASE64_PAD_BITS_INVALID = {
+        id: "base64_pad_bits_invalid",
+        title: "Final base64 symbol carries bits a conforming encoder zeroes",
+        message: "",
+        default_severity: Severity::Info,
+        spec: Some(RFC_4648_3_5),
+    }
+}
+
+/// The defect a [`SecWebSocketKeyDefect`] reports as, where this subject holds
+/// one.
+///
+/// [`SecWebSocketKeyDefect::Length`] is the only variant that answers `None`,
+/// and it is not an encoding defect at all: a base64 spelling of twelve octets
+/// is a perfectly good base64 spelling, and the sixteen is RFC 6455's sentence
+/// about what the field carries. That defect belongs to a `sec_websocket_key`
+/// subject nothing has written, and the rule reporting it keeps its own words
+/// until something does.
+///
+/// The mapping lives here rather than in a file named after the helper for
+/// 2.19's reason — the first thing this reader measures is the encoding, and a
+/// subject file holding nothing but a mapping fn would carry no `// cite` and
+/// fail the citation ratchet on the spot.
+pub fn sec_websocket_key_defect(defect: &SecWebSocketKeyDefect) -> Option<&'static ViolationDef> {
+    match defect {
+        SecWebSocketKeyDefect::Alphabet(_) => Some(&BASE64_CHARACTER_FORBIDDEN),
+        SecWebSocketKeyDefect::Shape => Some(&BASE64_QUANTUM_MALFORMED),
+        SecWebSocketKeyDefect::PadBits => Some(&BASE64_PAD_BITS_INVALID),
+        SecWebSocketKeyDefect::Length(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::helpers::websocket::sec_websocket_key_defect as read_key;
+
+    /// The mapping, written against the reader: four verdicts, three ids and
+    /// one deliberate `None`. The values are the ones RFC 6455's own examples
+    /// and NOTE reach.
+    #[test]
+    fn the_three_encoding_verdicts_are_three_ids_and_the_length_is_not_one() {
+        let id = |value: &str| {
+            let defect = read_key(value).expect("a defect");
+            sec_websocket_key_defect(&defect).map(|def| def.id)
+        };
+
+        // `!` is not one of the sixty-four, and `=` inside the value is a pad
+        // character where no padding goes.
+        assert_eq!(
+            id("dGhlIHNhbXBsZSBub25jZQ!="),
+            Some("base64_character_forbidden")
+        );
+        assert_eq!(
+            id("dGhlIHNhbXBsZ=Sbm9uY2U="),
+            Some("base64_quantum_malformed")
+        );
+        // § 4.1's own NOTE prints this spelling of the octets 0x01..0x10.
+        assert_eq!(
+            id("AQIDBAUGBwgJCgsMDQ4PEC=="),
+            Some("base64_pad_bits_invalid")
+        );
+        // A well-formed encoding of the wrong number of octets is not the
+        // encoding's defect, so this subject does not answer for it.
+        assert_eq!(id("dGhlIHNhbXBsZQ=="), None);
+        // And the value § 4.1 prints as the field's example is no defect at all.
+        assert!(read_key("dGhlIHNhbXBsZSBub25jZQ==").is_none());
+    }
+
+    /// The coarse entry and the fine ones are one subject read by two readers,
+    /// and each rule declares only what its reader can answer.
+    ///
+    /// Asserted because the shape looks like a mistake from either side: a
+    /// later commit reading `basic_auth_base64_valid` will want to give it the
+    /// three fine ids it cannot reach, and one reading this rule will want to
+    /// delete the coarse one it does not use. Both would be wrong, and the
+    /// module doc says why.
+    #[test]
+    fn the_coarse_reader_and_the_fine_one_declare_different_halves() {
+        let declared = |id: &str| {
+            crate::rules::all_rules()
+                .find(|rule| rule.id() == id)
+                .expect("a registered rule")
+                .violations()
+                .iter()
+                .map(|def| def.id)
+                .collect::<Vec<_>>()
+        };
+
+        let basic = declared("basic_auth_base64_valid");
+        assert!(basic.contains(&"base64_malformed"), "{basic:?}");
+        assert!(!basic.contains(&"base64_character_forbidden"), "{basic:?}");
+
+        let websocket = declared("sec_websocket_headers_consistent");
+        assert!(
+            websocket.contains(&"base64_character_forbidden"),
+            "{websocket:?}"
+        );
+        assert!(!websocket.contains(&"base64_malformed"), "{websocket:?}");
+    }
+
+    /// The value every decoder reads correctly sits below the three it is told
+    /// to reject.
+    #[test]
+    fn the_spelling_a_decoder_may_accept_sits_below_the_ones_it_must_not() {
+        assert!(
+            BASE64_PAD_BITS_INVALID.default_severity < BASE64_CHARACTER_FORBIDDEN.default_severity
+        );
+        assert_eq!(
+            BASE64_QUANTUM_MALFORMED.default_severity,
+            BASE64_CHARACTER_FORBIDDEN.default_severity,
+        );
+        // The coarse entry cannot rank against the fine ones — it is what a
+        // reader that distinguishes none of this reports.
+        assert_eq!(
+            BASE64_MALFORMED.default_severity,
+            BASE64_CHARACTER_FORBIDDEN.default_severity,
+        );
     }
 }

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -353,7 +353,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 103;
+        const FLOOR: usize = 106;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1649,6 +1649,12 @@ sources:
 - label: RFC 4648
   url: https://www.rfc-editor.org/rfc/rfc4648.html
   fragments:
+  - label: base64
+    section: § 4
+    snippet: The encoding process represents 24-bit groups of input bits as output strings of 4 encoded characters.
+    cited_by:
+    - file: lint-http-rules/src/violations/base64.rs
+      line: 103
   - label: base64 rejects non-alphabet
     section: § 3.3
     snippet: Implementations MUST reject the encoded data if it contains characters outside the base alphabet when interpreting base-encoded data, unless the specification referring to this document explicitly states otherwise.
@@ -1658,7 +1664,9 @@ sources:
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 210
     - file: lint-http-rules/src/violations/base64.rs
-      line: 41
+      line: 71
+    - file: lint-http-rules/src/violations/base64.rs
+      line: 86
   - label: lint-http-rules/src/helpers/websocket.rs
     section: § 3.5
     snippet: MAY chose to reject an encoding if the pad bits have not been set to zero.
@@ -1671,6 +1679,8 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 211
+    - file: lint-http-rules/src/violations/base64.rs
+      line: 129
 - label: RFC 5234
   url: https://www.rfc-editor.org/rfc/rfc5234.html
   fragments:
@@ -2483,7 +2493,7 @@ sources:
     - file: lint-http-proxy/src/proxy/websocket/mod.rs
       line: 38
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 24
+      line: 79
   - label: lint-http-proxy/src/proxy/websocket/mod.rs (2)
     section: § 4.1
     snippet: The request MUST contain an |Upgrade| header field whose value MUST include the "websocket" keyword.
@@ -2609,43 +2619,43 @@ sources:
     snippet: The ABNF for the value of this header field is 1#token, where the definitions of constructs and rules are as given in [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 116
+      line: 183
   - label: sec_websocket_headers_consistent (2)
     section: § 4.1
     snippet: The elements that comprise this value MUST be non-empty strings with characters in the range U+0021 to U+007E not including separator characters as defined in [RFC2616] and MUST all be unique strings.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 115
+      line: 182
   - label: sec_websocket_headers_consistent (3)
     section: § 4.1
     snippet: The request MUST include a header field with the name |Sec-WebSocket-Key|.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 90
+      line: 151
   - label: sec_websocket_headers_consistent (4)
     section: § 4.1
     snippet: The request MUST include a header field with the name |Sec-WebSocket-Version|.  The value of this header field MUST be 13.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 48
+      line: 103
   - label: sec_websocket_headers_consistent (5)
     section: § 4.2.1
     snippet: A |Connection| header field that includes the token "Upgrade", treated as an ASCII case-insensitive value.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 25
+      line: 80
   - label: sec_websocket_headers_consistent (6)
     section: § 4.2.1
     snippet: An HTTP/1.1 or higher GET request
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 305
+      line: 372
   - label: sec_websocket_headers_consistent (7)
     section: § 4.2.1
     snippet: the server MUST stop processing the client's handshake and return an HTTP response with an appropriate error code (such as 400 Bad Request)
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 306
+      line: 373
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
       line: 65
   - label: Sec-WebSocket-Protocol
@@ -2653,13 +2663,13 @@ sources:
     snippet: Sec-WebSocket-Protocol-Client = 1#token
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 117
+      line: 184
   - label: Sec-WebSocket-Version-Server
     section: § 4.3
     snippet: Sec-WebSocket-Version-Server = 1#version
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 56
+      line: 111
     - file: lint-http-rules/src/rules/sec_websocket_version_advertised.rs
       line: 39
   - label: sec_websocket_headers_consistent (8)
@@ -2667,7 +2677,7 @@ sources:
     snippet: If the server doesn't support the requested version, it MUST respond with a |Sec-WebSocket-Version| header field (or multiple |Sec-WebSocket-Version| header fields) containing all versions it is willing to use.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 76
+      line: 131
     - file: lint-http-rules/src/rules/sec_websocket_version_advertised.rs
       line: 40
   - label: sec_websocket_headers_consistent (9)
@@ -2675,7 +2685,7 @@ sources:
     snippet: a client can initially request the version of the WebSocket Protocol that it prefers (which doesn't necessarily have to be the latest supported by the client)
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 75
+      line: 130
   - label: sec_websocket_version_advertised
     section: § 11.3.5
     snippet: In such a case, the header field includes the protocol version(s) supported by the server.
@@ -6507,7 +6517,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 317
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 125
+      line: 192
   - label: lint-http-rules/src/helpers/auth.rs
     section: § 11.1
     snippet: It uses a case-insensitive token to identify the authentication scheme
@@ -7435,7 +7445,7 @@ sources:
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
       line: 207
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 118
+      line: 185
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 408
     - file: lint-http-rules/src/rules/te_header_valid.rs


### PR DESCRIPTION
`Sec-WebSocket-Key = base64-value-non-empty`, and RFC 6455 hands the encoding to RFC 4648 without restating a character of it. So the three verdicts the WebSocket reader gives a bad key — an octet outside the sixty-four, a symbol count no group of twenty-four bits accounts for, and a final symbol whose discarded bits are not zero — are not facts about WebSockets, and they now carry the encoding's ids.

They join the subject beside the coarse entry rather than replacing it. `base64::DecodeError` is what the `Basic` reader has and it distinguishes none of this, so that rule keeps reporting the one id it can answer for; a test asserts the two rules declare different halves, because the shape looks like a mistake from either side and both repairs would be wrong.

The pad-bits entry defaults to `info` and the other two to `warn`. That value decodes to exactly the octets it meant and the sentence refusing it leaves a decoder free to accept it — RFC 6455 prints such a spelling in its own NOTE — so what is wrong is the spelling and not the message.

The whitespace/control pair the id convention mandates is deliberately not drawn here: it exists where two different sentences refuse the two classes of octet, and RFC 4648 § 3.3 is one MUST over everything outside the alphabet. The message still names the octet.

Two of the field's four verdicts stay in the rule's own words — a well-formed encoding of the wrong number of octets, and no field at all — because both are the nonce sentence rather than the encoding's, and a subject with one reader is written when it is read twice. The judge says so in its type, the half-converted shape two other rules already use.

The rule's own reference for § 3.3 is deleted in favour of the subject's, which the gate comparing a def's spec against its rule's requires.

Catalogue 105 -> 108, spec floor 103 -> 106.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
