### PR TITLE
A method and a field name are one token

### DIFF
--- a/docs/rules/header_field_names_token_valid.md
+++ b/docs/rules/header_field_names_token_valid.md
@@ -17,7 +17,7 @@ An HTTP/1.1 field name that is not a `token` is rejected by the message parser b
 ## Specifications
 
 - [RFC 9110 §5.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.1): Field Names (field-name = token)
-- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens (the tchar set the production expands to)
+- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 - [RFC 9110 §6.5](https://www.rfc-editor.org/rfc/rfc9110.html#section-6.5): Trailer Fields
 - [RFC 9113 §8.2.1](https://www.rfc-editor.org/rfc/rfc9113.html#section-8.2.1): Field Validity (HTTP/2 recipients validate names against §5.1)
 - [RFC 9114 §4.2](https://www.rfc-editor.org/rfc/rfc9114.html#section-4.2): HTTP Fields (HTTP/3 defers field-name properties to §5.1)

--- a/docs/rules/request_method_token_valid.md
+++ b/docs/rules/request_method_token_valid.md
@@ -30,7 +30,7 @@ Reports a request whose method token does not derive from `method = token` (RFC 
 
 - [RFC 9110 §9.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1): `method = token`, the token's case-sensitivity, the convention that standardized methods are defined in all-uppercase US-ASCII letters, and the 501 an origin server gives an unrecognized method
 - [RFC 9110 §2.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2): The sentence that makes a value outside its ABNF a violation rather than an observation
-- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): `token = 1*tchar`. The character set is transcribed once, in `helpers::token::is_tchar`; the `1*` floor is what the empty-method branch here reads
+- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 - [RFC 9110 §16.1.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-16.1.1): The IANA method registry, which holds the names `registered_methods` is a deployment's copy of, and grows by IETF Review
 - [RFC 9112 §3.1](https://www.rfc-editor.org/rfc/rfc9112.html#section-3.1): Where an HTTP/1.1 message carries the method. This reference said §5.1, which is Field Line Parsing
 - [RFC 9113 §8.3.1](https://www.rfc-editor.org/rfc/rfc9113.html#section-8.3.1): The `:method` pseudo-header field, which is where an HTTP/2 request carries the same value

--- a/lint-http-rules/src/rules/header_field_names_token_valid.rs
+++ b/lint-http-rules/src/rules/header_field_names_token_valid.rs
@@ -4,8 +4,31 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::token::{
+    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
+    TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+};
+use crate::violations::ViolationDef;
 
 pub struct HeaderFieldNamesTokenValid;
+
+/// A field name is a `token` and nothing else, so this rule declares two defs
+/// and writes neither.
+///
+/// `field-name = token` is the whole of the grammar here — RFC 9110 § 5.1
+/// states it and adds no character of its own — and what this rule contributes
+/// is *where* to look: four field sections in wire order, trailers included,
+/// over three versions of the protocol. The defect an operator tunes is the
+/// same one `Vary`, `Allow`, a media type's subtype and every parameter name
+/// report.
+///
+/// The empty name is not among them: a `HeaderMap` cannot hold one, so
+/// `token_empty` is unreachable from here and is left to the readers that can
+/// see a name a sender wrote blank.
+static DECLARED: &[&ViolationDef] = &[
+    &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+    &TOKEN_CHARACTER_FORBIDDEN,
+];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -15,12 +38,6 @@ const RFC_9110_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("5.1"),
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.1",
     note: "Field Names (field-name = token)",
-};
-const RFC_9110_5_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("5.6.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
-    note: "Tokens (the tchar set the production expands to)",
 };
 const RFC_9110_6_5: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
@@ -64,6 +81,10 @@ severity = "warn"
             RFC_9113_8_2_1,
             RFC_9114_4_2,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -111,7 +132,7 @@ impl Rule for HeaderFieldNamesTokenValid {
             // at all is the framing's answer, not this rule's.
             // cite(RFC 9110 § 6.5): "Fields (Section 5) that are located within a "trailer section" are referred to as "trailer fields""
             for (section, headers) in crate::helpers::headers::transaction_field_sections(tx) {
-                if let Some(v) = check_section(section, headers, ctx.severity) {
+                if let Some(v) = check_section(section, headers, ctx) {
                     return Some(v);
                 }
             }
@@ -126,7 +147,7 @@ impl Rule for HeaderFieldNamesTokenValid {
 fn check_section(
     section: &str,
     fields: &hyper::HeaderMap,
-    severity: crate::lint::Severity,
+    ctx: &crate::rules::RuleContext<'_>,
 ) -> Option<Violation> {
     for (k, _v) in fields.iter() {
         // The one check a § 5.1 validator still owes -- that the name is not
@@ -135,7 +156,7 @@ fn check_section(
         // HTTP/2 and HTTP/3 decoders reject an uppercase name outright, so `as_str()`
         // has already been made lowercase by the time any rule reads it.
         // cite(RFC 9114 § 4.2): "A request or response containing uppercase characters in field names MUST be treated as malformed"
-        if let Some(v) = check_header_name(section, k.as_str(), severity) {
+        if let Some(v) = check_header_name(section, k.as_str(), ctx) {
             return Some(v);
         }
     }
@@ -153,7 +174,7 @@ fn check_section(
 fn check_header_name(
     section: &str,
     name: &str,
-    severity: crate::lint::Severity,
+    ctx: &crate::rules::RuleContext<'_>,
 ) -> Option<Violation> {
     // The production is defined in § 5.1; the quote is the collected grammar's copy,
     // where it sits beside a neighbour rather than alone between two paragraphs, so
@@ -161,8 +182,11 @@ fn check_header_name(
     // transcribed once, in the shared helper, and read from there.
     // cite(RFC 9110 § A): "field-name = token field-value = *field-content"
     if let Some(c) = crate::helpers::token::find_invalid_token_char(name) {
-        return Some(HeaderFieldNamesTokenValid.violation(
-            severity,
+        // Which of the two the octet is is `token`'s question and not this
+        // rule's: an octet nobody typed and one a sender chose are the same
+        // failure of `1*tchar` and two different things to go and fix.
+        return Some(ctx.report_with(
+            token_character(c),
             format!(
                 "Field name '{}' in the {} contains invalid character: '{}'",
                 name, section, c
@@ -282,8 +306,19 @@ mod tests {
         #[case] expect_violation: bool,
         #[case] expected_char: Option<char>,
     ) -> anyhow::Result<()> {
-        let res =
-            super::check_header_name("request header section", name, crate::lint::Severity::Warn);
+        // The context is assembled the way dispatch assembles one, so a
+        // declared defect resolves its configured severity here too — the same
+        // reason `content_type_valid` builds one for its direct reading.
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "header_field_names_token_valid",
+        ]);
+        let resolved = HeaderFieldNamesTokenValid
+            .prepare(&cfg)
+            .expect("a preparable config");
+        let severities = crate::rules::severities_for(&HeaderFieldNamesTokenValid, &cfg);
+        let ctx = crate::rules::RuleContext::new(&resolved)
+            .with_violations(&HeaderFieldNamesTokenValid, &severities);
+        let res = super::check_header_name("request header section", name, &ctx);
 
         if expect_violation {
             assert!(res.is_some(), "expected violation for '{}'", name);

--- a/lint-http-rules/src/rules/request_method_token_valid.rs
+++ b/lint-http-rules/src/rules/request_method_token_valid.rs
@@ -4,6 +4,11 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::token::{
+    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN, TOKEN_EMPTY,
+    TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+};
+use crate::violations::ViolationDef;
 
 #[derive(Debug, Clone)]
 pub struct MethodTokenConfig {
@@ -89,6 +94,26 @@ fn parse_method_token_config(
 
 pub struct RequestMethodTokenValid;
 
+/// The two grammar questions this rule asks are `token`'s, and the third is its
+/// own.
+///
+/// `method = token`, with nothing added, so a method of no characters and a
+/// method holding an octet outside `tchar` are the same defects a field name, a
+/// directive name or a subtype has — and the same ids. What is left is the
+/// finding this rule exists for and no production states: a `token` that is a
+/// standardized method's name written in another case, which parses perfectly
+/// and asks for a method nobody defined.
+///
+/// That last one keeps its own severity, and the split is now visible: a method
+/// spelled `get` is a request that will draw a 501, while a method carrying a
+/// control octet is a request that derives from no grammar at all, and one
+/// `severity` in `[rules.request_method_token_valid]` said both.
+static DECLARED: &[&ViolationDef] = &[
+    &TOKEN_EMPTY,
+    &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+    &TOKEN_CHARACTER_FORBIDDEN,
+];
+
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
@@ -103,12 +128,6 @@ const RFC_9110_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("2.2"),
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
     note: "The sentence that makes a value outside its ABNF a violation rather than an observation",
-};
-const RFC_9110_5_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("5.6.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
-    note: "`token = 1*tchar`. The character set is transcribed once, in `helpers::token::is_tchar`; the `1*` floor is what the empty-method branch here reads",
 };
 const RFC_9110_16_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
@@ -233,6 +252,10 @@ registered_methods = [
         ]
     }
 
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
+    }
+
     fn examples(&self) -> &'static [crate::rules::Example] {
         use crate::rules::{Compliance, Example};
         &[
@@ -318,8 +341,8 @@ impl Rule for RequestMethodTokenValid {
             // separate question and is asked here; three other readers of that helper say
             // the same thing in their own comments.
             if m.is_empty() {
-                return Some(self.violation(
-                    config.severity,
+                return Some(ctx.report_with(
+                    &TOKEN_EMPTY,
                     "Request carries an empty method token, and `method = token` has a one-character floor (`token = 1*tchar`), so the empty string derives from no production and names no method to apply to the target resource".into(),
                 ));
             }
@@ -332,8 +355,12 @@ impl Rule for RequestMethodTokenValid {
                 // Escaped, because the octet that fails a `tchar` test is very often one
                 // that prints as nothing: a raw DEL interpolated here produced a finding
                 // whose offending character was an empty pair of quotes.
-                return Some(self.violation(
-                    config.severity,
+                //
+                // Which of the two ids that octet draws is `token`'s question:
+                // a DEL in a method is something that happened to the request,
+                // an `@` is a client that meant it.
+                return Some(ctx.report_with(
+                    token_character(c),
                     format!(
                         "Method token contains {}, which is not a `tchar`, so the request's method derives from no `token` and therefore from no `method`",
                         crate::helpers::shown::shown_in_finding(&c.to_string())
@@ -479,6 +506,58 @@ mod tests {
     fn an_empty_method_token_is_reported() {
         let v = check("").expect("`method = token` has a one-character floor");
         assert!(v.message.contains("empty method token"));
+        assert_eq!(v.violation, "token_empty");
+    }
+
+    /// A method and a field name are both `token`, and the two most fundamental
+    /// readers of that production in HTTP now answer with the same ids.
+    ///
+    /// The two rules share no code and read different parts of the message --
+    /// the request line against a field section, one of them across three
+    /// versions of the protocol -- so nothing but the catalogue makes them
+    /// agree. The split inside the pair is `token`'s too: a DEL is an octet
+    /// that happened to the message, an `@` is a sender that meant it.
+    #[test]
+    fn a_method_and_a_field_name_report_the_same_two_defects() {
+        assert_eq!(
+            check("ge@t").expect("'@' is not a tchar").violation,
+            "token_character_forbidden"
+        );
+        assert_eq!(
+            check("GET\u{7f}").expect("DEL is not a tchar").violation,
+            "token_whitespace_or_control_forbidden"
+        );
+
+        let field_name = |name: &[u8]| {
+            let rule = crate::rules::header_field_names_token_valid::HeaderFieldNamesTokenValid;
+            let mut tx = crate::test_helpers::make_test_transaction();
+            let mut headers = hyper::HeaderMap::new();
+            headers.insert(
+                hyper::header::HeaderName::from_lowercase(name)
+                    .expect("the h2/h3 decoders convey this name"),
+                hyper::header::HeaderValue::from_static("v"),
+            );
+            tx.request.headers = headers;
+            crate::test_helpers::run_rule(
+                &rule,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "header_field_names_token_valid",
+                ]),
+            )
+            .expect("a field name that is not a token")
+            .violation
+        };
+        assert_eq!(field_name(b"x\"bad"), "token_character_forbidden");
+
+        // Only one half of the pair is reachable through a field name, and the
+        // reason is the transport rather than the grammar: every decoder in the
+        // tree refuses a control octet in a name outright, so DQUOTE is the one
+        // non-`tchar` that arrives. The def is declared anyway, because
+        // `token_character` is total over the octets and the rule cannot know
+        // which one it will be handed.
+        assert!(hyper::header::HeaderName::from_lowercase(b"x\x7fbad").is_err());
     }
 
     /// A DEL interpolated raw names nothing: the finding said "contains ''".

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -4981,7 +4981,7 @@ sources:
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
       line: 178
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 350
+      line: 377
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 246
     - file: lint-http-rules/src/rules/request_version_method_valid.rs
@@ -5205,9 +5205,9 @@ sources:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 344
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 272
+      line: 295
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 330
+      line: 353
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 270
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
@@ -5237,7 +5237,7 @@ sources:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 312
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 296
+      line: 319
   - label: alt_svc_header_syntax
     section: § 3.7
     snippet: All HTTP requirements applicable to an origin server also apply to the outbound communication of a gateway.
@@ -5837,7 +5837,7 @@ sources:
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
       line: 26
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 26
+      line: 31
   - label: early_data_header_safe_method (4)
     section: § 16.1.1
     snippet: Values to be added to this namespace require IETF Review
@@ -5845,7 +5845,7 @@ sources:
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
       line: 29
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 27
+      line: 32
   - label: early_data_header_safe_method (5)
     section: § 9.2.1
     snippet: Request methods are considered "safe" if their defined semantics are essentially read-only; i.e., the client does not request, and does not expect, any state change on the origin server as a result of applying a safe method to a target resource.
@@ -6075,7 +6075,7 @@ sources:
     snippet: field-name = token field-value = *field-content
     cited_by:
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
-      line: 162
+      line: 183
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
       line: 100
   - label: host_and_authority_consistent
@@ -6909,7 +6909,7 @@ sources:
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
       line: 135
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
-      line: 95
+      line: 116
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 5.3
     snippet: A recipient MAY combine multiple field lines within a field section that have the same field name into one field line, without changing the semantics of the message, by appending each subsequent field line value to the initial field line value in order, separated by a comma (",") and optional whitespace (OWS, defined in Section 5.6.3).  For consistency, use comma SP.
@@ -7087,7 +7087,7 @@ sources:
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
       line: 154
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
-      line: 112
+      line: 133
   - label: lint-http-rules/src/helpers/list.rs
     section: § 5.6.1.2
     snippet: '#element => [ element ] *( OWS "," OWS [ element ] )'
@@ -8397,19 +8397,19 @@ sources:
     snippet: All such methods ought to be registered within the "Hypertext Transfer Protocol (HTTP) Method Registry", as described in Section 16.1.
     cited_by:
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 28
+      line: 33
   - label: request_method_token_valid (2)
     section: § 9.1
     snippet: An origin server that receives a request method that is unrecognized or not implemented SHOULD respond with the 501 (Not Implemented) status code.
     cited_by:
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 358
+      line: 385
   - label: request_method_token_valid (3)
     section: § 9.1
     snippet: By convention, standardized methods are defined in all-uppercase US-ASCII letters.
     cited_by:
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 351
+      line: 378
   - label: absolute-path
     section: § 4.1
     snippet: absolute-path = 1*( "/" segment )
@@ -10240,7 +10240,7 @@ sources:
     snippet: HTTP/2 implementations SHOULD validate field names and values according to their definitions in Sections 5.1 and 5.5 of [HTTP], respectively, and treat messages that contain prohibited characters as malformed
     cited_by:
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
-      line: 151
+      line: 172
   - label: host_and_authority_consistent
     section: § 8.3.1
     snippet: A request in asterisk form (for OPTIONS) includes the value '*' for the ":path" pseudo-header field.
@@ -10322,7 +10322,7 @@ sources:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 308
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 297
+      line: 320
   - label: http2_pseudo_headers_valid (7)
     section: § 8.3.1
     snippet: The ":scheme" pseudo-header field includes the scheme portion of the request target.
@@ -10485,13 +10485,13 @@ sources:
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
       line: 191
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
-      line: 137
+      line: 158
   - label: header_field_names_token_valid
     section: § 4.2
     snippet: Properties of HTTP field names and values are discussed in more detail in Section 5.1 of [HTTP]
     cited_by:
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
-      line: 152
+      line: 173
   - label: host_and_authority_consistent
     section: § 4.3.1
     snippet: If both fields are present, they MUST contain the same value.
@@ -10765,7 +10765,7 @@ sources:
     snippet: '":method":  Contains the HTTP method (Section 9 of [HTTP])'
     cited_by:
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 298
+      line: 321
   - label: request_target_form_valid
     section: § 4.3.1
     snippet: An OPTIONS request that does not include a path component includes the value * (ASCII 0x2a) for the :path pseudo-header field


### PR DESCRIPTION
`method = token` and `field-name = token`, both with nothing added, so the two most fundamental readers of that production in HTTP have been wording the same two findings in their own sentences. They now declare the ids and write neither.

The pair splits the way the id convention says: an octet nobody typed outranks one a sender chose, and `token_character` is what decides which, so a DEL in a method and a DQUOTE in a field name arrive at two different entries out of one call. Only the second half is reachable through a field name — every decoder in the tree refuses a control octet in a name outright — and the test says so where a reader would otherwise wonder why the declared list is longer than the assertions.

The empty method is `token_empty`, which is the arithmetic half of the same production and was already the id twenty-three other list readers reach for.

What is left in each rule is its own: the field-name walk is four field sections in wire order across three versions of the protocol, and the method rule's remaining finding is a `token` that is a standardized method's name written in another case — no production states that, it parses perfectly, and it keeps the rule's own severity. That split is now expressible: one `severity` said both "this request will draw a 501" and "this request derives from no grammar at all".

Both rules' own references for the token section are deleted in favour of the subject's, which the gate comparing a def's spec against its rule's requires.

Catalogue unchanged at 108, all floors unchanged.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
