### PR TITLE
Historical whitespace has a name

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1083,6 +1083,10 @@ severity = "error"
 # Basic credentials hold no ':' separator
 severity = "warn"
 
+[violations.bws_forbidden]
+# Whitespace written where the grammar admits BWS
+severity = "info"
+
 [violations.challenge_empty]
 # Authentication challenge is empty
 severity = "warn"

--- a/docs/rules/prefer_header_valid.md
+++ b/docs/rules/prefer_header_valid.md
@@ -35,7 +35,7 @@ Reads a request's `Prefer` field against RFC 7240 §2's grammar — `Prefer = 1#
 - [RFC 9110 §5.6.1.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.2): The values a `1#element` production does not generate — the empty value among them — beside the recipient's instruction to ignore empty elements
 - [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 - [RFC 9110 §5.6.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4): `quoted-string = DQUOTE *( qdtext / quoted-pair ) DQUOTE` — the two delimiters, the class between them, and the backslash escape
-- [RFC 9110 §5.6.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3): `BWS`: a recipient must remove it before interpreting the element, and a sender must not have written it — both directions are read at the `=` in `preference` and in `parameter`
+- [RFC 9110 §5.6.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3): Whitespace — `BWS` is printed where a grammar allows optional whitespace for historical reasons only, with a MUST NOT on the sender and a matching MUST on the recipient to remove it before interpreting the element
 - [RFC 9111 §1.2.2](https://www.rfc-editor.org/rfc/rfc9111.html#section-1.2.2): `delta-seconds = 1*DIGIT` — what the `wait` preference's value has to be
 - [RFC 5234 §2.3](https://www.rfc-editor.org/rfc/rfc5234.html#section-2.3): An ABNF string literal matches any case, which is why `return=Minimal` is not reported against §4.2's `"minimal"`
 

--- a/docs/rules/preference_applied_header_valid.md
+++ b/docs/rules/preference_applied_header_valid.md
@@ -23,7 +23,7 @@ What it does not decide: whether a value is one the preference's own definition 
 - [RFC 9110 §5.6.1.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.2): The values a `1#element` production does not generate — the empty value among them — beside the recipient's instruction to ignore empty elements
 - [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 - [RFC 9110 §5.6.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4): `quoted-string = DQUOTE *( qdtext / quoted-pair ) DQUOTE` — the two delimiters, the class between them, and the backslash escape
-- [RFC 9110 §5.6.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3): `BWS`: a recipient must remove it before interpreting the element, and a sender must not have written it — both directions are read at the `=` in `applied-pref`
+- [RFC 9110 §5.6.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3): Whitespace — `BWS` is printed where a grammar allows optional whitespace for historical reasons only, with a MUST NOT on the sender and a matching MUST on the recipient to remove it before interpreting the element
 
 ## Configuration
 

--- a/docs/rules/te_header_valid.md
+++ b/docs/rules/te_header_valid.md
@@ -22,12 +22,13 @@ Scope: this rule reads a request's header section, and a response's only to repo
 
 ## Specifications
 
+- [RFC 9110 §5.6.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3): Whitespace — `BWS` is printed where a grammar allows optional whitespace for historical reasons only, with a MUST NOT on the sender and a matching MUST on the recipient to remove it before interpreting the element
 - [RFC 9110 §10.1.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.4): The field: what a member is, the grammar of its parameters, and the connection option a sender of TE must send beside it
 - [RFC 9110 §10.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1): The section the field is defined in — request context fields. It is the whole of the ground for reporting a TE in a response, and it carries no modal
 - [RFC 9110 §A](https://www.rfc-editor.org/rfc/rfc9110.html#appendix-A): The collected grammar, where the list construct is expanded for a sender — the form that shows both that the whole value may be empty and that a member may not
 - [RFC 9110 §12.4.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-12.4.2): `weight` and `qvalue`, and the MUST NOT on generating more than three digits after the point
 - [RFC 9110 §5.6.1.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1): The sender's half of the list construct: no empty elements. The recipient's half (§5.6.1.2, ignore them) is a different party's requirement
-- [RFC 9110 §5.6.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3): `BWS`: the whitespace around a transfer-parameter's `=`, which a recipient MUST remove and a sender MUST NOT write
+- [RFC 9110 §5.6.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3): Whitespace — `BWS` is printed where a grammar allows optional whitespace for historical reasons only, with a MUST NOT on the sender and a matching MUST on the recipient to remove it before interpreting the element
 - [RFC 9110 §7.6.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.1): The `Connection` field the option is listed in, and the note that some versions of HTTP do not allow the field at all
 - [RFC 9112 §7.4](https://www.rfc-editor.org/rfc/rfc9112.html#section-7.4): HTTP/1.1's own account of the field: what an empty value means, the `q` rank, the `chunked` MUST NOT, and why the connection option is required
 - [RFC 9112 §7.3](https://www.rfc-editor.org/rfc/rfc9112.html#section-7.3): `q` is a pseudo-parameter rather than a transfer-parameter, and its name is case-insensitive

--- a/lint-http-rules/src/rules/prefer_header_valid.rs
+++ b/lint-http-rules/src/rules/prefer_header_valid.rs
@@ -8,6 +8,7 @@ use crate::helpers::shown::shown_in_finding;
 use crate::helpers::word::parse_token_bws_word;
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::bws::{BWS_FORBIDDEN, RFC_9110_5_6_3};
 use crate::violations::list::{
     LIST_MEMBER_EMPTY, LIST_MEMBER_MISSING, RFC_9110_5_6_1_1, RFC_9110_5_6_1_2,
 };
@@ -47,6 +48,7 @@ pub struct PreferHeaderValid;
 /// meaning no value at all.
 static DECLARED: &[&ViolationDef] = &[
     &LIST_MEMBER_MISSING,
+    &BWS_FORBIDDEN,
     &LIST_MEMBER_EMPTY,
     &TOKEN_EMPTY,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
@@ -164,12 +166,6 @@ const RFC_9110_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("2.2"),
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
     note: "The MUST NOT on generating a protocol element that does not match its ABNF — what makes a value outside a §4 production a finding, since RFC 7240 writes those productions and states no requirement about them",
-};
-const RFC_9110_5_6_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("5.6.3"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3",
-    note: "`BWS`: a recipient must remove it before interpreting the element, and a sender must not have written it — both directions are read at the `=` in `preference` and in `parameter`",
 };
 const RFC_9111_1_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9111",
@@ -402,10 +398,10 @@ impl Rule for PreferHeaderValid {
                 // cite(RFC 9110 § 5.6.3): "A sender MUST NOT generate BWS in messages."
                 // cite(RFC 9110 § 5.6.3): "A recipient MUST parse for such bad whitespace and remove it before interpreting the protocol element."
                 if parsed.bws {
-                    return violation(format!(
+                    return Some(ctx.report_with(&BWS_FORBIDDEN, format!(
                         "Prefer member '{}' has whitespace around its '='; the grammar admits BWS there only for historical reasons",
                         shown_in_finding(member)
-                    ));
+                    )));
                 }
 
                 // `foo=""` is not a preference carrying the empty string, it is the
@@ -472,11 +468,11 @@ impl Rule for PreferHeaderValid {
                     // cite(RFC 9110 § 5.6.3): "A sender MUST NOT generate BWS in messages."
                     // cite(RFC 9110 § 5.6.3): "A recipient MUST parse for such bad whitespace and remove it before interpreting the protocol element."
                     if parsed_param.bws {
-                        return violation(format!(
+                        return Some(ctx.report_with(&BWS_FORBIDDEN, format!(
                             "Prefer parameter '{}' in member '{}' has whitespace around its '='; the grammar admits BWS there only for historical reasons",
                             shown_in_finding(param),
                             shown_in_finding(member)
-                        ));
+                        )));
                     }
                 }
 

--- a/lint-http-rules/src/rules/preference_applied_header_valid.rs
+++ b/lint-http-rules/src/rules/preference_applied_header_valid.rs
@@ -10,6 +10,7 @@ use crate::helpers::shown::shown_in_finding;
 use crate::helpers::word::parse_token_bws_word;
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::bws::{BWS_FORBIDDEN, RFC_9110_5_6_3};
 use crate::violations::list::{
     LIST_MEMBER_EMPTY, LIST_MEMBER_MISSING, RFC_9110_5_6_1_1, RFC_9110_5_6_1_2,
 };
@@ -41,6 +42,7 @@ pub struct PreferenceAppliedHeaderValid;
 /// the request never asked for.
 static DECLARED: &[&ViolationDef] = &[
     &LIST_MEMBER_MISSING,
+    &BWS_FORBIDDEN,
     &LIST_MEMBER_EMPTY,
     &TOKEN_EMPTY,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
@@ -158,12 +160,6 @@ const RFC_7240_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("1.1"),
     url: "https://www.rfc-editor.org/rfc/rfc7240.html#section-1.1",
     note: "Where `token`, `word`, `OWS`, `BWS` and the `#rule` extension come from. The named source is RFC 7230, which RFC 9110 obsoletes; `word` is the one name RFC 9110 did not keep, though both halves of it survive as `token` and `quoted-string`",
-};
-const RFC_9110_5_6_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("5.6.3"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3",
-    note: "`BWS`: a recipient must remove it before interpreting the element, and a sender must not have written it — both directions are read at the `=` in `applied-pref`",
 };
 
 impl RuleMeta for PreferenceAppliedHeaderValid {
@@ -357,10 +353,10 @@ impl Rule for PreferenceAppliedHeaderValid {
                 // cite(RFC 9110 § 5.6.3): "A sender MUST NOT generate BWS in messages."
                 // cite(RFC 9110 § 5.6.3): "A recipient MUST parse for such bad whitespace and remove it before interpreting the protocol element."
                 if parsed.bws {
-                    return violation(format!(
+                    return Some(ctx.report_with(&BWS_FORBIDDEN, format!(
                         "Preference-Applied member '{}' has whitespace around its '='; the grammar admits BWS there only for historical reasons",
                         shown_in_finding(member)
-                    ));
+                    )));
                 }
 
                 // One sentence decides both comparisons this rule makes, and it

--- a/lint-http-rules/src/rules/te_header_valid.rs
+++ b/lint-http-rules/src/rules/te_header_valid.rs
@@ -8,6 +8,22 @@ use crate::helpers::quoted_string::validate_quoted_string;
 use crate::helpers::qvalue::valid_qvalue;
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::bws::{BWS_FORBIDDEN, RFC_9110_5_6_3};
+use crate::violations::ViolationDef;
+
+/// The one defect this rule reports that is not about a transfer coding.
+///
+/// `transfer-parameter = token BWS "=" BWS ( token / quoted-string )` prints
+/// the whitespace, so the octets derive from the grammar and what refuses them
+/// is § 5.6.3's requirement on the sender — the same sentence a `preference`
+/// and a `link-param` break, over three documents that share nothing else.
+///
+/// The rule's other twenty-odd findings stay in its own words. Most of them are
+/// about what a transfer coding *is* — `trailers` taking neither parameter nor
+/// weight, a coding named twice, `chunked` asked for by a client that cannot
+/// receive it — and the rest are the `token`, `quoted-string` and `qvalue` this
+/// field is written out of, which are conversions of their own.
+static DECLARED: &[&ViolationDef] = &[&BWS_FORBIDDEN];
 
 #[derive(Debug, Clone)]
 pub struct TeHeaderValid;
@@ -24,7 +40,8 @@ impl TeHeaderValid {
     ///
     /// cite(RFC 9110 § 5.2): "When a field name is repeated within a section, its combined field value consists of the list of corresponding field line values within that section, concatenated in order, with each field line value separated by a comma."
     /// cite(RFC 9110 § 10.1.4): "The TE field value is a list of members, with each member (aside from "trailers") consisting of a transfer coding name token with an optional weight indicating the client's relative preference for that transfer coding (Section 12.4.2) and optional parameters for that transfer coding."
-    fn check_members(&self, value: &str, severity: crate::lint::Severity) -> Option<Violation> {
+    fn check_members(&self, value: &str, ctx: &crate::rules::RuleContext<'_>) -> Option<Violation> {
+        let severity = ctx.severity;
         let violation = |message: String| Some(self.violation(severity, message));
 
         // The field's list construct, expanded for a sender. The outer brackets are
@@ -121,7 +138,7 @@ impl TeHeaderValid {
             //
             // cite(RFC 9110 § A): "transfer-coding = token *( OWS ";" OWS transfer-parameter )"
             for parameter in segments.iter().skip(1) {
-                if let Some(v) = self.check_parameter(member, parameter, severity) {
+                if let Some(v) = self.check_parameter(member, parameter, ctx) {
                     return Some(v);
                 }
             }
@@ -197,8 +214,11 @@ impl TeHeaderValid {
         &self,
         member: &str,
         parameter: &str,
-        severity: crate::lint::Severity,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
+        // The unconverted branches read the rule's own severity, exactly as
+        // they did before the context was threaded through.
+        let severity = ctx.severity;
         let violation = |message: String| Some(self.violation(severity, message));
 
         // The `"="` is not optional in either production, so a segment written
@@ -291,11 +311,11 @@ impl TeHeaderValid {
         // Here the whitespace *is* `BWS`: the production prints it on both sides of the
         // `=`, for historical reasons and with a sender MUST NOT attached.
         if whitespace_around_equals {
-            return violation(format!(
+            return Some(ctx.report_with(&BWS_FORBIDDEN, format!(
                 "TE parameter '{}' in member '{}' writes whitespace around its '='; the production admits it there as BWS, which a sender must not generate",
                 parameter.escape_debug(),
                 member.escape_debug()
-            ));
+            )));
         }
 
         // `( token / quoted-string )` — the value is one or the other, and a value
@@ -371,12 +391,6 @@ const RFC_9110_5_6_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
     note: "The sender's half of the list construct: no empty elements. The recipient's half (§5.6.1.2, ignore them) is a different party's requirement",
 };
-const RFC_9110_5_6_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("5.6.3"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3",
-    note: "`BWS`: the whitespace around a transfer-parameter's `=`, which a recipient MUST remove and a sender MUST NOT write",
-};
 const RFC_9110_7_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
     section: Some("7.6.1"),
@@ -431,6 +445,7 @@ severity = "warn"
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
+            RFC_9110_5_6_3,
             RFC_9110_10_1_4,
             RFC_9110_10_1,
             RFC_9110_A,
@@ -444,6 +459,10 @@ severity = "warn"
             RFC_9114_4_2,
             RFC_9110_6_5_1,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -554,7 +573,7 @@ impl Rule for TeHeaderValid {
 
             let value = combined_field_value_as_written(&tx.request.headers, "te")?;
 
-            if let Some(v) = self.check_members(&value, ctx.severity) {
+            if let Some(v) = self.check_members(&value, ctx) {
                 return Some(v);
             }
 
@@ -611,6 +630,39 @@ mod tests {
     /// A conforming request: whatever the value, the connection option is there.
     fn te(value: &[u8]) -> Option<Violation> {
         request("HTTP/1.1", &[value], &[b"TE"])
+    }
+
+    /// The whitespace three documents print as `BWS` is one defect.
+    ///
+    /// `transfer-parameter`, `preference` and `applied-pref` are written by RFC
+    /// 9110, RFC 7240 and RFC 7240 again; none of them says anything about the
+    /// octets themselves, because § 5.6.3 already did. The three rules reading
+    /// them share no code and now answer with one id — and it sits at `info`,
+    /// below every grammar failure in the same field, because a recipient is
+    /// required to remove the whitespace and read what is left.
+    #[test]
+    fn the_historical_whitespace_is_one_defect_in_three_fields() {
+        let parameter = te(b"gzip;a = b").expect("BWS beside a transfer-parameter's '='");
+        assert_eq!(parameter.violation, "bws_forbidden");
+
+        let mut tx = crate::test_helpers::make_test_transaction();
+        let mut headers = hyper::HeaderMap::new();
+        headers.append("prefer", HeaderValue::from_static("wait = 10"));
+        tx.request.headers = headers;
+        let preference = crate::test_helpers::run_rule(
+            &crate::rules::prefer_header_valid::PreferHeaderValid,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["prefer_header_valid"]),
+        )
+        .expect("BWS beside a preference's '='");
+        assert_eq!(preference.violation, "bws_forbidden");
+
+        // One id, two sentences — and the level is the point: a `TE` whose
+        // parameter name is not a `token` still reports at the rule's own
+        // severity, and this does not.
+        assert_ne!(parameter.message, preference.message);
+        assert_eq!(parameter.severity, crate::lint::Severity::Info);
     }
 
     fn response(te: &[u8]) -> Option<Violation> {

--- a/lint-http-rules/src/violations/bws.rs
+++ b/lint-http-rules/src/violations/bws.rs
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `BWS` defects — the whitespace a grammar prints only because something once
+//! generated it.
+//!
+//! One entry, and the subject exists because `BWS` is a terminal rather than a
+//! field: `transfer-parameter = token BWS "=" BWS ( token / quoted-string )`,
+//! `preference = token [ BWS "=" BWS word ]`, `link-param = token BWS [ "=" BWS
+//! ( token / quoted-string ) ]`. Four documents, four fields, one production —
+//! and each of the rules reading them had written its own sentence about a
+//! space nobody should have typed.
+//!
+//! **This is not `parameter_equals_whitespace_forbidden`, and the difference is
+//! which sentence refuses the octet.** § 5.6.6's `parameter` prints no
+//! whitespace at all and adds a Note refusing even the "bad" kind, so there the
+//! whitespace derives from nothing. Here it *derives*: the production writes
+//! `BWS` where it sits, and what refuses it is § 5.6.3's requirement on the
+//! sender. Two sentences, two ids, and a rule that reads both productions
+//! declares both — which the `Prefer` rules do, since RFC 7240 writes `BWS` and
+//! RFC 9110 writes the media type's `=`.
+//!
+//! **Both default to `info`, and they arrive there by different routes.** The
+//! parameter's is `info` because six rules in this tree trim the whitespace and
+//! publish the leniency; this one is `info` because § 5.6.3 states the
+//! recipient's half in the same breath — a recipient MUST parse for the bad
+//! whitespace and remove it — so the value is read as intended and what is
+//! wrong is the spelling. **A requirement whose counterpart obliges the other
+//! party to cope is a requirement about hygiene**, which is 2.28's ranking read
+//! at a terminal instead of at a format.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// `BWS`, both directions of it: what a sender may not generate and what a
+/// recipient must do about it anyway.
+pub const RFC_9110_5_6_3: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3",
+    note: "Whitespace — `BWS` is printed where a grammar allows optional whitespace for historical reasons only, with a MUST NOT on the sender and a matching MUST on the recipient to remove it before interpreting the element",
+};
+
+defects! {
+    /// Whitespace written where a production prints `BWS`.
+    ///
+    /// The grammar admits it, which is the whole of what makes this its own
+    /// entry: nothing about the value is malformed, and a recipient is required
+    /// to remove the octets and read what is left. What a sender is told is
+    /// that the allowance is historical and not for it to use.
+    ///
+    /// Not the `<subject>_whitespace_or_control_forbidden` half of the pair
+    /// `docs/development.md` mandates, for the same reason
+    /// `parameter_equals_whitespace_forbidden` is not: that pair is about an
+    /// octet *inside* a value whose alphabet excludes it — something that
+    /// happened to the value — and this one sits between two constructs, where
+    /// a sender put it on purpose.
+    ///
+    // cite(RFC 9110 § 5.6.3): "A sender MUST NOT generate BWS in messages."
+    BWS_FORBIDDEN = {
+        id: "bws_forbidden",
+        title: "Whitespace written where the grammar admits BWS",
+        message: "",
+        default_severity: Severity::Info,
+        spec: Some(RFC_9110_5_6_3),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::violations::parameter::PARAMETER_EQUALS_WHITESPACE_FORBIDDEN;
+
+    /// The two whitespace-beside-an-`=` entries are separate on purpose and
+    /// level on purpose, and a later commit will want to merge them.
+    ///
+    /// They cannot merge: `every_violation_spec_is_declared_by_its_rule`
+    /// compares the const a def carries against the ones its rule declares, so
+    /// one id cannot hold two sections — and the two sections say different
+    /// things about the same octet. One production prints the whitespace and
+    /// one does not.
+    #[test]
+    fn the_admitted_whitespace_and_the_underived_one_are_two_ids_at_one_level() {
+        assert_ne!(BWS_FORBIDDEN.id, PARAMETER_EQUALS_WHITESPACE_FORBIDDEN.id);
+        assert_eq!(
+            BWS_FORBIDDEN.default_severity,
+            PARAMETER_EQUALS_WHITESPACE_FORBIDDEN.default_severity,
+        );
+        assert_ne!(
+            BWS_FORBIDDEN.spec.expect("a sentence").section,
+            PARAMETER_EQUALS_WHITESPACE_FORBIDDEN
+                .spec
+                .expect("a sentence")
+                .section,
+        );
+    }
+}

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -32,6 +32,7 @@ use std::sync::LazyLock;
 pub mod auth_scheme;
 pub mod base64;
 pub mod basic_credentials;
+pub mod bws;
 pub mod challenge;
 pub mod content_length;
 pub mod content_range;
@@ -353,7 +354,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 107;
+        const FLOOR: usize = 108;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1701,7 +1701,7 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 242
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 116
+      line: 118
   - label: lint-http-rules/src/helpers/mailbox.rs
     section: § B.1
     snippet: WSP            =  SP / HTAB ; white space
@@ -3469,9 +3469,9 @@ sources:
     - file: lint-http-rules/src/rules/prefer_header_and_preference_applied.rs
       line: 36
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 419
+      line: 415
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 369
+      line: 365
   - label: prefer_header_and_preference_applied (3)
     section: § 2
     snippet: If a server supports the optional application of a preference that might result in a variance to a cache's handling of a response entity, a Vary header field MUST be included in the response listing the Prefer header field regardless of whether the client actually used Prefer in the request.
@@ -3485,7 +3485,7 @@ sources:
     - file: lint-http-rules/src/rules/prefer_header_and_preference_applied.rs
       line: 276
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 281
+      line: 277
   - label: prefer_header_and_preference_applied (4)
     section: § 3
     snippet: The Preference-Applied response header MAY be included within a response message as an indication as to which Prefer tokens were honored by the server and applied to the processing of a request.
@@ -3493,9 +3493,9 @@ sources:
     - file: lint-http-rules/src/rules/prefer_header_and_preference_applied.rs
       line: 227
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 253
+      line: 249
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 387
+      line: 383
   - label: prefer_header_and_preference_applied (5)
     section: § 3
     snippet: applied-pref = token [ BWS "=" BWS word ]
@@ -3503,7 +3503,7 @@ sources:
     - file: lint-http-rules/src/rules/prefer_header_and_preference_applied.rs
       line: 288
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 333
+      line: 329
   - label: prefer_header_and_preference_applied (6)
     section: § 4.1
     snippet: the server can honor the "respond-async" preference by returning a 202 (Accepted) response.
@@ -3541,137 +3541,137 @@ sources:
     - file: lint-http-rules/src/rules/prefer_header_and_preference_applied.rs
       line: 30
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 70
+      line: 72
   - label: prefer_header_valid
     section: § 2
     snippet: '*( OWS ";" [ OWS parameter ] )'
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 373
+      line: 369
   - label: prefer_header_valid (2)
     section: § 2
     snippet: A client MAY use multiple instances of the Prefer header field in a single message, or it MAY use a single Prefer header field with multiple comma-separated preference tokens.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 314
+      line: 310
   - label: prefer_header_valid (3)
     section: § 2
     snippet: A server that does not recognize or is unable to comply with particular preference tokens in the Prefer header field of a request MUST ignore those tokens and continue processing instead of signaling an error.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 71
+      line: 73
   - label: prefer_header_valid (4)
     section: § 2
     snippet: An optional set of parameters can be specified for any preference token.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 448
+      line: 444
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 112
+      line: 114
   - label: prefer_header_valid (5)
     section: § 2
     snippet: Empty or zero-length values on both the preference token and within parameters are equivalent to no value being specified at all.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 416
+      line: 412
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 61
+      line: 63
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 374
+      line: 370
   - label: prefer_header_valid (6)
     section: § 2
     snippet: If any preference is specified more than once, only the first instance is to be considered.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 490
+      line: 486
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 128
+      line: 130
   - label: prefer_header_valid (7)
     section: § 2
     snippet: If multiple Prefer header fields are used, it is equivalent to a single Prefer header field with the comma-separated concatenation of all of the tokens.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 315
+      line: 311
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 80
+      line: 82
   - label: prefer_header_valid (8)
     section: § 2
     snippet: Prefer     = "Prefer" ":" 1#preference
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 323
+      line: 319
   - label: prefer_header_valid (9)
     section: § 2
     snippet: The Prefer request header field is used to indicate that particular server behaviors are preferred by the client but are not required for successful completion of the request.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 289
+      line: 285
   - label: prefer_header_valid (10)
     section: § 2
     snippet: To avoid any possible ambiguity, individual preference tokens SHOULD NOT appear multiple times within a single request.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 489
+      line: 485
   - label: prefer_header_valid (11)
     section: § 2
     snippet: parameter  = token [ BWS "=" BWS word ]
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 447
+      line: 443
   - label: prefer_header_valid (12)
     section: § 2
     snippet: preference = token [ BWS "=" BWS word ]
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 372
+      line: 368
   - label: prefer_header_valid (13)
     section: § 4
     snippet: The following subsections define an initial set of preferences.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 69
+      line: 71
   - label: prefer_header_valid (14)
     section: § 4.1
     snippet: respond-async = "respond-async"
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 77
+      line: 79
   - label: prefer_header_valid (15)
     section: § 4.2
     snippet: The "return=minimal" and "return=representation" preferences are mutually exclusive directives.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 491
+      line: 487
   - label: prefer_header_valid (16)
     section: § 4.2
     snippet: return = "return" BWS "=" BWS ("representation" / "minimal")
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 84
+      line: 86
   - label: prefer_header_valid (17)
     section: § 4.3
     snippet: wait = "wait" BWS "=" BWS delta-seconds
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 88
+      line: 90
   - label: prefer_header_valid (18)
     section: § 4.4
     snippet: The "handling=strict" and "handling=lenient" preferences are mutually exclusive directives.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 492
+      line: 488
   - label: prefer_header_valid (19)
     section: § 4.4
     snippet: handling = "handling" BWS "=" BWS ("strict" / "lenient")
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 86
+      line: 88
   - label: preference_applied_header_valid
     section: § 3
     snippet: The syntax of the Preference-Applied header differs from that of the Prefer header in that parameters are not included.
     cited_by:
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 325
+      line: 321
 - label: RFC 7301
   url: https://www.rfc-editor.org/rfc/rfc7301.html
   fragments:
@@ -4743,9 +4743,9 @@ sources:
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
       line: 238
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 82
+      line: 99
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 269
+      line: 289
   - label: accept_encoding_parameter_valid (3)
     section: § 12.5.3
     snippet: 'Accept-Encoding  = #( codings [ weight ] ) codings          = content-coding / "identity" / "*"'
@@ -4845,7 +4845,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 417
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 280
+      line: 300
   - label: accept_header_media_type_syntax (2)
     section: § 12.5.1
     snippet: Each media-range might be followed by optional applicable media type parameters (e.g., charset), followed by an optional "q" parameter for indicating a relative weight (Section 12.4.2).
@@ -4947,9 +4947,9 @@ sources:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
       line: 200
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 333
+      line: 329
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 292
+      line: 288
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
       line: 412
     - file: lint-http-rules/src/violations/list.rs
@@ -5203,7 +5203,7 @@ sources:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
       line: 178
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 428
+      line: 424
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 344
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
@@ -5739,7 +5739,7 @@ sources:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 238
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 538
+      line: 557
   - label: context_fields_direction (2)
     section: § 10.1.1
     snippet: The "Expect" header field in a request indicates a certain set of behaviors (expectations) that need to be supported by the server in order to properly handle this request.
@@ -5773,9 +5773,9 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 191
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 504
+      line: 523
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 539
+      line: 558
   - label: context_fields_direction (6)
     section: § 10.1.5
     snippet: The "User-Agent" header field contains information about the user agent originating the request
@@ -6249,11 +6249,11 @@ sources:
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 718
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 403
+      line: 399
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 473
+      line: 469
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 358
+      line: 354
   - label: link_header_valid (2)
     section: § 5.6.3
     snippet: A sender MUST NOT generate BWS in messages.
@@ -6261,11 +6261,13 @@ sources:
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 717
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 402
+      line: 398
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 472
+      line: 468
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 357
+      line: 353
+    - file: lint-http-rules/src/violations/bws.rs
+      line: 61
   - label: lint-http-core/src/http_date.rs
     section: § 5.6.7
     snippet: A recipient that parses a timestamp value in an HTTP field MUST accept all three HTTP-date formats.
@@ -6583,9 +6585,9 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 355
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 332
+      line: 328
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 291
+      line: 287
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 259
   - label: lint-http-rules/src/helpers/cache_control.rs
@@ -6613,7 +6615,7 @@ sources:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
       line: 21
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 25
+      line: 41
   - label: lint-http-rules/src/helpers/cache_control.rs (2)
     section: § 5.6.1
     snippet: '#element => [ element ] *( OWS "," OWS [ element ] )'
@@ -6655,15 +6657,15 @@ sources:
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
       line: 196
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 346
+      line: 342
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 305
+      line: 301
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 268
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 375
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 67
+      line: 84
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
       line: 160
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
@@ -7169,7 +7171,7 @@ sources:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 340
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 304
+      line: 324
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 195
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -7215,7 +7217,7 @@ sources:
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
       line: 233
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 43
+      line: 60
     - file: lint-http-rules/src/rules/upgrade_header_syntax.rs
       line: 137
   - label: lint-http-rules/src/helpers/media_type.rs (2)
@@ -7451,7 +7453,7 @@ sources:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 408
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 233
+      line: 253
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 258
     - file: lint-http-rules/src/rules/via_header_syntax.rs
@@ -7819,7 +7821,7 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 240
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 99
+      line: 116
   - label: no_connection_specific_fields (2)
     section: § A
     snippet: transfer-parameter = token BWS "=" BWS ( token / quoted-string )
@@ -7827,9 +7829,9 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 241
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 59
+      line: 76
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 195
+      line: 212
   - label: options_method_capabilities
     section: § 10.2.1
     snippet: An origin server MUST generate an Allow header field in a 405 (Method Not Allowed) response and MAY do so in any other response.
@@ -7981,7 +7983,7 @@ sources:
     - file: lint-http-rules/src/rules/proxy_connection_discouraged.rs
       line: 120
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 153
+      line: 170
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
       line: 60
   - label: range_and_content_range_consistent
@@ -8933,13 +8935,13 @@ sources:
     snippet: A sender of TE MUST also send a "TE" connection option within the Connection header field (Section 7.6.1) to inform intermediaries not to forward this field.
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 175
+      line: 192
   - label: te_header_valid (2)
     section: § 10.1.4
     snippet: The TE field value is a list of members, with each member (aside from "trailers") consisting of a transfer coding name token with an optional weight indicating the client's relative preference for that transfer coding (Section 12.4.2) and optional parameters for that transfer coding.
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 26
+      line: 42
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 451
   - label: te_header_valid (3)
@@ -8947,21 +8949,21 @@ sources:
     snippet: The BWS rule is used where the grammar allows optional whitespace only for historical reasons.  A sender MUST NOT generate BWS in messages.  A recipient MUST parse for such bad whitespace and remove it before interpreting the protocol element.
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 224
+      line: 244
   - label: te_header_valid (4)
     section: § A
     snippet: TE = [ t-codings *( OWS "," OWS t-codings ) ]
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 41
+      line: 58
   - label: te_header_valid (5)
     section: § A
     snippet: transfer-coding = token *( OWS ";" OWS transfer-parameter )
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 81
+      line: 98
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 122
+      line: 139
   - label: timing_allow_origin_valid
     section: § 5.6.1.2
     snippet: 'A recipient MUST parse and ignore a reasonable number of empty list elements: enough to handle common mistakes by senders that merge values, but not so much that they could be used as a denial-of-service mechanism'
@@ -9426,7 +9428,7 @@ sources:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
       line: 627
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 97
+      line: 99
   - label: lint-http-rules/src/helpers/cache_control.rs
     section: § 4.2.1
     snippet: If the max-age response directive (Section 5.2.2.1) is present, use its value, or If the Expires response header field (Section 5.3) is present, use its value minus the value of the Date response header field (using the time the message was received if it is not present, as per Section 6.6.1 of [HTTP]), or
@@ -10133,13 +10135,13 @@ sources:
     snippet: The TE header field (Section 10.1.4 of [HTTP]) uses a pseudo-parameter named "q" as the rank value when multiple transfer codings are acceptable.
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 260
+      line: 280
   - label: te_header_valid (2)
     section: § 7.4
     snippet: If the TE field value is empty or if no TE field is present, the only acceptable transfer coding is chunked.
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 42
+      line: 59
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 450
   - label: te_header_valid (3)
@@ -10147,13 +10149,13 @@ sources:
     snippet: Since the TE header field only applies to the immediate connection, a sender of TE MUST also send a "TE" connection option within the Connection header field (Section 7.6.1 of [HTTP]) in order to prevent the TE header field from being forwarded by intermediaries that do not support its semantics.
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 176
+      line: 193
   - label: te_header_valid (4)
     section: § 7.4
     snippet: When multiple transfer codings are acceptable, the client MAY rank the codings by preference using a case-insensitive "q" parameter (similar to the qvalues used in content negotiation fields; see Section 12.4.2 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 261
+      line: 281
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 343
   - label: transfer_coding_registered
@@ -10422,7 +10424,7 @@ sources:
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
       line: 168
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 154
+      line: 171
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
       line: 62
   - label: no_connection_specific_fields
@@ -10450,7 +10452,7 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 175
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 155
+      line: 172
   - label: request_target_form_valid
     section: § 8.3.1
     snippet: Note that request targets for CONNECT or asterisk-form OPTIONS requests never include authority information
@@ -10721,7 +10723,7 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 152
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 156
+      line: 173
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
       line: 64
   - label: no_connection_specific_fields (2)


### PR DESCRIPTION
`BWS` is what a grammar prints where something once generated whitespace and the production had to keep admitting it. Three rules over three documents — a `transfer-parameter`, a `preference` and an `applied-pref` — each wrote its own sentence about the same octets, and § 5.6.3 had already written it for all of them.

It is not the parameter's whitespace def, and the difference is which sentence refuses the octet. A media type's `=` prints no whitespace at all and its section adds a Note refusing even the bad kind, so there the space derives from nothing. Here it derives: the production writes `BWS` where it sits, and what refuses it is the requirement on the sender. Two sentences cannot share one id, because the gate comparing a def's spec against its rule's declares one const per def.

Both default to `info` and arrive there by different routes — one because six rules in this tree trim the whitespace and publish the leniency, this one because the same paragraph obliges a recipient to remove it and read what is left. A requirement whose counterpart tells the other party to cope is about hygiene, and it now sits below the grammar failures in the fields that carry it.

The fourth reader is a `Link` parameter, judged through a chain that answers in strings; converting it is a reading of that chain and not of this terminal.

Catalogue 109 -> 110, spec floor 107 -> 108.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
