### PR TITLE
A coding name is a token in four fields

### DIFF
--- a/docs/rules/content_encoding_registered.md
+++ b/docs/rules/content_encoding_registered.md
@@ -20,6 +20,7 @@ The two headers do not share a vocabulary. `Accept-Encoding` additionally admits
 - [RFC 9110 §8.4.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4.1): `content-coding = token`, case-insensitive, and the "ought to be registered" guidance that motivates the rule without being what it checks
 - [RFC 9110 §12.5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.3): The wider Accept-Encoding grammar (`codings = content-coding / "identity" / "*"`), which is why the two headers are checked against different vocabularies
 - [IANA HTTP Parameters](https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding): The registry this rule is named after but does not read; the configured `allowed` array stands in for it
+- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 
 ## Configuration
 

--- a/docs/rules/transfer_coding_registered.md
+++ b/docs/rules/transfer_coding_registered.md
@@ -31,6 +31,7 @@ Validate `Transfer-Encoding` and `TE` header values: transfer-coding names must 
 - [RFC 9112 §7.4](https://www.rfc-editor.org/rfc/rfc9112.html#section-7.4): Negotiating transfer codings: chunked is forbidden in TE, an empty TE is conforming, and the q is a rank
 - [RFC 9110 §10.1.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.4): TE, and the grammar both fields share — including the quoted-string a transfer-parameter may carry
 - [IANA HTTP Parameters](https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#transfer-coding): The registry this rule is named after and does not read: names are checked against the configured 'allowed' list instead
+- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/content_encoding_registered.rs
+++ b/lint-http-rules/src/rules/content_encoding_registered.rs
@@ -4,8 +4,30 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::token::{
+    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
+    TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+};
+use crate::violations::ViolationDef;
 
 pub struct ContentEncodingRegistered;
+
+/// `content-coding = token`, and the two defects a `token` has.
+///
+/// RFC 9110 § 8.4.1 writes the production and adds no character to it, so an
+/// octet outside `tchar` in a coding name is the same defect it is in a field
+/// name, a method or a subtype. The rule reads two fields with it —
+/// `Content-Encoding` and `Accept-Encoding` — and the mirror rule reads
+/// `Transfer-Encoding` and `TE` off the same production.
+///
+/// What stays is everything the rule is named for: a coding the operator's list
+/// does not hold, and `identity` written where it is reserved away. Both are
+/// about which names exist rather than about how one is spelled, and the second
+/// is a SHOULD NOT that has no business sharing a level with a mangled octet.
+static DECLARED: &[&ViolationDef] = &[
+    &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+    &TOKEN_CHARACTER_FORBIDDEN,
+];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -75,7 +97,12 @@ allowed = ["aes128gcm", "br", "compress", "dcb", "dcz", "deflate", "exi", "gzip"
             RFC_9110_8_4_1,
             RFC_9110_12_5_3,
             IANA_HTTP_PARAMETERS,
+            RFC_9110_5_6_2,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -151,8 +178,11 @@ impl Rule for ContentEncodingRegistered {
                     }
                     // cite(RFC 9110 § 8.4.1): "content-coding = token"
                     if let Some(c) = crate::helpers::token::find_invalid_token_char(token) {
-                        return Some(ContentEncodingRegistered.violation(
-                            ctx.severity,
+                        // `content-coding = token` adds nothing to the
+                        // production, so which of the two ids the octet draws is
+                        // `token`'s question and not this field's.
+                        return Some(ctx.report_with(
+                            token_character(c),
                             format!("Invalid token '{}' in {} header", c, hdr_name),
                         ));
                     }
@@ -231,6 +261,77 @@ mod tests {
             }),
         );
         cfg
+    }
+
+    /// A coding name is a `token` and nothing more, and four fields over two
+    /// documents say so with one id.
+    ///
+    /// `Content-Encoding` and `Accept-Encoding` are read here,
+    /// `Transfer-Encoding` and `TE` by the mirror rule out of a body that
+    /// shares no line with this one, and `content-coding = token` /
+    /// `transfer-coding = token …` are the whole of what either field adds. The
+    /// split inside the pair is the token's too: a control octet is something
+    /// that happened to the value, a `<` is a sender that meant it.
+    #[test]
+    fn a_coding_name_is_a_token_in_all_four_fields() {
+        let content_encoding = |value: &str| {
+            let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
+            tx.response.as_mut().expect("a response").headers =
+                crate::test_helpers::make_headers_from_pairs(&[("content-encoding", value)]);
+            crate::test_helpers::run_rule(
+                &ContentEncodingRegistered,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &make_cfg(),
+            )
+            .expect("a finding")
+            .violation
+        };
+        assert_eq!(content_encoding("gz<ip"), "token_character_forbidden");
+        // A `HeaderValue` refuses DEL outright, so the invisible half of the
+        // pair is reached here by the octet that *is* admitted and is still no
+        // `tchar`: the SP inside a member, left there after the list's `OWS`
+        // has been trimmed off both ends.
+        assert_eq!(
+            content_encoding("gz ip"),
+            "token_whitespace_or_control_forbidden"
+        );
+
+        let transfer_encoding = |value: &str| {
+            let mut cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "transfer_coding_registered",
+            ]);
+            let table = cfg
+                .rules
+                .get_mut("transfer_coding_registered")
+                .expect("the rule's section")
+                .as_table_mut()
+                .expect("a table");
+            table.insert(
+                "allowed".into(),
+                toml::Value::Array(vec![toml::Value::String("chunked".into())]),
+            );
+            let mut tx = crate::test_helpers::make_test_transaction();
+            tx.request.headers =
+                crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", value)]);
+            crate::test_helpers::run_rule(
+                &crate::rules::transfer_coding_registered::TransferCodingRegistered,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &cfg,
+            )
+            .expect("a finding")
+            .violation
+        };
+        assert_eq!(transfer_encoding("chu<nked"), "token_character_forbidden");
+        assert_eq!(
+            transfer_encoding("chu nked"),
+            "token_whitespace_or_control_forbidden"
+        );
+        // The floor is the mirror rule's alone: a `Content-Encoding` member
+        // with no name reaches the registry check, where the finding is that
+        // nothing is registered under that name.
+        assert_eq!(transfer_encoding(";ext=1"), "token_empty");
     }
 
     #[rstest]

--- a/lint-http-rules/src/rules/transfer_coding_registered.rs
+++ b/lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -4,6 +4,11 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::token::{
+    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN, TOKEN_EMPTY,
+    TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+};
+use crate::violations::ViolationDef;
 
 /// Every coding RFC 9112 says defines no parameters. The first five are § 7.2's
 /// compression codings, defined there by reference to the content coding of the
@@ -20,6 +25,24 @@ const PARAMETERLESS_CODINGS: [&str; 6] = [
 ];
 
 pub struct TransferCodingRegistered;
+
+/// The transfer coding's name is a `token`, and this rule declares the three
+/// ways one fails.
+///
+/// `transfer-coding = token *( OWS ";" OWS transfer-parameter )`, so a member
+/// that is nothing but parameters names no coding — the `1*` floor, which is
+/// arithmetic — and an octet outside `tchar` is the `token`'s defect wherever
+/// it appears. The mirror rule reports the same ids for `content-coding` out of
+/// two other fields.
+///
+/// What stays is the registry reading this rule is named for, `chunked` in a
+/// `TE`, and the coding's parameters — which are `token BWS "=" BWS ( token /
+/// quoted-string )` and belong to a later commit.
+static DECLARED: &[&ViolationDef] = &[
+    &TOKEN_EMPTY,
+    &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+    &TOKEN_CHARACTER_FORBIDDEN,
+];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -119,7 +142,12 @@ allowed = ["chunked", "compress", "gzip", "deflate"]
             RFC_9112_7_4,
             RFC_9110_10_1_4,
             IANA_HTTP_PARAMETERS,
+            RFC_9110_5_6_2,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -257,8 +285,8 @@ impl Rule for TransferCodingRegistered {
                     // named `''`, which describes the wrong defect.
                     // cite(RFC 9110 § 5.6.2): "token = 1*tchar tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA"
                     if token.is_empty() {
-                        return Some(TransferCodingRegistered.violation(
-                            ctx.severity,
+                        return Some(ctx.report_with(
+                            &TOKEN_EMPTY,
                             format!(
                                 "Missing transfer-coding name in {} header member '{}'",
                                 hdr_name, part
@@ -266,8 +294,8 @@ impl Rule for TransferCodingRegistered {
                         ));
                     }
                     if let Some(c) = crate::helpers::token::find_invalid_token_char(token) {
-                        return Some(TransferCodingRegistered.violation(
-                            ctx.severity,
+                        return Some(ctx.report_with(
+                            token_character(c),
                             // The offending character alone does not locate itself
                             // on a field with several members -- `Invalid token
                             // '<'` says nothing about which coding carried it.

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -4779,7 +4779,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
       line: 195
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
-      line: 133
+      line: 160
   - label: accept_encoding_parameter_valid (8)
     section: § 12.5.3
     snippet: The field value is evaluated the same way as in a request.
@@ -5399,7 +5399,7 @@ sources:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 182
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 232
+      line: 260
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
       line: 152
   - label: compression_and_transfer_encoding_consistent (2)
@@ -5409,7 +5409,7 @@ sources:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 183
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 213
+      line: 241
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
       line: 134
   - label: compression_and_transfer_encoding_consistent (3)
@@ -5427,7 +5427,7 @@ sources:
     - file: lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
       line: 88
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
-      line: 118
+      line: 145
   - label: compression_and_transfer_encoding_consistent (5)
     section: § 8.4
     snippet: If one or more encodings have been applied to a representation, the sender that applied the encodings MUST generate a Content-Encoding header field that lists the content codings in the order in which they were applied.
@@ -5453,7 +5453,7 @@ sources:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 161
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
-      line: 163
+      line: 193
   - label: conditional_headers_consistent
     section: § 13.1.3
     snippet: A recipient MUST ignore If-Modified-Since if the request contains an If-None-Match header field
@@ -5567,19 +5567,19 @@ sources:
     snippet: codings = content-coding / "identity" / "*"
     cited_by:
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
-      line: 119
+      line: 146
   - label: content_encoding_registered (2)
     section: § 8.4
     snippet: Note that the coding named "identity" is reserved for its special role in Accept-Encoding and thus SHOULD NOT be included.
     cited_by:
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
-      line: 145
+      line: 172
   - label: content_encoding_registered (3)
     section: § 8.4.1
     snippet: content-coding = token
     cited_by:
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
-      line: 152
+      line: 179
   - label: content_length_valid
     section: § 8.6
     snippet: The "Content-Length" header field indicates the associated representation's data length as a decimal non-negative integer number of octets.
@@ -6509,7 +6509,7 @@ sources:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
       line: 16
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 218
+      line: 246
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
       line: 136
   - label: lint-http-rules/src/helpers/accept_ranges.rs (5)
@@ -6925,7 +6925,7 @@ sources:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 158
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 403
+      line: 431
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 5.3
     snippet: Since it cannot be combined into a single field value, recipients ought to handle "Set-Cookie" as a special case while processing fields.
@@ -7069,7 +7069,7 @@ sources:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 491
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 233
+      line: 261
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
       line: 153
     - file: lint-http-rules/src/rules/x_forwarded_consistent.rs
@@ -7173,9 +7173,9 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 324
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 195
+      line: 223
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 415
+      line: 443
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
       line: 116
     - file: lint-http-rules/src/violations/quoted_string.rs
@@ -7409,7 +7409,7 @@ sources:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 102
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 416
+      line: 444
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
       line: 654
     - file: lint-http-rules/src/violations/quoted_string.rs
@@ -7455,7 +7455,7 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 253
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 258
+      line: 286
     - file: lint-http-rules/src/rules/via_header_syntax.rs
       line: 227
     - file: lint-http-rules/src/violations/token.rs
@@ -8943,7 +8943,7 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 42
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 451
+      line: 479
   - label: te_header_valid (3)
     section: § 5.6.3
     snippet: The BWS rule is used where the grammar allows optional whitespace only for historical reasons.  A sender MUST NOT generate BWS in messages.  A recipient MUST parse for such bad whitespace and remove it before interpreting the protocol element.
@@ -9059,7 +9059,7 @@ sources:
     snippet: 'TE                 = #t-codings t-codings          = "trailers" / ( transfer-coding [ weight ] ) transfer-coding    = token *( OWS ";" OWS transfer-parameter ) transfer-parameter = token BWS "=" BWS ( token / quoted-string )'
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 342
+      line: 370
   - label: upgrade_and_connection_consistent
     section: § 7.6.1
     snippet: In contrast, a connection-specific field received without a corresponding connection option usually indicates that the field has been improperly forwarded by an intermediary and ought to be ignored by the recipient.
@@ -9671,11 +9671,11 @@ sources:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 192
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 92
+      line: 115
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 290
+      line: 318
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 376
+      line: 404
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
       line: 158
   - label: compression_and_transfer_encoding_consistent (4)
@@ -10143,7 +10143,7 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 59
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 450
+      line: 478
   - label: te_header_valid (3)
     section: § 7.4
     snippet: Since the TE header field only applies to the immediate connection, a sender of TE MUST also send a "TE" connection option within the Connection header field (Section 7.6.1 of [HTTP]) in order to prevent the TE header field from being forwarded by intermediaries that do not support its semantics.
@@ -10157,61 +10157,61 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 281
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 343
+      line: 371
   - label: transfer_coding_registered
     section: § 6.1
     snippet: A server that receives a request message with a transfer coding it does not understand SHOULD respond with 501 (Not Implemented).
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 364
+      line: 392
   - label: transfer_coding_registered (2)
     section: § 6.1
     snippet: 'Transfer-Encoding = #transfer-coding'
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 426
+      line: 454
   - label: transfer_coding_registered (3)
     section: § 7.1
     snippet: The chunked coding does not define any parameters.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 316
+      line: 344
   - label: transfer_coding_registered (4)
     section: § 7.1
     snippet: Their presence SHOULD be treated as an error.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 317
+      line: 345
   - label: transfer_coding_registered (5)
     section: § 7.2
     snippet: The compression codings do not define any parameters.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 307
+      line: 335
   - label: transfer_coding_registered (6)
     section: § 7.2
     snippet: The presence of parameters with any of these compression codings SHOULD be treated as an error.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 308
+      line: 336
   - label: transfer_coding_registered (7)
     section: § 7.3
     snippet: The "HTTP Transfer Coding Registry" defines the namespace for transfer coding names.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 205
+      line: 233
   - label: transfer_coding_registered (8)
     section: § 7.4
     snippet: A client MUST NOT send the chunked transfer coding name in TE; chunked is always acceptable for HTTP/1.1 recipients.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 287
+      line: 315
   - label: transfer_coding_registered (9)
     section: § 7.4
     snippet: The keyword "trailers" indicates that the sender will not discard trailer fields, as described in Section 6.5 of [HTTP].
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 242
+      line: 270
   - label: transfer_encoding_chunked_final
     section: § 6.1
     snippet: A sender MUST NOT apply the chunked transfer coding more than once to a message body (i.e., chunking an already chunked message is not allowed).


### PR DESCRIPTION
`content-coding = token` and `transfer-coding = token *( OWS ";" OWS transfer-parameter )`: two documents, four fields — `Content-Encoding`, `Accept-Encoding`, `Transfer-Encoding` and `TE` — and neither production adds a character to the one it borrows. The three ways a coding name fails now carry the token's ids.

The mirror rules share no code and read opposite halves of a message, so the assertion that `gz<ip` and `chu<nked` draw one id is made by the catalogue alone. The invisible half of the pair is reached by a space rather than by a control octet, because a header value refuses the latter outright — noted at the assertion so the next reader does not try it.

Each rule keeps what it is named for: a name the operator's list does not hold, `identity` written where it is reserved away, `chunked` in a `TE`. Those are about which names exist rather than how one is spelled, and the SHOULD NOT among them had no business sharing a level with a mangled octet.

The transfer coding's parameters are a `token BWS "=" BWS ( token / quoted-string )` and stay unconverted; that production's whitespace already has its id, and the rest of it is a reading of its own.

Catalogue unchanged at 110, all floors unchanged.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
