### PR TITLE
The last two coding names are tokens too

### DIFF
--- a/docs/rules/accept_encoding_parameter_valid.md
+++ b/docs/rules/accept_encoding_parameter_valid.md
@@ -30,6 +30,7 @@ Check that an `Accept-Encoding` header reads as `#( codings [ weight ] )`: each 
 - [RFC 9110 §12.4.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-12.4.2): Quality Values: the `weight` production this field admits, the `qvalue` its value must be, and the case-insensitive parameter name
 - [RFC 9110 §8.4.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4.1): Content Codings: `content-coding = token`, which is what the character check on each coding enforces
 - [RFC 9110 §5.6.1.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.2): Sender Requirements for lists: the bracketing that makes an empty list element something a recipient may ignore
+- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 
 ## Configuration
 

--- a/docs/rules/content_encoding_and_type_consistent.md
+++ b/docs/rules/content_encoding_and_type_consistent.md
@@ -20,6 +20,7 @@ Repeating a coding is likewise a judgement call rather than a conformance failur
 
 - [RFC 9110 §8.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4): `Content-Encoding = #content-coding` — the list the member checks walk. Note it does not forbid repeating a coding, so the duplicate check is this rule's judgement
 - [RFC 9110 §15.4.5](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.5): Why a 304 should not carry Content-Encoding: a sender SHOULD NOT include representation metadata beyond the listed fields. (This reference previously pointed at §8.3, which is Content-Type, not message-body rules.) The 1xx and 204 cases have no such sentence and are inferred
+- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
+++ b/lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
@@ -4,8 +4,32 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::token::{
+    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
+    TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+};
+use crate::violations::ViolationDef;
 
 pub struct AcceptEncodingParameterValid;
+
+/// The `token` pair, and nothing else in this rule belongs to a subject.
+///
+/// `content-coding = token` is the one production this field borrows whole, and
+/// § 8.4.1 states it here the way RFC 6797 § 6.1 states it for a directive
+/// name: the field's own section says *which* production, and § 5.6.2 says what
+/// the production is. So a `@` in a coding name draws the same id it draws in a
+/// `Content-Encoding`, a `TE`, a field name or a method.
+///
+/// **Everything else this rule reports is about the member's shape**, and
+/// `codings [ weight ]` owns all of it: a separator introducing a weight that
+/// is not there, two of something there may be at most one of, a member whose
+/// non-optional half is missing, and a `name=value` pair no derivation of the
+/// field produces. That is 2.38's residue — what a construct says about its own
+/// assembly — and it is the whole of what this rule is named for.
+static DECLARED: &[&ViolationDef] = &[
+    &TOKEN_CHARACTER_FORBIDDEN,
+    &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -60,7 +84,12 @@ severity = "warn"
             RFC_9110_12_4_2,
             RFC_9110_8_4_1,
             RFC_9110_5_6_1_2,
+            RFC_9110_5_6_2,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -207,8 +236,8 @@ impl Rule for AcceptEncodingParameterValid {
                                 if let Some(c) =
                                     crate::helpers::token::find_invalid_token_char(primary)
                                 {
-                                    return Some(self.violation(
-                                        ctx.severity,
+                                    return Some(ctx.report_with(
+                                        token_character(c),
                                         format!("Invalid token '{}' in Accept-Encoding header", c),
                                     ));
                                 }

--- a/lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
+++ b/lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
@@ -4,8 +4,34 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::token::{
+    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
+    TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+};
+use crate::violations::ViolationDef;
 
 pub struct ContentEncodingAndTypeConsistent;
+
+/// The `token` pair, and it is the same field 2.37 converted read by a second
+/// rule asking a different question.
+///
+/// 2.37 took `Content-Encoding` and `Accept-Encoding` for the rule that asks
+/// which coding *names* exist; this takes them for the rule that asks which
+/// were applied twice, and the octet no `tchar` admits comes out with the same
+/// id from both. The two even say it in the same words — one of S6's duplicate
+/// templates, written in two files that share no code — so here the id retires
+/// a duplication the prose still carries, which is the state Phase 5's dedup
+/// was deferred to act on.
+///
+/// **Nothing this rule is named for changed.** A coding repeated, a `*` where
+/// none is defined, a member whose coding half is missing, and the field on a
+/// response with no content are all statements about what a *well-formed* list
+/// means, and they keep the rule's severity because no production is broken by
+/// any of them.
+static DECLARED: &[&ViolationDef] = &[
+    &TOKEN_CHARACTER_FORBIDDEN,
+    &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -39,7 +65,11 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[RFC_9110_8_4, RFC_9110_15_4_5]
+        &[RFC_9110_8_4, RFC_9110_15_4_5, RFC_9110_5_6_2]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -89,6 +119,13 @@ impl Rule for ContentEncodingAndTypeConsistent {
                 for part in crate::helpers::list::list_members(val) {
                     // Strip parameters (not expected for Content-Encoding but be forgiving)
                     let token = part.split(';').next().unwrap().trim();
+                    // **Not `list_member_empty`, though the message says
+                    // "member".** The walk above drops the list's empty members
+                    // before this sees them, so what reaches here is a member
+                    // that is *present* and whose coding half is missing --
+                    // `;q=1` and the like. That is `#content-coding`'s element
+                    // saying it is not optional, which is a statement about the
+                    // member's assembly and belongs to no subject.
                     if token.is_empty() {
                         return Some(self.violation(
                             ctx.severity,
@@ -102,8 +139,8 @@ impl Rule for ContentEncodingAndTypeConsistent {
                         ));
                     }
                     if let Some(c) = crate::helpers::token::find_invalid_token_char(token) {
-                        return Some(self.violation(
-                            ctx.severity,
+                        return Some(ctx.report_with(
+                            token_character(c),
                             format!("Invalid token '{}' in {} header", c, hdr_name),
                         ));
                     }
@@ -200,6 +237,90 @@ mod tests {
     use super::*;
     use hyper::header::HeaderValue;
     use rstest::rstest;
+
+    /// The six fields spelling `content-coding = token` now answer for it with
+    /// one pair of ids, and the last two arrive from the rules that ask the
+    /// fields a *different* question. Asserted against 2.37's rule, which reads
+    /// the same field for which names exist and shares no code with this one.
+    #[test]
+    fn a_coding_name_is_a_token_whatever_the_rule_is_asking() {
+        let judge = |rule: &dyn crate::rules::Rule,
+                     cfg: &crate::config::Config,
+                     value: &str|
+         -> Violation {
+            let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
+            tx.response.as_mut().unwrap().headers =
+                crate::test_helpers::make_headers_from_pairs(&[("content-encoding", value)]);
+            crate::test_helpers::run_rule(
+                rule,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                cfg,
+            )
+            .unwrap_or_else(|| panic!("{}: {value}", rule.id()))
+        };
+
+        // The neighbour reads an operator's list of names, so it needs one; the
+        // octet below is refused before any name is looked up.
+        let mut registered_cfg = crate::config::Config::default();
+        registered_cfg.rules.insert(
+            "content_encoding_registered".into(),
+            toml::Value::Table({
+                let mut t = toml::map::Map::new();
+                t.insert("enabled".into(), toml::Value::Boolean(true));
+                t.insert("severity".into(), toml::Value::String("warn".into()));
+                t.insert(
+                    "allowed".into(),
+                    toml::Value::Array(vec![toml::Value::String("gzip".into())]),
+                );
+                t
+            }),
+        );
+
+        let here = judge(
+            &ContentEncodingAndTypeConsistent,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "content_encoding_and_type_consistent",
+            ]),
+            "x@bad",
+        );
+        let registered = judge(
+            &crate::rules::content_encoding_registered::ContentEncodingRegistered,
+            &registered_cfg,
+            "x@bad",
+        );
+        assert_eq!(here.violation, "token_character_forbidden");
+        assert_eq!(registered.violation, "token_character_forbidden");
+        // And the sentence is *the same one*, written twice in two files that
+        // share no code -- one of the duplicate templates S6 counted, retired
+        // by the id and left as two strings for Phase 5's dedup to collapse.
+        assert_eq!(here.message, registered.message);
+    }
+
+    /// What this rule is named for keeps its own severity and no id: a coding
+    /// repeated and a wildcard where none is defined are both well-formed
+    /// tokens in a well-formed list, saying something § 8.4 does not license.
+    #[rstest]
+    #[case::duplicate("gzip, gzip", "")]
+    #[case::wildcard("*", "")]
+    #[case::no_coding("gzip, ;q=1", "")]
+    #[case::bad_octet("x@bad", "token_character_forbidden")]
+    #[case::space_inside("g zip", "token_whitespace_or_control_forbidden")]
+    fn the_grammars_defects_are_the_grammars(#[case] value: &str, #[case] violation: &str) {
+        let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
+        tx.response.as_mut().unwrap().headers =
+            crate::test_helpers::make_headers_from_pairs(&[("content-encoding", value)]);
+        let finding = crate::test_helpers::run_rule(
+            &ContentEncodingAndTypeConsistent,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "content_encoding_and_type_consistent",
+            ]),
+        )
+        .unwrap_or_else(|| panic!("expected a finding for {value:?}"));
+        assert_eq!(finding.violation, violation, "for {value:?}");
+    }
 
     #[rstest]
     #[case(Some("gzip"), 200, false)]

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -4727,7 +4727,7 @@ sources:
     snippet: The content negotiation fields defined by this specification use a common parameter, named "q" (case-insensitive), to assign a relative "weight" to the preference for that associated kind of content.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 250
+      line: 279
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 408
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
@@ -4737,7 +4737,7 @@ sources:
     snippet: weight = OWS ";" OWS "q=" qvalue
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 153
+      line: 182
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
       line: 139
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
@@ -4751,19 +4751,19 @@ sources:
     snippet: 'Accept-Encoding  = #( codings [ weight ] ) codings          = content-coding / "identity" / "*"'
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 152
+      line: 181
   - label: accept_encoding_parameter_valid (4)
     section: § 12.5.3
     snippet: An "identity" token is used as a synonym for "no encoding" in order to communicate when no encoding is preferred.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 196
+      line: 225
   - label: accept_encoding_parameter_valid (5)
     section: § 12.5.3
     snippet: An Accept-Encoding header field with a field value that is empty implies that the user agent does not want any content coding in response.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 174
+      line: 203
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
       line: 127
   - label: accept_encoding_parameter_valid (6)
@@ -4771,13 +4771,13 @@ sources:
     snippet: Each codings value MAY be given an associated quality value (weight) representing the preference for that encoding, as defined in Section 12.4.2.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 229
+      line: 258
   - label: accept_encoding_parameter_valid (7)
     section: § 12.5.3
     snippet: The asterisk "*" symbol in an Accept-Encoding field matches any available content coding not explicitly listed in the field.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 195
+      line: 224
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
       line: 160
   - label: accept_encoding_parameter_valid (8)
@@ -4785,13 +4785,13 @@ sources:
     snippet: The field value is evaluated the same way as in a request.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 135
+      line: 164
   - label: accept_encoding_parameter_valid (9)
     section: § 12.5.3
     snippet: When sent by a user agent in a request, Accept-Encoding indicates the content codings acceptable in a response.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 133
+      line: 162
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
       line: 119
   - label: accept_encoding_parameter_valid (10)
@@ -4799,13 +4799,13 @@ sources:
     snippet: When the Accept-Encoding header field is present in a response, it indicates what content codings the resource was willing to accept in the associated request.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 134
+      line: 163
   - label: accept_encoding_parameter_valid (11)
     section: § 8.4.1
     snippet: content-coding   = token
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 194
+      line: 223
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 142
   - label: accept_encoding_present
@@ -5431,7 +5431,7 @@ sources:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 141
     - file: lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
-      line: 88
+      line: 118
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
       line: 145
   - label: compression_and_transfer_encoding_consistent (5)
@@ -5567,7 +5567,7 @@ sources:
     snippet: a sender SHOULD NOT generate representation metadata other than the above listed fields unless said metadata exists for the purpose of guiding cache updates
     cited_by:
     - file: lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
-      line: 154
+      line: 191
   - label: content_encoding_registered
     section: § 12.5.3
     snippet: codings = content-coding / "identity" / "*"
@@ -7107,7 +7107,7 @@ sources:
     - file: lint-http-rules/src/helpers/list.rs
       line: 84
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 175
+      line: 204
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 211
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
@@ -7431,7 +7431,7 @@ sources:
     - file: lint-http-rules/src/helpers/qvalue.rs
       line: 31
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 279
+      line: 308
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
       line: 213
   - label: 3xx redirection class


### PR DESCRIPTION
`content_encoding_and_type_consistent` and `accept_encoding_parameter_valid` declare the `token` pair, three sites, no new defs. These are the same two fields 2.37 converted, read by two rules asking a different question of them — which codings were applied twice, and whether anything but a weight follows a coding — and the octet no `tchar` admits comes out with the same id either way.

The two `Content-Encoding` rules say it in the *same words*: "Invalid token '@' in Content-Encoding header", written in two files that share no code. One of S6's duplicate templates, and the test asserts both halves — one id, two strings — which is the state Phase 5's dedup was deferred to act on.

Two findings that look like the list's are not, and the walk is why. The "empty member" branch of `Content-Encoding` cannot see one: the reader drops the list's empty members before it, so what reaches it is a member that is present with its coding half missing. `Accept-Encoding`'s "empty content-coding" is the same shape from `codings [ weight ]`. Both are a construct's statement about its own assembly, and both stay at the rule's severity, beside the coding repeated and the wildcard where none is defined.

Catalogue unchanged at 110, all floors unchanged. Coverage 97.76% (22,247/22,756), +0.00%.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
