### PR TITLE
A disposition type is a token, twice over

### DIFF
--- a/docs/rules/content_disposition_token_valid.md
+++ b/docs/rules/content_disposition_token_valid.md
@@ -23,7 +23,7 @@ Since the grammar has no comma-separated-list alternative, a message section car
 - [RFC 6266 §4.1](https://www.rfc-editor.org/rfc/rfc6266.html#section-4.1): Grammar: a mandatory `disposition-type` followed by optional `;`-separated parameters, with `disp-ext-type = token`. Whitespace around the separators is implied rather than written
 - [RFC 6266 §4.2](https://www.rfc-editor.org/rfc/rfc6266.html#section-4.2): Disposition Type: an unknown type is conforming and has defined handling (treat as `attachment`), which is why this rule validates the value's shape and not its membership in any list
 - [RFC 6266 §4](https://www.rfc-editor.org/rfc/rfc6266.html#section-4): Defines Content-Disposition as a *response* header field — the request half of this rule is a deliberate extension beyond the document, since upload APIs do send one
-- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): `token = 1*tchar` — where the production actually lives now. RFC 6266 §4.1 imports `token` from the obsolete RFC 2616; the character set is unchanged
+- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 - [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order: a sender MUST NOT emit multiple field lines for a field whose definition has no comma-separated-list alternative
 
 ## Configuration

--- a/lint-http-rules/src/rules/content_disposition_token_valid.rs
+++ b/lint-http-rules/src/rules/content_disposition_token_valid.rs
@@ -4,8 +4,39 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::token::{
+    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN, TOKEN_EMPTY,
+    TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+};
+use crate::violations::ViolationDef;
 
 pub struct ContentDispositionTokenValid;
+
+/// The `token` trio, and the field's own document defines none of it.
+///
+/// `disposition-type = "inline" | "attachment" | disp-ext-type` with
+/// `disp-ext-type = token`, and § 4.1 imports `token` from the obsolete RFC
+/// 2616 — whose character set is § 5.6.2's, which is the reading
+/// `Sec-WebSocket-Extensions` and `Strict-Transport-Security` each arrived at
+/// from their own grammars. The rule is *named* for a token check and now
+/// writes none of it.
+///
+/// **Two messages, one id, and that is the point of the pair.** An empty field
+/// value and a value opening on its first `;` are two spellings of the same
+/// missing `disposition-type`, and the operator's fix is the same word either
+/// way. The rule still says which it saw.
+///
+/// Two findings stay unnamed. A message carrying two field lines is § 5.3's
+/// MUST NOT about *field order*, which is about the message rather than about
+/// any production in it; and the octet outside visible US-ASCII is open
+/// question 1's shape — a verdict naming an encoding where the defect is an
+/// octet the grammar does not admit, whose right conversion is an octet-wise
+/// reader first.
+static DECLARED: &[&ViolationDef] = &[
+    &TOKEN_EMPTY,
+    &TOKEN_CHARACTER_FORBIDDEN,
+    &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -27,12 +58,6 @@ const RFC_6266_4: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("4"),
     url: "https://www.rfc-editor.org/rfc/rfc6266.html#section-4",
     note: "Defines Content-Disposition as a *response* header field — the request half of this rule is a deliberate extension beyond the document, since upload APIs do send one",
-};
-const RFC_9110_5_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("5.6.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
-    note: "`token = 1*tchar` — where the production actually lives now. RFC 6266 §4.1 imports `token` from the obsolete RFC 2616; the character set is unchanged",
 };
 const RFC_9110_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
@@ -68,6 +93,10 @@ severity = "warn"
             RFC_9110_5_6_2,
             RFC_9110_5_3,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -143,9 +172,8 @@ impl Rule for ContentDispositionTokenValid {
                 // cite(RFC 6266 § 4.1): "content-disposition = "Content-Disposition" ":" disposition-type *( ";" disposition-parm )"
                 let s = val.trim();
                 if s.is_empty() {
-                    return Some(self.cited(
-                        &RFC_6266_4_1,
-                        ctx.severity,
+                    return Some(ctx.report_with(
+                        &TOKEN_EMPTY,
                         format!("{} header value must not be empty", hdr_name),
                     ));
                 }
@@ -156,10 +184,13 @@ impl Rule for ContentDispositionTokenValid {
                 // cite(RFC 6266 § 4.1): "Note that due to the rules for implied linear whitespace (Section 2.1 of [RFC2616]), OPTIONAL whitespace can appear between words (token or quoted-string) and separator characters."
                 let dispo = s.split(';').next().unwrap().trim();
                 // cite(RFC 6266 § 4.1): "disposition-type = "inline" | "attachment" | disp-ext-type"
+                // The same id as the branch above, said differently: a value
+                // that is nothing and a value opening on its first `;` are two
+                // spellings of one missing `disposition-type`, and `token` is
+                // `1*tchar` for both.
                 if dispo.is_empty() {
-                    return Some(self.cited(
-                        &RFC_6266_4_1,
-                        ctx.severity,
+                    return Some(ctx.report_with(
+                        &TOKEN_EMPTY,
                         format!("{} header disposition-type must not be empty", hdr_name),
                     ));
                 }
@@ -173,8 +204,8 @@ impl Rule for ContentDispositionTokenValid {
                 // cite(RFC 6266 § 4.1): "disp-ext-type       = token"
                 // cite(RFC 6266 § 4.2): "Unknown or unhandled disposition types SHOULD be handled by recipients the same way as "attachment" (see also [RFC2183], Section 2.8)."
                 if let Some(c) = crate::helpers::token::find_invalid_token_char(dispo) {
-                    return Some(self.violation(
-                        ctx.severity,
+                    return Some(ctx.report_with(
+                        token_character(c),
                         format!(
                             "{} disposition-type contains invalid token character: '{}'",
                             hdr_name, c
@@ -320,6 +351,65 @@ mod tests {
         } else {
             assert!(v.is_none(), "did not expect violation for '{:?}'", value);
         }
+    }
+
+    /// Every finding, with the defect it reports as. The two spellings of a
+    /// missing `disposition-type` share an id and keep their own sentences; the
+    /// two that stay unnamed are § 5.3's requirement about the *message* and
+    /// the octet reading open question 1 is about.
+    #[rstest]
+    #[case::empty_value("", "token_empty")]
+    #[case::no_type_before_semicolon("; filename=\"a\"", "token_empty")]
+    #[case::bad_octet("bad@type; filename=\"a\"", "token_character_forbidden")]
+    #[case::space_inside("bad type", "token_whitespace_or_control_forbidden")]
+    fn each_finding_reports_the_production_it_belongs_to(
+        #[case] value: &str,
+        #[case] violation: &str,
+    ) {
+        let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
+        tx.response.as_mut().unwrap().headers =
+            crate::test_helpers::make_headers_from_pairs(&[("content-disposition", value)]);
+        let finding = crate::test_helpers::run_rule(
+            &ContentDispositionTokenValid,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_severity(
+                "content_disposition_token_valid",
+                "warn",
+            ),
+        )
+        .unwrap_or_else(|| panic!("expected a finding for {value:?}"));
+        assert_eq!(finding.violation, violation, "for {value:?}");
+    }
+
+    /// A `disp-ext-type` is a `token` and so is a `Vary` member, and RFC 6266
+    /// importing the production from the obsolete RFC 2616 changes nothing
+    /// about the octet. Two rules, two documents, one id.
+    #[test]
+    fn a_disposition_type_is_a_token_like_any_other() {
+        let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
+        tx.response.as_mut().unwrap().headers =
+            crate::test_helpers::make_headers_from_pairs(&[("content-disposition", "bad@type")]);
+        let here = crate::test_helpers::run_rule(
+            &ContentDispositionTokenValid,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_severity(
+                "content_disposition_token_valid",
+                "warn",
+            ),
+        )
+        .expect("a finding");
+        let elsewhere = crate::test_helpers::run_rule(
+            &crate::rules::vary_header_valid::VaryHeaderValid,
+            &crate::test_helpers::make_test_transaction_with_response(200, &[("vary", "b@d")]),
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["vary_header_valid"]),
+        )
+        .expect("a finding");
+
+        assert_eq!(here.violation, elsewhere.violation);
+        assert_ne!(here.message, elsewhere.message);
     }
 
     #[test]

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1283,14 +1283,17 @@ severity = "warn"
     /// and defines neither, so the two sites had nowhere nearer to point. The
     /// sentence saying what a token is now sits on the def; the sentence saying
     /// that *this* field's directive name is one stays at the site, which is
-    /// what licensed the borrowing.
+    /// what licensed the borrowing. `content_disposition_token_valid` took two
+    /// more of the same shape, both citing RFC 6266 §4.1 for a
+    /// `disposition-type` that is not there — one sentence, two spellings, and
+    /// now one def.
     #[test]
     fn citation_coverage_does_not_regress() {
         /// Finding sites that name the specification sentence they enforce.
         /// The rest are the per-rule reading that has not happened yet — the
         /// denominator is computed below, because merges and conversions both
         /// move it.
-        const FLOOR: usize = 155;
+        const FLOOR: usize = 153;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -2334,45 +2334,45 @@ sources:
     - file: lint-http-rules/src/rules/content_disposition_parameter_valid.rs
       line: 145
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 143
+      line: 172
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 224
+      line: 255
   - label: content_disposition_token_valid
     section: § 1
     snippet: This document does not apply to Content-Disposition header fields appearing in payload bodies transmitted over HTTP, such as when using the media type "multipart/form-data" ([RFC2388]).
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 124
+      line: 153
   - label: content_disposition_token_valid (2)
     section: § 4
     snippet: The Content-Disposition response header field is used to convey additional information about how to process the response payload, and also can be used to attach additional metadata, such as the filename to use when saving the response payload locally.
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 123
+      line: 152
   - label: content_disposition_token_valid (3)
     section: § 4.1
     snippet: Note that due to the rules for implied linear whitespace (Section 2.1 of [RFC2616]), OPTIONAL whitespace can appear between words (token or quoted-string) and separator characters.
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 156
+      line: 184
   - label: content_disposition_token_valid (4)
     section: § 4.1
     snippet: disp-ext-type       = token
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 173
+      line: 204
   - label: content_disposition_token_valid (5)
     section: § 4.1
     snippet: disposition-type = "inline" | "attachment" | disp-ext-type
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 158
+      line: 186
   - label: content_disposition_token_valid (6)
     section: § 4.2
     snippet: Unknown or unhandled disposition types SHOULD be handled by recipients the same way as "attachment" (see also [RFC2183], Section 2.8).
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 174
+      line: 205
 - label: RFC 6335
   url: https://www.rfc-editor.org/rfc/rfc6335.html
   fragments:
@@ -5559,7 +5559,7 @@ sources:
     snippet: Field values are usually constrained to the range of US-ASCII characters [USASCII].
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 251
+      line: 282
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
       line: 220
   - label: content_encoding_and_type_consistent
@@ -6951,7 +6951,7 @@ sources:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
       line: 169
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 226
+      line: 257
     - file: lint-http-rules/src/rules/content_type_valid.rs
       line: 222
     - file: lint-http-rules/src/rules/deprecation_header_syntax.rs
@@ -7017,7 +7017,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 387
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 225
+      line: 256
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 263
   - label: lint-http-rules/src/helpers/headers.rs (7)


### PR DESCRIPTION
`content_disposition_token_valid` declares the `token` trio and writes none of it. RFC 6266 § 4.1 spells `disp-ext-type = token` and imports the production from the obsolete RFC 2616, whose character set is § 5.6.2's — the same reading `Sec-WebSocket-Extensions` and `Strict-Transport-Security` each arrived at from their own grammars. The rule is named for a token check and now writes none of it; a `bad@type` here and a `b@d` in a `Vary` are asserted as one defect.

Two messages, one id. An empty field value and a value opening on its first `;` are two spellings of the same missing `disposition-type`, and the operator's fix is the same word either way — so both report `token_empty` and each keeps the sentence it always said.

Two findings stay unnamed. A message carrying two field lines is § 5.3's MUST NOT about field order, which is about the message rather than about any production in it; and the octet outside visible US-ASCII names an encoding where the defect is an octet the grammar does not admit, whose right conversion is an octet-wise reader first.

The citation floor falls 155 → 153 — the two converted sites both cited RFC 6266 § 4.1 for a `disposition-type` that is not there, which is one sentence answering two spellings and is exactly what a def is for.

Catalogue unchanged at 110, spec floor unchanged. Coverage 97.76% (22,247/22,756), +0.00%.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
