### PR TITLE
An auth-param list fails in four ways

### DIFF
--- a/docs/rules/digest_auth_valid.md
+++ b/docs/rules/digest_auth_valid.md
@@ -20,6 +20,7 @@ Servers and clients relying on Digest authentication may behave incorrectly when
 
 - [RFC 7616 §3.4](https://www.rfc-editor.org/rfc/rfc7616.html#section-3.4): The Authorization Header Field — the Digest credentials, their parameters, the 4xx consequence for missing or improper ones, the "MUST be used by all implementations" on cnonce and nc, and the two historical-reasons quoting MUSTs enforced here in both directions
 - [RFC 2617 §3.2.2](https://www.rfc-editor.org/rfc/rfc2617.html#section-3.2.2): The obsolete document whose qop-less credential shape is why cnonce and nc are demanded only beside a qop: its own conditional ("MUST be specified if a qop directive is sent") is the observable line, and deployed servers still verify the older shape
+- [RFC 9110 §5.6.1.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1): The list construct — `1#element => element *( OWS "," OWS element )`, and the sender's MUST NOT against an empty element
 - [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 - [RFC 9110 §5.6.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4): `quoted-string = DQUOTE *( qdtext / quoted-pair ) DQUOTE` — the two delimiters, the class between them, and the backslash escape
 

--- a/lint-http-rules/src/helpers/auth.rs
+++ b/lint-http-rules/src/helpers/auth.rs
@@ -619,30 +619,84 @@ pub fn validate_bearer_token(token: &str) -> Result<(), BearerTokenDefect> {
     Ok(())
 }
 
+/// What one member of an `#auth-param` list fails to be.
+///
+/// Four variants and three of them belong to another subject: the list
+/// construct's empty element, and the `token` an `auth-param` name has to be.
+/// The fourth is `auth-param`'s own — that the `=` and the value after it are
+/// not optional — and no subject holds it, because § 5.6.6's `parameter` is a
+/// different production with `BWS` where this one has none.
+///
+/// The type exists so the rule reading these can name *which*; it used to
+/// receive one rendered sentence and could only pass it on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthParamsDefect<'a> {
+    /// A member contributing nothing to the list: a stray or trailing comma.
+    Empty,
+    /// A member whose name is empty — the `=` with nothing before it.
+    NameEmpty,
+    /// A character in the name that no `tchar` admits.
+    NameCharacter(char),
+    /// A member with no `=` in it at all. Carries the name, because the
+    /// finding names the parameter that owes a value.
+    ValueMissing(&'a str),
+}
+
+impl AuthParamsDefect<'_> {
+    /// The finding, worded as every caller has always worded it.
+    pub fn message(self) -> String {
+        match self {
+            Self::Empty => "empty auth-param".into(),
+            Self::NameEmpty => "empty auth-param name".into(),
+            Self::NameCharacter(c) => {
+                format!("Invalid character '{}' in auth-param name", c)
+            }
+            Self::ValueMissing(name) => format!("auth-param '{}' missing value", name),
+        }
+    }
+}
+
 /// Parse an auth-param list (e.g., `username="Mufasa", realm="x", nonce=abc`) into a
 /// HashMap of (name -> value) pairs. Values preserve quotes when present (e.g., `"x"`).
-/// Returns Err(String) on parse error.
-pub fn parse_auth_params(s: &str) -> Result<std::collections::HashMap<String, String>, String> {
+///
+/// **The `Err` is the defect and not a sentence.** Rendering it is
+/// [`AuthParamsDefect::message`] at the call site — one method, and the string
+/// is byte-identical to what this returned before. What the change buys is that
+/// three of the four defects are *nameable* by a caller reporting through the
+/// catalogue: the empty member is the list's, and the two about the name are
+/// the `token`'s.
+///
+/// Four rules call this and one of them reports. The other three treat a
+/// failure as "there is nothing here to reason about" and move on, which is
+/// what makes the caller count an upper bound rather than a work list.
+///
+/// The name is measured here rather than left to the caller, which is why
+/// `digest_auth_valid`'s own name check answers nothing: this returns first.
+// cite(RFC 9110 § 11.2): "auth-param     = token BWS "=" BWS ( token / quoted-string )"
+// cite(RFC 9110 § 5.6.1.1): "In any production that uses the list construct, a sender MUST NOT generate empty list elements."
+pub fn parse_auth_params(
+    s: &str,
+) -> Result<std::collections::HashMap<String, String>, AuthParamsDefect<'_>> {
     let mut out = std::collections::HashMap::new();
     // split comma-separated params respecting quoted-strings
     for part in split_commas_respecting_quotes(s) {
         let p = part;
         if p.is_empty() {
-            return Err("empty auth-param".into());
+            return Err(AuthParamsDefect::Empty);
         }
         let mut kv = p.splitn(2, '=');
         let name = kv
             .next()
             .map(|x| x.trim())
             .filter(|x| !x.is_empty())
-            .ok_or_else(|| "empty auth-param name".to_string())?;
+            .ok_or(AuthParamsDefect::NameEmpty)?;
         let val = kv
             .next()
             .map(|x| x.trim())
-            .ok_or_else(|| format!("auth-param '{}' missing value", name))?;
+            .ok_or(AuthParamsDefect::ValueMissing(name))?;
         // name must be a token
         if let Some(inv) = crate::helpers::token::find_invalid_token_char(name) {
-            return Err(format!("Invalid character '{}' in auth-param name", inv));
+            return Err(AuthParamsDefect::NameCharacter(inv));
         }
         out.insert(name.to_ascii_lowercase(), val.to_string());
     }
@@ -838,15 +892,38 @@ mod tests {
     #[test]
     fn parse_auth_params_invalid_name_char() {
         let r = parse_auth_params("user@name=abc");
-        assert!(r.is_err());
-        assert!(r.unwrap_err().contains("Invalid character"));
+        assert_eq!(r.unwrap_err(), AuthParamsDefect::NameCharacter('@'));
     }
 
     #[test]
     fn parse_auth_params_empty_member_is_error() {
         let r = parse_auth_params("a=b, , c=d");
-        assert!(r.is_err());
-        assert!(r.unwrap_err().contains("empty"));
+        assert_eq!(r.unwrap_err(), AuthParamsDefect::Empty);
+    }
+
+    /// The four verdicts and the sentence each renders as, which is what every
+    /// caller embedded when this returned a `String` — byte for byte, so the
+    /// typing changed no message anywhere.
+    #[test]
+    fn each_auth_param_defect_renders_the_sentence_it_always_did() {
+        for (input, defect, message) in [
+            ("a=b, , c=d", AuthParamsDefect::Empty, "empty auth-param"),
+            ("=abc", AuthParamsDefect::NameEmpty, "empty auth-param name"),
+            (
+                "user@name=abc",
+                AuthParamsDefect::NameCharacter('@'),
+                "Invalid character '@' in auth-param name",
+            ),
+            (
+                "username",
+                AuthParamsDefect::ValueMissing("username"),
+                "auth-param 'username' missing value",
+            ),
+        ] {
+            let got = parse_auth_params(input).unwrap_err();
+            assert_eq!(got, defect, "{input}");
+            assert_eq!(got.message(), message, "{input}");
+        }
     }
 
     #[test]

--- a/lint-http-rules/src/rules/digest_auth_valid.rs
+++ b/lint-http-rules/src/rules/digest_auth_valid.rs
@@ -4,23 +4,21 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::list::{auth_param_member, LIST_MEMBER_EMPTY, RFC_9110_5_6_1_1};
 use crate::violations::quoted_string::{
     quoted_string_defect, QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
     QUOTED_STRING_DELIMITER_MISSING, QUOTED_STRING_QUOTED_PAIR_MALFORMED,
     QUOTED_STRING_QUOTE_ESCAPE_MISSING, RFC_9110_5_6_4,
 };
 use crate::violations::token::{
-    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
+    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN, TOKEN_EMPTY,
     TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
 };
 use crate::violations::ViolationDef;
 
 pub struct DigestAuthValid;
 
-/// The specification references this rule declares, each named so a finding
-/// site can cite the one it enforces. `specifications()` below is built from
-/// exactly these, so the docs and the citations cannot name different text.
-/// The six defects an `auth-param` can have that are not RFC 7616's.
+/// The eight defects an `auth-param` can have that are not RFC 7616's.
 ///
 /// `auth-param = token BWS "=" BWS ( token / quoted-string )` is RFC 9110
 /// § 11.2's, imported by RFC 7616 unchanged, so a name holding a `@` and a
@@ -36,18 +34,16 @@ pub struct DigestAuthValid;
 /// quoting lists — which are requirements about *which spelling* a
 /// well-formed value uses, not about whether it is well formed.
 ///
-/// One site is left, and it is a whole commit of its own.
-/// [`crate::helpers::auth::parse_auth_params`] answers every caller in a
-/// rendered `String`, which is 2.15's tell exactly; three of its five verdicts
-/// are already named here (an empty member, an empty name, a name holding a
-/// character no `tchar` admits) and it has four callers. **It is also why
-/// `TOKEN_CHARACTER_FORBIDDEN` is declared and only reachable through the
-/// value half**: that helper measures the name first and hands back a sentence,
-/// so this rule's own name check answers nothing until the helper is typed. The
-/// declaration is kept because the mapping is exhaustive and the reachable half
-/// needs both ids anyway — the invisible octet cannot arrive through a
-/// `HeaderValue`, the visible one can.
+/// [`crate::helpers::auth::parse_auth_params`] is typed as well, so the list
+/// construct's empty member and the two `token` verdicts about a name arrive
+/// named from the reader — which is where they were always decided. Its fourth
+/// verdict stays this production's: § 11.2 writes `auth-param = token BWS "="
+/// BWS ( token / quoted-string )`, so a member with no `=` breaks *that*
+/// sentence, and `parameter_equals_missing` carries § 5.6.6's about a
+/// production with no `BWS` in it.
 static DECLARED: &[&ViolationDef] = &[
+    &LIST_MEMBER_EMPTY,
+    &TOKEN_EMPTY,
     &TOKEN_CHARACTER_FORBIDDEN,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
     &QUOTED_STRING_DELIMITER_MISSING,
@@ -56,6 +52,9 @@ static DECLARED: &[&ViolationDef] = &[
     &QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
 ];
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
 const RFC_7616_3_4: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 7616",
     section: Some("3.4"),
@@ -85,7 +84,13 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[RFC_7616_3_4, RFC_2617_3_2_2, RFC_9110_5_6_2, RFC_9110_5_6_4]
+        &[
+            RFC_7616_3_4,
+            RFC_2617_3_2_2,
+            RFC_9110_5_6_1_1,
+            RFC_9110_5_6_2,
+            RFC_9110_5_6_4,
+        ]
     }
 
     fn violations(&self) -> &'static [&'static ViolationDef] {
@@ -229,18 +234,17 @@ impl Rule for DigestAuthValid {
                                     // so the two ids here are the ones every
                                     // other reader of it answers with.
                                     //
-                                    // **This branch cannot fire today**, and the
+                                    // **This branch still cannot fire**, and the
                                     // reason is two lines up rather than anywhere
                                     // in this document: `parse_auth_params`
                                     // measures the name against the same reader
                                     // and returns `Err` first, so a `user@name`
-                                    // reaches the rendered-string arm below
-                                    // instead. That is a sixth variety of
-                                    // unreachable -- not the transport, not the
-                                    // field's spelling, but a shared reader that
-                                    // already answered -- and it is what typing
-                                    // that helper will resolve, at which point
-                                    // the id here is the one it should hand back.
+                                    // is answered there. It is kept because the
+                                    // two answers now agree by construction --
+                                    // the helper's mapping hands back this same
+                                    // id -- and because a reader that stopped
+                                    // measuring the name would leave this the
+                                    // only check of it.
                                     if let Some(inv) =
                                         crate::helpers::token::find_invalid_token_char(k)
                                     {
@@ -307,11 +311,19 @@ impl Rule for DigestAuthValid {
                                     }
                                 }
                             }
-                            Err(msg) => {
-                                return Some(self.violation(
-                                    ctx.severity,
-                                    format!("Invalid Digest auth parameters: {}", msg),
-                                ))
+                            // The reader is typed now, so three of its four
+                            // verdicts arrive with a name: an empty member is
+                            // the list's, an empty name and a bad character are
+                            // the `token`'s. The fourth — a member with no `=`
+                            // — is § 11.2's own sentence about `auth-param`,
+                            // and § 5.6.6's `parameter` does not answer for it.
+                            Err(defect) => {
+                                let message =
+                                    format!("Invalid Digest auth parameters: {}", defect.message());
+                                return Some(match auth_param_member(defect) {
+                                    Some(def) => ctx.report_with(def, message),
+                                    None => self.violation(ctx.severity, message),
+                                });
                             }
                         }
                     }
@@ -428,13 +440,16 @@ mod tests {
     /// with the ids they now carry — and the four that stay RFC 7616's, at the
     /// rule's own severity.
     #[rstest]
-    // A bad *name* does not reach this rule's own check: `parse_auth_params`
-    // measures it with the same reader and returns a rendered string first,
-    // which is the unnamed arm below and the next commit's work.
+    // A bad *name* is answered by the reader rather than by this rule's own
+    // check -- `parse_auth_params` measures it two lines earlier -- and since
+    // that reader is typed, the same id arrives either way.
     #[case::name_character(
         "Digest user@name=abc, realm=\"r\", nonce=\"n\", uri=\"/\", response=\"d\"",
-        ""
+        "token_character_forbidden"
     )]
+    #[case::empty_member("Digest username=\"u\", , realm=\"r\"", "list_member_empty")]
+    #[case::empty_name("Digest =abc, realm=\"r\"", "token_empty")]
+    #[case::value_missing("Digest username, realm=\"r\"", "")]
     #[case::value_character("Digest username=\"u\", realm=\"r\", nonce=\"n\", uri=\"/\", response=\"d\", algorithm=M@D5", "token_character_forbidden")]
     #[case::unterminated_quote(
         "Digest username=\"u\", realm=\"r\", nonce=\"n\", uri=\"/\", response=\"d\", opaque=\"abc",

--- a/lint-http-rules/src/violations/list.rs
+++ b/lint-http-rules/src/violations/list.rs
@@ -35,6 +35,7 @@
 //! not generate — so the section a sentence sits in is not what decides whose
 //! requirement it states.
 
+use crate::helpers::auth::AuthParamsDefect;
 use crate::helpers::cache_control::MemberDefect as CacheControlMemberDefect;
 use crate::lint::Severity;
 use crate::rules::SpecRef;
@@ -123,6 +124,33 @@ pub fn cache_directive_member(defect: CacheControlMemberDefect<'_>) -> &'static 
     }
 }
 
+/// The defect one `#auth-param` member reports as — `None` where the answer is
+/// the production's own.
+///
+/// The reader is [`crate::helpers::auth::parse_auth_params`], called by four
+/// rules of the authentication cluster, and three of its four defects belong
+/// elsewhere: the empty member to this subject, the empty name and the bad
+/// character to the `token` an `auth-param` name has to be.
+///
+/// The `None` is the fourth, and it is refused rather than unwritten.
+/// § 11.2 writes `auth-param = token BWS "=" BWS ( token / quoted-string )`,
+/// so a member with no `=` breaks *that* sentence — not
+/// [`crate::violations::parameter::PARAMETER_EQUALS_MISSING`]'s, which carries
+/// § 5.6.6's `parameter` and its Note refusing the whitespace this production
+/// prints. Two documents' worth of the same-looking construct, and the third
+/// time in this catalogue that difference has decided an id.
+///
+/// It lives here for the reason `cache_directive_member` does: the first thing
+/// the reader measures is the list member.
+pub fn auth_param_member(defect: AuthParamsDefect<'_>) -> Option<&'static ViolationDef> {
+    match defect {
+        AuthParamsDefect::Empty => Some(&LIST_MEMBER_EMPTY),
+        AuthParamsDefect::NameEmpty => Some(&TOKEN_EMPTY),
+        AuthParamsDefect::NameCharacter(c) => Some(token_character(c)),
+        AuthParamsDefect::ValueMissing(_) => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -146,6 +174,46 @@ mod tests {
         ] {
             assert_eq!(cache_directive_member(defect).id, id);
         }
+    }
+
+    /// Four variants and one of them has no answer here, which is the decision
+    /// the `Option` exists to record: `auth-param` requires its `=`, and the
+    /// def that looks like it answers carries a production with no `BWS` in it.
+    #[test]
+    fn an_auth_param_member_answers_with_the_production_it_failed() {
+        for (defect, id) in [
+            (AuthParamsDefect::Empty, Some("list_member_empty")),
+            (AuthParamsDefect::NameEmpty, Some("token_empty")),
+            (
+                AuthParamsDefect::NameCharacter('@'),
+                Some("token_character_forbidden"),
+            ),
+            (
+                AuthParamsDefect::NameCharacter(' '),
+                Some("token_whitespace_or_control_forbidden"),
+            ),
+            (AuthParamsDefect::ValueMissing("username"), None),
+        ] {
+            assert_eq!(auth_param_member(defect).map(|d| d.id), id, "{defect:?}");
+        }
+    }
+
+    /// Two readers, two documents, and the same two ids for the same two
+    /// mistakes — which is the whole reason both mappings live in this file.
+    #[test]
+    fn a_cache_directive_and_an_auth_param_fail_the_list_alike() {
+        assert_eq!(
+            cache_directive_member(CacheControlMemberDefect::Empty).id,
+            auth_param_member(AuthParamsDefect::Empty)
+                .expect("named")
+                .id,
+        );
+        assert_eq!(
+            cache_directive_member(CacheControlMemberDefect::NameCharacter('@')).id,
+            auth_param_member(AuthParamsDefect::NameCharacter('@'))
+                .expect("named")
+                .id,
+        );
     }
 
     /// The whole of this subject so far, and the assertion that matters about

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1098,7 +1098,7 @@ sources:
     snippet: This MUST be specified if a qop directive is sent (see above), and MUST NOT be specified if the server did not send a qop directive in the WWW-Authenticate header field.
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
-      line: 213
+      line: 218
 - label: RFC 3230
   url: https://www.rfc-editor.org/rfc/rfc3230.html
   fragments:
@@ -3779,31 +3779,31 @@ sources:
     snippet: 'For historical reasons, a sender MUST NOT generate the quoted string syntax for the following parameters: algorithm, qop, and nc.'
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
-      line: 265
+      line: 269
   - label: digest_auth_valid (2)
     section: § 3.4
     snippet: 'For historical reasons, a sender MUST only generate the quoted string syntax for the following parameters: username, realm, nonce, uri, response, cnonce, and opaque.'
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
-      line: 264
+      line: 268
   - label: digest_auth_valid (3)
     section: § 3.4
     snippet: If a parameter or its value is improper, or required parameters are missing, the proper response is a 4xx error code.
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
-      line: 170
+      line: 175
   - label: cnonce
     section: § 3.4
     snippet: This parameter MUST be used by all implementations.
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
-      line: 212
+      line: 217
   - label: lint-http-rules/src/helpers/auth.rs
     section: § 3.5
     snippet: For historical reasons, the nc value MUST be exactly 8 hexadecimal digits.
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 664
+      line: 718
 - label: RFC 7617
   url: https://www.rfc-editor.org/rfc/rfc7617.html
   fragments:
@@ -4953,7 +4953,7 @@ sources:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
       line: 412
     - file: lint-http-rules/src/violations/list.rs
-      line: 98
+      line: 99
   - label: accept_patch_header_valid (6)
     section: § 9.1
     snippet: The method token is case-sensitive because it might be used as a gateway to object-based systems with case-sensitive method names.
@@ -5352,18 +5352,6 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/cached_validators_reused.rs
       line: 138
-  - label: challenge
-    section: § 11.2
-    snippet: auth-param     = token BWS "=" BWS ( token / quoted-string )
-    cited_by:
-    - file: lint-http-rules/src/violations/challenge.rs
-      line: 126
-    - file: lint-http-rules/src/violations/challenge.rs
-      line: 139
-    - file: lint-http-rules/src/violations/challenge.rs
-      line: 153
-    - file: lint-http-rules/src/violations/challenge.rs
-      line: 167
   - label: charset_present
     section: § 8.3.2
     snippet: HTTP uses "charset" names to indicate or negotiate the character encoding scheme
@@ -6541,10 +6529,24 @@ sources:
     - file: lint-http-rules/src/rules/bearer_token_syntax.rs
       line: 110
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
-      line: 145
+      line: 150
     - file: lint-http-rules/src/violations/auth_scheme.rs
       line: 42
   - label: lint-http-rules/src/helpers/auth.rs (2)
+    section: § 11.2
+    snippet: auth-param     = token BWS "=" BWS ( token / quoted-string )
+    cited_by:
+    - file: lint-http-rules/src/helpers/auth.rs
+      line: 675
+    - file: lint-http-rules/src/violations/challenge.rs
+      line: 126
+    - file: lint-http-rules/src/violations/challenge.rs
+      line: 139
+    - file: lint-http-rules/src/violations/challenge.rs
+      line: 153
+    - file: lint-http-rules/src/violations/challenge.rs
+      line: 167
+  - label: lint-http-rules/src/helpers/auth.rs (3)
     section: § 11.3
     snippet: 'challenge = auth-scheme [ 1*SP ( token68 / #auth-param ) ]'
     cited_by:
@@ -6556,7 +6558,7 @@ sources:
       line: 88
     - file: lint-http-rules/src/violations/challenge.rs
       line: 114
-  - label: lint-http-rules/src/helpers/auth.rs (3)
+  - label: lint-http-rules/src/helpers/auth.rs (4)
     section: § 11.4
     snippet: 'credentials = auth-scheme [ 1*SP ( token68 / #auth-param ) ]'
     cited_by:
@@ -6566,7 +6568,7 @@ sources:
       line: 52
     - file: lint-http-rules/src/violations/credentials.rs
       line: 82
-  - label: lint-http-rules/src/helpers/auth.rs (4)
+  - label: lint-http-rules/src/helpers/auth.rs (5)
     section: § 11.6.1
     snippet: 'WWW-Authenticate = #challenge'
     cited_by:
@@ -6596,44 +6598,12 @@ sources:
       line: 287
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 259
-  - label: lint-http-rules/src/helpers/cache_control.rs
-    section: § 5.2
-    snippet: When a field name is repeated within a section, its combined field value consists of the list of corresponding field line values within that section, concatenated in order, with each field line value separated by a comma.
-    cited_by:
-    - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 110
-    - file: lint-http-rules/src/helpers/headers.rs
-      line: 121
-    - file: lint-http-rules/src/helpers/headers.rs
-      line: 389
-    - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
-      line: 110
-    - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
-      line: 110
-    - file: lint-http-rules/src/rules/max_forwards_numeric.rs
-      line: 153
-    - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 216
-    - file: lint-http-rules/src/rules/proxy_connection_discouraged.rs
-      line: 134
-    - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
-      line: 184
-    - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 21
-    - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 41
-  - label: lint-http-rules/src/helpers/cache_control.rs (2)
-    section: § 5.6.1
-    snippet: '#element => [ element ] *( OWS "," OWS [ element ] )'
-    cited_by:
-    - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 112
-    - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 339
-  - label: lint-http-rules/src/helpers/cache_control.rs (3)
+  - label: lint-http-rules/src/helpers/auth.rs (6)
     section: § 5.6.1.1
     snippet: In any production that uses the list construct, a sender MUST NOT generate empty list elements.
     cited_by:
+    - file: lint-http-rules/src/helpers/auth.rs
+      line: 676
     - file: lint-http-rules/src/helpers/cache_control.rs
       line: 111
     - file: lint-http-rules/src/helpers/cache_control.rs
@@ -6683,7 +6653,41 @@ sources:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
       line: 274
     - file: lint-http-rules/src/violations/list.rs
-      line: 71
+      line: 72
+  - label: lint-http-rules/src/helpers/cache_control.rs
+    section: § 5.2
+    snippet: When a field name is repeated within a section, its combined field value consists of the list of corresponding field line values within that section, concatenated in order, with each field line value separated by a comma.
+    cited_by:
+    - file: lint-http-rules/src/helpers/cache_control.rs
+      line: 110
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 121
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 389
+    - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
+      line: 110
+    - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
+      line: 110
+    - file: lint-http-rules/src/rules/max_forwards_numeric.rs
+      line: 153
+    - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
+      line: 216
+    - file: lint-http-rules/src/rules/proxy_connection_discouraged.rs
+      line: 134
+    - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
+      line: 184
+    - file: lint-http-rules/src/rules/status_code_semantics.rs
+      line: 21
+    - file: lint-http-rules/src/rules/te_header_valid.rs
+      line: 41
+  - label: lint-http-rules/src/helpers/cache_control.rs (2)
+    section: § 5.6.1
+    snippet: '#element => [ element ] *( OWS "," OWS [ element ] )'
+    cited_by:
+    - file: lint-http-rules/src/helpers/cache_control.rs
+      line: 112
+    - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
+      line: 339
   - label: lint-http-rules/src/helpers/comment.rs
     section: § 5.6.4
     snippet: The backslash octet ("\") can be used as a single-octet quoting mechanism within quoted-string and comment constructs.


### PR DESCRIPTION
`parse_auth_params` stops rendering prose. Four rules of the authentication cluster call it and one of them reports; that one now answers three of its four verdicts with the ids the productions own — an empty member is the list's, an empty name and a name holding an octet no `tchar` admits are the token's — and the sentences are byte-identical to what the helper returned before.

The fourth stays unnamed and is refused rather than unwritten. RFC 9110 § 11.2 writes `auth-param = token BWS "=" BWS ( token / quoted-string )`, so a member with no `=` breaks *that* sentence, and `parameter_equals_missing` carries § 5.6.6's about a production printing no whitespace beside its delimiter. Third time that difference has decided an id in as many commits.

It also resolves what the previous commit could only record. `digest_auth_valid` has its own auth-param name check that cannot fire, because this reader measures the name two lines earlier; the two now hand back the same id by construction instead of by attention, and the test asserts a `user@name` reports `token_character_forbidden` from whichever of them answered.

`auth_param_member` lives beside `cache_directive_member` for the same reason that one does — the first thing either reader measures is the list member — and a test holds the two to one id apiece for the two mistakes they share.

Catalogue unchanged at 110, all floors unchanged. Coverage 97.77% (22,269/22,778), +0.00%.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
