### PR TITLE
A MIME token is two characters wider

### DIFF
--- a/docs/rules/content_transfer_encoding_valid.md
+++ b/docs/rules/content_transfer_encoding_valid.md
@@ -17,6 +17,7 @@ The value is reported as detail: a single `token` naming one of `7bit`, `8bit`, 
 ## Specifications
 
 - [RFC 9112 §B.5](https://www.rfc-editor.org/rfc/rfc9112.html#appendix-B.5): Why the field is reported at all: HTTP does not use Content-Transfer-Encoding, and gateways from MIME-compliant protocols must remove it
+- [RFC 2045 §5.1](https://www.rfc-editor.org/rfc/rfc2045.html#section-5.1): The `token` an `x-token` is made of, and the fifteen `tspecials` it excludes — `(` `)` `<` `>` `@` `,` `;` `:` `\` `"` `/` `[` `]` `?` `=`. This is not HTTP's `token`: MIME subtracts those delimiters from the visible US-ASCII and keeps `{` and `}`, which `tchar` does not admit
 - [RFC 2045 §6.1](https://www.rfc-editor.org/rfc/rfc2045.html#section-6.1): The MIME `mechanism` grammar the value is described against — five named encodings plus `ietf-token` / `x-token`, all case-insensitive
 - [RFC 2045 §6.3](https://www.rfc-editor.org/rfc/rfc2045.html#section-6.3): Private mechanisms must be spelled with an `X-` prefix, which is why an `x-` value is well-formed MIME rather than an unrecognized one
 

--- a/lint-http-rules/src/helpers/token.rs
+++ b/lint-http-rules/src/helpers/token.rs
@@ -56,6 +56,43 @@ pub fn token_run_end(s: &str) -> usize {
     s.find(|c| !is_tchar(c)).unwrap_or(s.len())
 }
 
+/// RFC 2045's `token`, over a single character — **not** `tchar`.
+///
+/// MIME subtracts a list of delimiters from the visible US-ASCII where HTTP
+/// enumerates the characters it keeps, and the two alphabets come out one pair
+/// apart. Counting them: the visible range holds 94 characters, MIME's fifteen
+/// `tspecials` leave 79, and `tchar` names 77 (52 ALPHA, 10 DIGIT, 15
+/// punctuation marks). The two the MIME alphabet has and this one does not are
+/// `{` and `}` — RFC 2068's `tspecials` list them and RFC 2045's does not — so
+/// those two octets derive from a MIME token and from no HTTP one. Nothing else
+/// separates the pair: SPACE and the CTLs are excluded by both, and both stop
+/// at US-ASCII.
+///
+/// That is why this is written as [`is_tchar`] plus two characters rather than
+/// as a second transcription of the class, which could drift from the first.
+/// The difference is reachable in one rule only — a `Content-Transfer-Encoding`
+/// value is § 5.1's `token`, and using [`is_tchar`] on it reports `{` and `}`
+/// as defects of a production that admits them. `multipart_boundary_syntax`
+/// reads the same difference and is right to ignore it, because a `bchars`
+/// admits neither character either way.
+pub fn is_mime_token_char(c: char) -> bool {
+    // The `tspecials` production is uncitable here for the same reason it is in
+    // `keep_alive_header_valid`: its `<">` alternative leaves the quotation
+    // marks in the line unpaired, and this cite grammar has no escape for that.
+    // The list is transcribed in the note on the rule's `SpecRef` instead.
+    // cite(RFC 2045 § 5.1): "token := 1*<any (US-ASCII) CHAR except SPACE, CTLs, or tspecials>"
+    is_tchar(c) || matches!(c, '{' | '}')
+}
+
+/// Return the first character of `s` that RFC 2045's `token` does not admit, or
+/// `None` when the whole string is one.
+///
+/// The MIME twin of [`find_invalid_token_char`]; [`is_mime_token_char`] carries
+/// the reading of how far the two alphabets differ.
+pub fn find_invalid_mime_token_char(s: &str) -> Option<char> {
+    s.chars().find(|&c| !is_mime_token_char(c))
+}
+
 /// Return the first ASCII lowercase alphabetic character in `s` if any.
 pub fn find_first_lowercase(s: &str) -> Option<char> {
     s.chars()
@@ -99,6 +136,39 @@ mod tests {
     fn test_token_run_end(#[case] s: &str, #[case] expected: usize) {
         assert_eq!(token_run_end(s), expected);
         assert!(s.is_char_boundary(token_run_end(s)));
+    }
+
+    /// The whole of the difference between the two alphabets, asserted from
+    /// both sides so neither reader can quietly widen: `{` and `}` are a MIME
+    /// token and are not an HTTP one, and every other octet answers the same
+    /// way to both.
+    #[rstest]
+    #[case('{')]
+    #[case('}')]
+    fn the_two_alphabets_differ_by_exactly_these(#[case] c: char) {
+        assert!(is_mime_token_char(c) && !is_tchar(c));
+        for other in (0u8..=0x7f)
+            .map(char::from)
+            .filter(|&o| o != '{' && o != '}')
+        {
+            assert_eq!(
+                is_mime_token_char(other),
+                is_tchar(other),
+                "{other:?} separates the two alphabets"
+            );
+        }
+    }
+
+    #[rstest]
+    #[case("x-my-new-encoding", None)]
+    // The two characters HTTP's reader reports and MIME's does not.
+    #[case("x-my{new}encoding", None)]
+    #[case("quoted-printable", None)]
+    // SPACE and the fifteen `tspecials` are refused by both.
+    #[case("7bit 8bit", Some(' '))]
+    #[case("base64;q=1", Some(';'))]
+    fn test_find_invalid_mime_token_char(#[case] s: &str, #[case] expected: Option<char>) {
+        assert_eq!(find_invalid_mime_token_char(s), expected);
     }
 
     #[rstest]

--- a/lint-http-rules/src/rules/content_transfer_encoding_valid.rs
+++ b/lint-http-rules/src/rules/content_transfer_encoding_valid.rs
@@ -16,6 +16,12 @@ const RFC_9112_B_5: crate::rules::SpecRef = crate::rules::SpecRef {
     url: "https://www.rfc-editor.org/rfc/rfc9112.html#appendix-B.5",
     note: "Why the field is reported at all: HTTP does not use Content-Transfer-Encoding, and gateways from MIME-compliant protocols must remove it",
 };
+const RFC_2045_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 2045",
+    section: Some("5.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc2045.html#section-5.1",
+    note: "The `token` an `x-token` is made of, and the fifteen `tspecials` it excludes — `(` `)` `<` `>` `@` `,` `;` `:` `\\` `\"` `/` `[` `]` `?` `=`. This is not HTTP's `token`: MIME subtracts those delimiters from the visible US-ASCII and keeps `{` and `}`, which `tchar` does not admit",
+};
 const RFC_2045_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 2045",
     section: Some("6.1"),
@@ -45,7 +51,7 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[RFC_9112_B_5, RFC_2045_6_1, RFC_2045_6_3]
+        &[RFC_9112_B_5, RFC_2045_5_1, RFC_2045_6_1, RFC_2045_6_3]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -117,7 +123,16 @@ impl Rule for ContentTransferEncodingValid {
                 let Some(tok) = parts.first().copied() else {
                     return Some("the value is empty".into());
                 };
-                if let Some(c) = crate::helpers::token::find_invalid_token_char(tok) {
+                // The `token` here is RFC 2045's and not HTTP's, which are two
+                // different character sets: `x-token` is "X-" followed by any
+                // token of *this* document, and § 5.1 builds one by subtracting
+                // fifteen `tspecials` from the visible US-ASCII rather than by
+                // listing what it keeps. `{` and `}` survive that subtraction
+                // and are not `tchar`, so reading the value with the HTTP
+                // helper reported `Content-Transfer-Encoding: x-my{new}encoding`
+                // for characters its own grammar admits.
+                // cite(RFC 2045 § 5.1): "x-token := <The two characters "X-" or "x-" followed, with no intervening white space, by any token>"
+                if let Some(c) = crate::helpers::token::find_invalid_mime_token_char(tok) {
                     return Some(format!("the value contains an invalid character: '{}'", c));
                 }
 
@@ -220,6 +235,40 @@ mod tests {
             assert!(violation.is_some());
         } else {
             assert!(violation.is_none());
+        }
+        Ok(())
+    }
+
+    /// The value is a MIME token, and MIME's alphabet is two characters wider
+    /// than HTTP's. A private mechanism spelled with braces derives from
+    /// § 5.1's `token` exactly, so the detail must say nothing about its
+    /// characters — while a SPACE, which neither document admits, still does.
+    /// The field is reported either way: presence is the finding.
+    #[rstest]
+    #[case("x-my{new}encoding", None)]
+    #[case("x-my new encoding", Some(' '))]
+    fn the_value_is_read_against_mimes_token(
+        #[case] value: &str,
+        #[case] bad: Option<char>,
+    ) -> anyhow::Result<()> {
+        let rule = ContentTransferEncodingValid;
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "content_transfer_encoding_valid",
+        ]);
+
+        let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
+        tx.response.as_mut().unwrap().headers =
+            crate::test_helpers::make_headers_from_pairs(&[("content-transfer-encoding", value)]);
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        );
+        let v = v.expect("presence is reported whatever the value");
+        match bad {
+            Some(c) => assert!(v.message.contains(&format!("invalid character: '{c}'"))),
+            None => assert!(!v.message.contains("invalid character")),
         }
         Ok(())
     }

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -848,23 +848,35 @@ sources:
   url: https://www.rfc-editor.org/rfc/rfc2045.html
   fragments:
   - label: content_transfer_encoding_valid
+    section: § 5.1
+    snippet: x-token := <The two characters "X-" or "x-" followed, with no intervening white space, by any token>
+    cited_by:
+    - file: lint-http-rules/src/rules/content_transfer_encoding_valid.rs
+      line: 134
+  - label: content_transfer_encoding_valid (2)
     section: § 6.1
     snippet: These values are not case sensitive
     cited_by:
     - file: lint-http-rules/src/rules/content_transfer_encoding_valid.rs
-      line: 131
-  - label: content_transfer_encoding_valid (2)
+      line: 146
+  - label: content_transfer_encoding_valid (3)
     section: § 6.1
     snippet: mechanism := "7bit" / "8bit" / "binary" / "quoted-printable" / "base64" / ietf-token / x-token
     cited_by:
     - file: lint-http-rules/src/rules/content_transfer_encoding_valid.rs
-      line: 103
-  - label: content_transfer_encoding_valid (3)
+      line: 109
+  - label: content_transfer_encoding_valid (4)
     section: § 6.3
     snippet: Implementors may, if necessary, define private Content-Transfer-Encoding values, but must use an x-token, which is a name prefixed by "X-", to indicate its non-standard status
     cited_by:
     - file: lint-http-rules/src/rules/content_transfer_encoding_valid.rs
-      line: 130
+      line: 145
+  - label: lint-http-rules/src/helpers/token.rs
+    section: § 5.1
+    snippet: token := 1*<any (US-ASCII) CHAR except SPACE, CTLs, or tspecials>
+    cited_by:
+    - file: lint-http-rules/src/helpers/token.rs
+      line: 83
 - label: RFC 2046
   url: https://www.rfc-editor.org/rfc/rfc2046.html
   fragments:
@@ -6497,7 +6509,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 333
     - file: lint-http-rules/src/rules/content_transfer_encoding_valid.rs
-      line: 116
+      line: 122
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 358
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
@@ -9745,13 +9757,13 @@ sources:
     snippet: HTTP does not use the Content-Transfer-Encoding field of MIME.
     cited_by:
     - file: lint-http-rules/src/rules/content_transfer_encoding_valid.rs
-      line: 146
+      line: 161
   - label: content_transfer_encoding_valid (2)
     section: § B.5
     snippet: Proxies and gateways from MIME-compliant protocols to HTTP need to remove any Content-Transfer-Encoding prior to delivering the response message to an HTTP client.
     cited_by:
     - file: lint-http-rules/src/rules/content_transfer_encoding_valid.rs
-      line: 147
+      line: 162
   - label: content_type_present
     section: § 6.3
     snippet: Any 2xx (Successful) response to a CONNECT request implies that the connection will become a tunnel immediately after the empty line that concludes the header fields.


### PR DESCRIPTION
`content_transfer_encoding_valid` measured its value with the HTTP `token` reader. The value is RFC 2045 § 5.1's `token`, which is built by subtracting fifteen `tspecials` from the visible US-ASCII rather than by listing what it keeps, and the two alphabets differ by exactly `{` and `}`: RFC 2068's `tspecials` list them and MIME's does not. So a conforming private mechanism — `x-my{new}encoding`, an `x-token` of "X-" followed by any token of that document — was reported for characters its own grammar admits.

`is_mime_token_char` is `is_tchar` plus those two characters, so the class cannot drift from the one it is defined against, and the counting that shows the pair is the whole difference is asserted over every octet below %x80. `multipart_boundary_syntax` reads the same difference and is right to ignore it: a `bchars` admits neither character either way.

The `tspecials` production itself stays uncitable — its `<">` alternative leaves the quotation marks unpaired — so the list is transcribed in the note on the rule's reference, as `keep_alive_header_valid` already does.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
