### PR TITLE
A form-data name borrows its parameter's defects

### DIFF
--- a/docs/rules/form_data_content_disposition_valid.md
+++ b/docs/rules/form_data_content_disposition_valid.md
@@ -20,6 +20,8 @@ An empty `name` value is reported as a defect. The specification requires the pa
 
 - [RFC 7578 §4.2](https://www.rfc-editor.org/rfc/rfc7578.html#section-4.2): Each multipart/form-data *part* MUST contain a `Content-Disposition` header with disposition-type `form-data` and MUST also contain a `name` parameter — a requirement on parts, which this rule approximates at the message level
 - [RFC 6266 §4.1](https://www.rfc-editor.org/rfc/rfc6266.html#section-4.1): The disposition types HTTP messages actually use (`inline`, `attachment`); a message-level `form-data` is outside this grammar, which is why the type gate skips everything else
+- [RFC 9110 §5.6.6](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.6): Parameters — `parameters = *( OWS ";" OWS [ parameter ] )`, the `name=value` pair inside it with neither half optional, and the bracketing that leaves a trailing `;` conforming
+- [RFC 9110 §5.6.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4): `quoted-string = DQUOTE *( qdtext / quoted-pair ) DQUOTE` — the two delimiters, the class between them, and the backslash escape
 
 ## Configuration
 

--- a/lint-http-rules/src/helpers/quoted_string.rs
+++ b/lint-http-rules/src/helpers/quoted_string.rs
@@ -274,16 +274,26 @@ pub fn check_quoted_string(val: &str) -> Result<(), QuotedStringDefect> {
 }
 
 /// Check whether a quoted-string's unescaped inner content, after trimming,
-/// is empty. Returns Ok(true) if the inner content is empty after trimming,
-/// Ok(false) if it contains any non-whitespace character, or Err(msg) if the
-/// input is not a well-formed quoted-string. This is useful for treating
+/// is empty. Returns `Ok(true)` if the inner content is empty after trimming,
+/// `Ok(false)` if it contains any non-whitespace character, or the
+/// [`QuotedStringDefect`] that stopped the walk. This is useful for treating
 /// quoted-empty values (e.g., `""` or `"   "`) as empty for presence checks.
-pub fn quoted_string_inner_trimmed_is_empty(val: &str) -> Result<bool, String> {
+///
+/// **The `Err` is the defect and not a sentence**, for the reason
+/// [`unescape_quoted_string`] gives: a caller reporting through the catalogue
+/// answers with the `quoted_string_*` def the variant maps to, and one that
+/// wants the prose asks [`QuotedStringDefect::message`] for it. This wrapper
+/// used to render on the way out, which put a rendered `String` between the
+/// only reporter and the four defects the production has.
+///
+/// The empty verdict itself belongs to no def: a `quoted-string` holding
+/// nothing derives from § 5.6.4 exactly as written, so what an empty one means
+/// is the *field's* question and each caller answers it. That is the same line
+/// `charset_registered` draws between `charset=`, a parameter value that does
+/// not exist, and `charset=""`, a well-formed pair of DQUOTEs around no name.
+pub fn quoted_string_inner_trimmed_is_empty(val: &str) -> Result<bool, QuotedStringDefect> {
     // Reuse `unescape_quoted_string` to perform unescaping and validation
-    match unescape_quoted_string(val) {
-        Ok(s) => Ok(s.trim().is_empty()),
-        Err(defect) => Err(defect.message(val)),
-    }
+    unescape_quoted_string(val).map(|s| s.trim().is_empty())
 }
 
 /// Unescape a well-formed HTTP `quoted-string` value and return its inner contents.
@@ -571,8 +581,12 @@ mod tests {
     fn quoted_string_inner_unescaped_quote_reports_error() {
         let s = "\"a\"b\""; // inner unescaped quote before terminating quote
         let r = quoted_string_inner_trimmed_is_empty(s);
-        assert!(r.is_err());
-        assert!(r.unwrap_err().contains("Unescaped quote"));
+        // The variant, not its prose: what the caller names the finding after
+        // is the defect, and the sentence is one method away from it.
+        assert_eq!(r.unwrap_err(), QuotedStringDefect::UnescapedQuote);
+        assert!(QuotedStringDefect::UnescapedQuote
+            .message(s)
+            .contains("Unescaped quote"));
     }
 
     /// Three of the four `quoted-string` defects are about an octet that would

--- a/lint-http-rules/src/rules/form_data_content_disposition_valid.rs
+++ b/lint-http-rules/src/rules/form_data_content_disposition_valid.rs
@@ -4,8 +4,44 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::parameter::{PARAMETER_VALUE_EMPTY, RFC_9110_5_6_6};
+use crate::violations::quoted_string::{
+    quoted_string_defect, QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
+    QUOTED_STRING_DELIMITER_MISSING, QUOTED_STRING_QUOTED_PAIR_MALFORMED,
+    QUOTED_STRING_QUOTE_ESCAPE_MISSING, RFC_9110_5_6_4,
+};
+use crate::violations::ViolationDef;
 
 pub struct FormDataContentDispositionValid;
+
+/// The defects this rule reports through the catalogue, all of them borrowed.
+///
+/// **The position decides the grammar, and the position is an HTTP header
+/// field.** RFC 7578 § 4.2 states its requirement about a *part* of a
+/// `multipart/form-data` body, where the field is MIME's and its parameters are
+/// RFC 2183's; what this rule can actually read is a message-level
+/// `Content-Disposition`, which RFC 6266 § 4.1 defines and which takes its
+/// `token`, its `quoted-string` and its `name=value` shape from HTTP. So the
+/// parameter defects are the shared ones — the same entries
+/// `content_disposition_parameter_valid` declares for the same field — and what
+/// stays this rule's own is what RFC 7578 says the `name` parameter *means*.
+/// The day the linter parses body parts, that reading is RFC 2183's and the
+/// question is worth asking again.
+///
+/// Two findings are deliberately absent. A `form-data` disposition missing its
+/// `name` altogether is § 4.2's MUST about the *set* of parameters, not a
+/// defect of any one of them. And a `name` whose quoted value holds nothing is
+/// a `quoted-string` deriving exactly as § 5.6.4 says, around a form field name
+/// of nothing: the production is satisfied and the requirement is not, which is
+/// why it does not answer with [`PARAMETER_VALUE_EMPTY`] the way the unquoted
+/// spelling does.
+static DECLARED: &[&ViolationDef] = &[
+    &PARAMETER_VALUE_EMPTY,
+    &QUOTED_STRING_DELIMITER_MISSING,
+    &QUOTED_STRING_QUOTED_PAIR_MALFORMED,
+    &QUOTED_STRING_QUOTE_ESCAPE_MISSING,
+    &QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
+];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -43,7 +79,11 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[RFC_7578_4_2, RFC_6266_4_1]
+        &[RFC_7578_4_2, RFC_6266_4_1, RFC_9110_5_6_6, RFC_9110_5_6_4]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -143,6 +183,14 @@ impl Rule for FormDataContentDispositionValid {
                         if raw.starts_with('"') {
                             // quoted-string: check if inner trimmed content is empty or invalid
                             match crate::helpers::quoted_string::quoted_string_inner_trimmed_is_empty(raw) {
+                                // The production is satisfied here and the
+                                // requirement is not: a pair of DQUOTEs around
+                                // nothing is the `quoted-string` § 5.6.4
+                                // writes, carrying a form field name of
+                                // nothing. That is § 4.2's sentence about what
+                                // the value *is*, so it stays this rule's, and
+                                // the unquoted spelling below — where there is
+                                // no value at all — is the parameter's.
                                 Ok(true) => {
                                     return Some(self.violation(ctx.severity, "Content-Disposition 'form-data' has empty 'name' parameter"
                                             .into()));
@@ -151,18 +199,28 @@ impl Rule for FormDataContentDispositionValid {
                                     name_found = true;
                                     break;
                                 }
-                                Err(e) => {
-                                    return Some(self.violation(ctx.severity, format!(
+                                // Whatever stopped the walk is the production's
+                                // defect and not this field's, and the sentence
+                                // it breaks is the same one whichever field
+                                // carried the value.
+                                Err(defect) => {
+                                    return Some(ctx.report_with(
+                                        quoted_string_defect(defect),
+                                        format!(
                                             "Content-Disposition 'form-data' has invalid quoted 'name' parameter: {}",
-                                            e
-                                        )))
+                                            defect.message(raw)
+                                        ),
+                                    ))
                                 }
                             }
                         } else {
                             // token/unquoted value
                             if raw.is_empty() {
-                                return Some(self.violation(ctx.severity, "Content-Disposition 'form-data' has empty 'name' parameter"
-                                            .into()));
+                                return Some(ctx.report_with(
+                                    &PARAMETER_VALUE_EMPTY,
+                                    "Content-Disposition 'form-data' has empty 'name' parameter"
+                                        .into(),
+                                ));
                             }
                             name_found = true;
                             break;
@@ -237,6 +295,72 @@ static REGISTRATION: &dyn crate::rules::Rule = &FormDataContentDispositionValid;
 mod tests {
     use super::*;
     use rstest::rstest;
+
+    /// The `name` parameter is read against the same productions any other
+    /// parameter of this field is, and the last two rows are the pair that
+    /// looks like one finding and is two: a value that does not exist is
+    /// § 5.6.6's, and a pair of DQUOTEs around nothing is a `quoted-string`
+    /// that derives — leaving a form field name of nothing, which is § 4.2's
+    /// sentence and stays this rule's.
+    ///
+    /// The first two rows are asserted against `content_disposition_parameter_
+    /// valid` reading the same shapes at the same field, out of a rule that
+    /// walks the parameters differently and shares no code with this one.
+    #[rstest]
+    #[case("form-data; name=\"unterminated", "quoted_string_delimiter_missing")]
+    // The fourth defect of the production, a control octet inside the quotes,
+    // is declared and unreachable from here: a `HeaderValue` refuses the octet
+    // outright, so the transaction cannot be built to carry one.
+    #[case("form-data; name=\"a\"b\"", "quoted_string_quote_escape_missing")]
+    #[case("form-data; name=", "parameter_value_empty")]
+    #[case("form-data; name=\"\"", "")]
+    #[case("form-data; filename=example.txt", "")]
+    fn the_name_parameter_reports_the_productions_it_borrows(
+        #[case] value: &str,
+        #[case] id: &str,
+    ) {
+        let mut tx = crate::test_helpers::make_test_transaction();
+        tx.request.headers =
+            crate::test_helpers::make_headers_from_pairs(&[("content-disposition", value)]);
+        let found = crate::test_helpers::run_rule(
+            &FormDataContentDispositionValid,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_severity(
+                "form_data_content_disposition_valid",
+                "warn",
+            ),
+        )
+        .expect("a finding");
+        // An unconverted site carries no defect id at all, which is what the
+        // two empty rows assert.
+        assert_eq!(found.violation, id, "{value}");
+    }
+
+    /// The same two values at the same field, judged by the rule that reads an
+    /// `attachment` disposition: two rules, one id apiece, no shared code.
+    #[rstest]
+    #[case(
+        "attachment; filename=\"unterminated",
+        "quoted_string_delimiter_missing"
+    )]
+    #[case("attachment; filename=", "parameter_value_empty")]
+    fn the_sibling_rule_answers_with_the_same_ids(#[case] value: &str, #[case] id: &str) {
+        let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
+        tx.response.as_mut().expect("a response").headers =
+            crate::test_helpers::make_headers_from_pairs(&[("content-disposition", value)]);
+        let found = crate::test_helpers::run_rule(
+            &crate::rules::content_disposition_parameter_valid::ContentDispositionParameterValid,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_severity(
+                "content_disposition_parameter_valid",
+                "warn",
+            ),
+        )
+        .expect("a finding");
+        assert_eq!(found.violation, id, "{value}");
+    }
 
     #[rstest]
     #[case(Some("form-data; name=\"user\""), false)]

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -3754,13 +3754,13 @@ sources:
     snippet: The Content-Disposition header field MUST also contain an additional parameter of "name"; the value of the "name" parameter is the original field name from the form
     cited_by:
     - file: lint-http-rules/src/rules/form_data_content_disposition_valid.rs
-      line: 117
+      line: 157
   - label: form_data_content_disposition_valid (2)
     section: § 4.2
     snippet: where the disposition type is "form-data".
     cited_by:
     - file: lint-http-rules/src/rules/form_data_content_disposition_valid.rs
-      line: 108
+      line: 148
 - label: RFC 7616
   url: https://www.rfc-editor.org/rfc/rfc7616.html
   fragments:


### PR DESCRIPTION
`form_data_content_disposition_valid` reported a broken quoted `name` and an empty unquoted one in its own words. Both are defects of productions the field borrows: the position it reads is an HTTP header field, which RFC 6266 § 4.1 defines by taking `token`, `quoted-string` and the `name=value` shape from HTTP without restating them, so the ids are the ones `content_disposition_parameter_valid` already declares for the same field. What stays this rule's own is what RFC 7578 § 4.2 says the parameter *means* — a `name` missing from the set, and a well-formed pair of DQUOTEs around a form field name of nothing.

`quoted_string_inner_trimmed_is_empty` hands back the defect instead of a rendered sentence, which is what makes the four ids reachable from its one reporter. Its other caller discards the error and is unchanged.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
