### PR TITLE
An authority is one production, read twice

### DIFF
--- a/docs/rules/host_header.md
+++ b/docs/rules/host_header.md
@@ -26,8 +26,9 @@ Three things this rule deliberately does **not** report:
 - [RFC 9110 §7.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.2): Host and :authority — the grammar, the MUST, and the pseudo-header the MUST excepts. The SHOULD to send Host first is not checked: the capture does not preserve field order.
 - [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order — a sender MUST NOT repeat a field name unless the field is a comma-separated list, and Host is not one
 - [RFC 9112 §3.2](https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2): Request Target — Host is required in all HTTP/1.1 requests, its value excludes userinfo, and it is empty when the target URI has no authority
-- [RFC 3986 §3.2.2](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.2): Host — an IP literal is distinguished by its square brackets; every other host is a registered name
-- [RFC 3986 §3.2.3](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.3): Port — `port = *DIGIT` bounds nothing, so a port outside the TCP range is not a syntax finding
+- [RFC 3986 §3.2.2](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.2): Host — `host = IP-literal / IPv4address / reg-name`, where the square brackets of the IP literal are the only ones the URI syntax admits anywhere
+- [RFC 3986 §3.2.3](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.3): Port — `port = *DIGIT`, which has no lower bound, no upper bound, and admits the empty string
+- [RFC 3986 §2.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1): Percent-Encoding — `pct-encoded = "%" HEXDIG HEXDIG`, the two digits every `%` still owes
 
 ## Configuration
 

--- a/docs/rules/http2_pseudo_headers_valid.md
+++ b/docs/rules/http2_pseudo_headers_valid.md
@@ -39,6 +39,9 @@ HTTP/2 carries a request's control data as pseudo-header fields — `:method`, `
 - [RFC 9112 §3.2.3](https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2.3): authority-form — the production RFC 9113 §8.5 points at for what `:authority` carries on a CONNECT, and where both halves turn out to be `*`-quantified
 - [RFC 8441 §4](https://www.rfc-editor.org/rfc/rfc8441.html#section-4): The Extended CONNECT Method — `:protocol` is what distinguishes it, and on such a request `:scheme` and `:path` MUST be included. A capture records no `:protocol`, which is why an absolute-form CONNECT target is accepted.
 - [RFC 6335 §6](https://www.rfc-editor.org/rfc/rfc6335.html#section-6): Port Number Ranges — the 16-bit namespace that bounds a CONNECT port above, and the reserved edge values that are why `0` is not reported
+- [RFC 3986 §3.2.2](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.2): Host — `host = IP-literal / IPv4address / reg-name`, where the square brackets of the IP literal are the only ones the URI syntax admits anywhere
+- [RFC 3986 §3.2.3](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.3): Port — `port = *DIGIT`, which has no lower bound, no upper bound, and admits the empty string
+- [RFC 3986 §2.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1): Percent-Encoding — `pct-encoded = "%" HEXDIG HEXDIG`, the two digits every `%` still owes
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/host_header.rs
+++ b/lint-http-rules/src/rules/host_header.rs
@@ -4,8 +4,37 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::uri::{
+    host_and_port, PERCENT_ENCODING_DIGITS_MISSING, PERCENT_ENCODING_MALFORMED, RFC_3986_2_1,
+    RFC_3986_3_2_2, RFC_3986_3_2_3, URI_HOST_BRACKET_FORBIDDEN, URI_HOST_CHARACTER_FORBIDDEN,
+    URI_HOST_CLOSING_BRACKET_MISSING, URI_HOST_IP_LITERAL_MALFORMED, URI_PORT_CHARACTER_FORBIDDEN,
+};
+use crate::violations::ViolationDef;
 
 pub struct HostHeader;
+
+/// The defects of `Host = uri-host [ ":" port ]`, every one of them the
+/// authority's rather than the field's.
+///
+/// § 7.2 writes the field as two productions RFC 3986 defines and adds nothing
+/// to either, so what an operator tunes here is a bracket, a character or a
+/// port — the same entries a `:authority`, a `Forwarded` `host` and a `Via`
+/// `received-by` draw, out of the one reader all of them call.
+///
+/// What stays this rule's own is everything § 7.2 says *about* the field and
+/// not about its grammar: that a request must carry one, that it must not be
+/// repeated, that its value excludes the userinfo, and that an IPv6 literal
+/// written without its brackets is a value the reader would otherwise have to
+/// guess at.
+static DECLARED: &[&ViolationDef] = &[
+    &URI_HOST_CLOSING_BRACKET_MISSING,
+    &URI_HOST_IP_LITERAL_MALFORMED,
+    &URI_HOST_BRACKET_FORBIDDEN,
+    &URI_HOST_CHARACTER_FORBIDDEN,
+    &URI_PORT_CHARACTER_FORBIDDEN,
+    &PERCENT_ENCODING_DIGITS_MISSING,
+    &PERCENT_ENCODING_MALFORMED,
+];
 
 /// Whether this request sent its authority as control data rather than as a
 /// `Host` field — the state §7.2's MUST excepts.
@@ -52,19 +81,6 @@ const RFC_9112_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
     url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2",
     note: "Request Target — Host is required in all HTTP/1.1 requests, its value excludes userinfo, and it is empty when the target URI has no authority",
 };
-const RFC_3986_3_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 3986",
-    section: Some("3.2.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.2",
-    note: "Host — an IP literal is distinguished by its square brackets; every other host is a registered name",
-};
-const RFC_3986_3_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 3986",
-    section: Some("3.2.3"),
-    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.3",
-    note: "Port — `port = *DIGIT` bounds nothing, so a port outside the TCP range is not a syntax finding",
-};
-
 impl RuleMeta for HostHeader {
     fn id(&self) -> &'static str {
         "host_header"
@@ -87,7 +103,12 @@ severity = "warn"
             RFC_9112_3_2,
             RFC_3986_3_2_2,
             RFC_3986_3_2_3,
+            RFC_3986_2_1,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -249,10 +270,14 @@ impl Rule for HostHeader {
             // is the `Host` production; the port it admits is `*DIGIT`, which is
             // the whole of what RFC 3986 §3.2.3 says a port looks like.
             // cite(RFC 9110 § 7.2, label: Host grammar): "Host = uri-host [ ":" port ]"
+            //
+            // The sentence that stays here is the one saying the field carries
+            // those two productions; what each of them *is* moved onto the
+            // defects, which is why the finding is named after the authority
+            // and not after the field that carried it.
             if let Err(defect) = crate::helpers::uri::validate_host_and_optional_port(s) {
-                return Some(self.cited(
-                    &RFC_9110_7_2,
-                    ctx.severity,
+                return Some(ctx.report_with(
+                    host_and_port(defect),
                     format!(
                         "Host field value '{}' is not a host and port: {}",
                         s,

--- a/lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
+++ b/lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
@@ -4,8 +4,66 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::uri::{
+    host_and_port, PERCENT_ENCODING_DIGITS_MISSING, PERCENT_ENCODING_MALFORMED, RFC_3986_2_1,
+    RFC_3986_3_2_2, RFC_3986_3_2_3, URI_HOST_BRACKET_FORBIDDEN, URI_HOST_CHARACTER_FORBIDDEN,
+    URI_HOST_CLOSING_BRACKET_MISSING, URI_HOST_IP_LITERAL_MALFORMED, URI_PORT_CHARACTER_FORBIDDEN,
+};
+use crate::violations::ViolationDef;
 
 pub struct Http2PseudoHeadersValid;
+
+/// The authority's defects, which is all this rule borrows.
+///
+/// `:authority` carries what the authority-form of a request-target carries —
+/// § 8.5 says so by pointing at that production rather than by writing one —
+/// so a bracket, a character or a port number is the same defect here as in a
+/// `Host` field, and the two rules answer with one id apiece for the same
+/// value.
+///
+/// Everything else this rule reports is about *which* pseudo-headers a message
+/// carries and where: a name that is not one of the four, a pseudo-header after
+/// a regular field, one repeated, one sent on a response, a CONNECT with no
+/// port. None of that is a defect of a production, and the two documents that
+/// require it write no grammar this catalogue could name it after.
+static DECLARED: &[&ViolationDef] = &[
+    &URI_HOST_CLOSING_BRACKET_MISSING,
+    &URI_HOST_IP_LITERAL_MALFORMED,
+    &URI_HOST_BRACKET_FORBIDDEN,
+    &URI_HOST_CHARACTER_FORBIDDEN,
+    &URI_PORT_CHARACTER_FORBIDDEN,
+    &PERCENT_ENCODING_DIGITS_MISSING,
+    &PERCENT_ENCODING_MALFORMED,
+];
+
+/// One finding from the CONNECT reading, and the defect it reports as where
+/// the catalogue names that defect.
+///
+/// The shape `expect_header_valid` settled: a judge that is half converted says
+/// so in its type. Here the named half is the authority's grammar and the
+/// unnamed half is what § 9.3.6 says a CONNECT's authority must *hold* — an
+/// authority at all, no userinfo, a port that is present and not empty — which
+/// is prose about this method's target rather than a production's defect.
+struct Defect {
+    def: Option<&'static ViolationDef>,
+    message: String,
+}
+
+impl Defect {
+    /// A defect the catalogue names.
+    fn named(def: &'static ViolationDef, message: String) -> Self {
+        Self {
+            def: Some(def),
+            message,
+        }
+    }
+
+    /// A defect no subject has claimed yet, reported at the rule's severity the
+    /// way every finding here was before the catalogue existed.
+    fn unnamed(message: String) -> Self {
+        Self { def: None, message }
+    }
+}
 
 /// What a basic CONNECT's `:authority` has to be, and what is wrong with this
 /// one.
@@ -22,15 +80,15 @@ pub struct Http2PseudoHeadersValid;
 // cite(RFC 9110 § 9.3.6): "CONNECT uses a special form of request target, unique to this method, consisting of only the host and port number of the tunnel destination, separated by a colon."
 // cite(RFC 9110 § 9.3.6): "There is no default port; a client MUST send the port number even if the CONNECT request is based on a URI reference that contains an authority component with an elided port (Section 4.1)."
 // cite(RFC 9110 § 9.3.6): "A server MUST reject a CONNECT request that targets an empty or invalid port number, typically by responding with a 400 (Bad Request) status code."
-fn connect_authority_finding(authority: &str) -> Option<String> {
+fn connect_authority_finding(authority: &str) -> Option<Defect> {
     let shown = crate::helpers::shown::shown_in_finding(authority);
 
     if authority.is_empty() {
-        return Some(
+        return Some(Defect::unnamed(
             "CONNECT request carries no ':authority', and there is nothing else in the message \
              naming the host and port to open the tunnel to"
                 .into(),
-        );
+        ));
     }
 
     // Asked before the grammar so the answer names what is wrong: a userinfo
@@ -46,17 +104,18 @@ fn connect_authority_finding(authority: &str) -> Option<String> {
         let shown = crate::helpers::uri::userinfo_password_withheld(authority)
             .map(|redacted| crate::helpers::shown::shown_in_finding(&redacted))
             .unwrap_or(shown);
-        return Some(format!(
+        return Some(Defect::unnamed(format!(
             "CONNECT ':authority' '{shown}' carries a userinfo subcomponent and its '@' \
              delimiter: the field is only the host and port number of the tunnel destination"
-        ));
+        )));
     }
 
     let (host, port) = crate::helpers::uri::split_host_and_port(authority);
     if let Err(defect) = crate::helpers::uri::validate_host_and_optional_port(authority) {
         let message = defect.message();
-        return Some(format!(
-            "CONNECT ':authority' '{shown}' is not a host and port: {message}"
+        return Some(Defect::named(
+            host_and_port(defect),
+            format!("CONNECT ':authority' '{shown}' is not a host and port: {message}"),
         ));
     }
 
@@ -65,20 +124,22 @@ fn connect_authority_finding(authority: &str) -> Option<String> {
     // is required outright; the host is what "the host and port number of the
     // tunnel destination" leaves nothing of if it is absent.
     match port {
-        None => Some(format!(
+        None => Some(Defect::unnamed(format!(
             "CONNECT ':authority' '{shown}' names no port, and a CONNECT has no default port: a \
              client sends the port number even when the URI reference it started from elided one"
-        )),
-        Some("") => Some(format!(
+        ))),
+        Some("") => Some(Defect::unnamed(format!(
             "CONNECT ':authority' '{shown}' ends at the colon with no port number, which a server \
              is required to reject"
-        )),
-        Some(port) if host.is_empty() => Some(format!(
+        ))),
+        Some(port) if host.is_empty() => Some(Defect::unnamed(format!(
             "CONNECT ':authority' '{shown}' names the port '{port}' and no host, so it names \
              nothing to open a tunnel to"
-        )),
+        ))),
         Some(port) => connect_port_range_finding(port).map(|msg| {
-            format!("CONNECT ':authority' '{shown}' targets an invalid port number: {msg}")
+            Defect::unnamed(format!(
+                "CONNECT ':authority' '{shown}' targets an invalid port number: {msg}"
+            ))
         }),
     }
 }
@@ -208,7 +269,14 @@ severity = "error"
             RFC_9112_3_2_3,
             RFC_8441_4,
             RFC_6335_6,
+            RFC_3986_3_2_2,
+            RFC_3986_3_2_3,
+            RFC_3986_2_1,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -364,8 +432,11 @@ impl Rule for Http2PseudoHeadersValid {
                                 .into()));
                     }
                 } else if absolute_form.is_none() {
-                    if let Some(msg) = connect_authority_finding(target) {
-                        return Some(self.violation(ctx.severity, msg));
+                    if let Some(defect) = connect_authority_finding(target) {
+                        return Some(match defect.def {
+                            Some(def) => ctx.report_with(def, defect.message),
+                            None => self.violation(ctx.severity, defect.message),
+                        });
                     }
                 }
             } else {
@@ -465,8 +536,8 @@ impl Rule for Http2PseudoHeadersValid {
                 if let Err(defect) =
                     crate::helpers::uri::validate_host_and_optional_port(&authority)
                 {
-                    return Some(self.violation(
-                        ctx.severity,
+                    return Some(ctx.report_with(
+                        host_and_port(defect),
                         format!(
                             "Authority '{}' is not a host and port: {}",
                             crate::helpers::shown::shown_in_finding(&authority),
@@ -526,6 +597,45 @@ mod tests {
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         )
         .map(|v| v.message)
+    }
+
+    /// The authority is one production wherever it is read, and this is the
+    /// assertion: a CONNECT `:authority` and a `Host` field value draw the same
+    /// id for the same value, out of two rules that share no code and read two
+    /// different parts of the message. What each still says in its own words is
+    /// which of the two carried it.
+    #[rstest]
+    #[case("[::1:443", "uri_host_closing_bracket_missing")]
+    #[case("[not-an-address]:443", "uri_host_ip_literal_malformed")]
+    #[case("exa mple.com:443", "uri_host_character_forbidden")]
+    #[case("example.com:44a", "uri_port_character_forbidden")]
+    #[case("exa%zzmple.com:443", "percent_encoding_malformed")]
+    fn an_authority_and_a_host_field_report_one_id(#[case] value: &str, #[case] id: &str) {
+        let mut tx = h2();
+        tx.request.method = "CONNECT".into();
+        tx.request.uri = value.into();
+        let authority = crate::test_helpers::run_rule(
+            &Http2PseudoHeadersValid,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "http2_pseudo_headers_valid",
+            ]),
+        )
+        .expect("a finding");
+        assert_eq!(authority.violation, id, "{value}");
+        assert!(authority.message.contains("':authority'"), "{value}");
+
+        let tx = crate::test_helpers::make_test_transaction_with_headers(&[("host", value)]);
+        let host = crate::test_helpers::run_rule(
+            &super::super::host_header::HostHeader,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["host_header"]),
+        )
+        .expect("a finding");
+        assert_eq!(host.violation, id, "{value}");
+        assert!(host.message.contains("Host field value"), "{value}");
     }
 
     fn judge_request(method: &str, target: &str) -> Option<String> {

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1293,7 +1293,7 @@ severity = "warn"
         /// The rest are the per-rule reading that has not happened yet — the
         /// denominator is computed below, because merges and conversions both
         /// move it.
-        const FLOOR: usize = 153;
+        const FLOOR: usize = 152;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1166,7 +1166,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1174
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 236
+      line: 257
   - label: lint-http-rules/src/helpers/ipv6.rs (2)
     section: § 3.2.2
     snippet: This is the only place where square bracket characters are allowed in the URI syntax.
@@ -2399,7 +2399,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 336
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 102
+      line: 163
   - label: lint-http-rules/src/helpers/uri.rs (2)
     section: § 6
     snippet: TCP, UDP, UDP-Lite, SCTP, and DCCP use 16-bit namespaces for their port number registries.
@@ -2409,7 +2409,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 335
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 101
+      line: 162
 - label: RFC 6454
   url: https://www.rfc-editor.org/rfc/rfc6454.html
   fragments:
@@ -4389,13 +4389,13 @@ sources:
     snippet: A new pseudo-header field :protocol MAY be included on request HEADERS indicating the desired protocol to be spoken on the tunnel created by CONNECT.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 345
+      line: 413
   - label: http2_pseudo_headers_valid (2)
     section: § 4
     snippet: On requests that contain the :protocol pseudo-header field, the :scheme and :path pseudo-header fields of the target URI (see Section 5) MUST also be included.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 346
+      line: 414
   - label: lint-http-rules/src/helpers/websocket.rs
     section: § 5
     snippet: Implementations using this extended CONNECT to bootstrap WebSockets do not do the processing of the Sec-WebSocket-Key and Sec-WebSocket-Accept header fields of [RFC6455] as that functionality has been superseded by the :protocol pseudo-header field.
@@ -4985,7 +4985,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 355
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 335
+      line: 403
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 192
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
@@ -5251,7 +5251,7 @@ sources:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 126
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 312
+      line: 380
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
       line: 319
   - label: alt_svc_header_syntax
@@ -6125,13 +6125,13 @@ sources:
     snippet: A user agent MUST generate a Host header field in a request unless it sends that information as an ":authority" pseudo-header field.
     cited_by:
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 162
+      line: 183
   - label: http2_pseudo_headers_valid
     section: § 7.1
     snippet: For OPTIONS (Section 9.3.7), the request target can be a single asterisk ("*").
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 376
+      line: 447
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
       line: 231
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
@@ -6141,7 +6141,7 @@ sources:
     snippet: These forms MUST NOT be used with other methods.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 377
+      line: 448
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
       line: 232
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
@@ -6151,19 +6151,19 @@ sources:
     snippet: A server MUST reject a CONNECT request that targets an empty or invalid port number, typically by responding with a 400 (Bad Request) status code.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 24
+      line: 82
   - label: http2_pseudo_headers_valid (4)
     section: § 9.3.6
     snippet: CONNECT uses a special form of request target, unique to this method, consisting of only the host and port number of the tunnel destination, separated by a colon.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 22
+      line: 80
   - label: http2_pseudo_headers_valid (5)
     section: § 9.3.6
     snippet: There is no default port; a client MUST send the port number even if the CONNECT request is based on a URI reference that contains an authority component with an elided port (Section 4.1).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 23
+      line: 81
   - label: if_match_etag_syntax
     section: § 13.1.1
     snippet: 'If-Match = "*" / #entity-tag'
@@ -6855,7 +6855,7 @@ sources:
     - file: lint-http-rules/src/helpers/product.rs
       line: 69
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 208
+      line: 229
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
       line: 461
     - file: lint-http-rules/src/rules/link_header_valid.rs
@@ -6979,7 +6979,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 369
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 178
+      line: 199
     - file: lint-http-rules/src/rules/retry_after_date_or_delay.rs
       line: 82
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
@@ -7083,7 +7083,7 @@ sources:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 191
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 207
+      line: 228
     - file: lint-http-rules/src/rules/if_modified_since_date_syntax.rs
       line: 117
     - file: lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
@@ -7507,7 +7507,7 @@ sources:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 129
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 251
+      line: 272
     - file: lint-http-rules/src/rules/x_forwarded_consistent.rs
       line: 177
   - label: lint-http-rules/src/helpers/uri.rs (2)
@@ -7519,9 +7519,9 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 316
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 23
+      line: 52
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 359
+      line: 427
   - label: lint-http-rules/src/helpers/uri.rs (3)
     section: § 7.2
     snippet: The "Host" header field in a request provides the host and port information from the target URI, enabling the origin server to distinguish among resources while servicing requests for multiple host names.
@@ -9817,25 +9817,25 @@ sources:
     snippet: A client MUST send a Host header field (Section 7.2 of [HTTP]) in all HTTP/1.1 request messages.
     cited_by:
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 163
+      line: 184
   - label: host_header (2)
     section: § 3.2
     snippet: If the authority component is missing or undefined for the target URI, then a client MUST send a Host header field with an empty field value.
     cited_by:
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 214
+      line: 235
   - label: host_header (3)
     section: § 3.2
     snippet: If the target URI includes an authority component, then a client MUST send a field value for Host that is identical to that authority component, excluding any userinfo subcomponent and its "@" delimiter (Section 4.2 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 223
+      line: 244
   - label: authority-form
     section: § 3.2.3
     snippet: authority-form = uri-host ":" port
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 21
+      line: 79
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 64
   - label: http_version_syntax
@@ -9921,7 +9921,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 422
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 179
+      line: 200
   - label: request-target forms
     section: § 3.2
     snippet: request-target = origin-form / absolute-form / authority-form / asterisk-form
@@ -10284,7 +10284,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 354
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 375
+      line: 446
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 235
   - label: host_and_authority_consistent (2)
@@ -10314,7 +10314,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 337
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 407
+      line: 478
   - label: host_and_authority_consistent (6)
     section: § 8.3.1
     snippet: The values of fields need to be normalized to compare them (see Section 6.2 of [RFC3986]).
@@ -10326,37 +10326,37 @@ sources:
     snippet: A field value MUST NOT start or end with an ASCII whitespace character (ASCII SP or HTAB, 0x20 or 0x09).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 325
+      line: 393
   - label: http2_pseudo_headers_valid (2)
     section: § 8.3
     snippet: Endpoints MUST treat a request or response that contains undefined or invalid pseudo-header fields as malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 313
+      line: 381
   - label: http2_pseudo_headers_valid (3)
     section: § 8.3.1
     snippet: '":authority" MUST NOT include the deprecated userinfo subcomponent for "http" or "https" schemed URIs.'
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 447
+      line: 518
   - label: http2_pseudo_headers_valid (4)
     section: § 8.3.1
     snippet: '":scheme" is not restricted to "http" and "https" schemed URIs.'
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 412
+      line: 483
   - label: http2_pseudo_headers_valid (5)
     section: § 8.3.1
     snippet: All HTTP/2 requests MUST include exactly one valid value for the ":method", ":scheme", and ":path" pseudo-header fields, unless they are CONNECT requests (Section 8.5).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 387
+      line: 458
   - label: http2_pseudo_headers_valid (6)
     section: § 8.3.1
     snippet: The ":method" pseudo-header field includes the HTTP method (Section 9 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 308
+      line: 376
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
       line: 320
   - label: http2_pseudo_headers_valid (7)
@@ -10364,51 +10364,51 @@ sources:
     snippet: The ":scheme" pseudo-header field includes the scheme portion of the request target.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 406
+      line: 477
   - label: http2_pseudo_headers_valid (8)
     section: § 8.3.1
     snippet: This pseudo-header field MUST NOT be empty for "http" or "https" URIs; "http" or "https" URIs that do not contain a path component MUST include a value of '/'.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 386
+      line: 457
   - label: http2_pseudo_headers_valid (9)
     section: § 8.3.2
     snippet: For HTTP/2 responses, a single ":status" pseudo-header field is defined that carries the HTTP status code field (see Section 15 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 495
+      line: 566
   - label: http2_pseudo_headers_valid (10)
     section: § 8.3.2
     snippet: This pseudo-header field MUST be included in all responses, including interim responses; otherwise, the response is malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 496
+      line: 567
   - label: http2_pseudo_headers_valid (11)
     section: § 8.5
     snippet: A CONNECT request that does not conform to these restrictions is malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 351
+      line: 419
   - label: http2_pseudo_headers_valid (12)
     section: § 8.5
     snippet: A proxy that supports CONNECT establishes a TCP connection [TCP] to the host and port identified in the ":authority" pseudo-header field.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 100
+      line: 161
   - label: http2_pseudo_headers_valid (13)
     section: § 8.5
     snippet: The ":authority" pseudo-header field contains the host and port to connect to (equivalent to the authority-form of the request-target of CONNECT requests; see Section 3.2.3 of [HTTP/1.1]).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 20
+      line: 78
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 350
+      line: 418
   - label: http2_pseudo_headers_valid (14)
     section: § 8.5
     snippet: The ":method" pseudo-header field is set to CONNECT.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 336
+      line: 404
   - label: lint-http-core/src/http_version.rs
     section: § 8.3.1
     snippet: All HTTP/2 requests implicitly have a protocol version of "2.0"


### PR DESCRIPTION
`host_header` and `http2_pseudo_headers_valid` each worded their own finding for a value that is not a host and a port. `Host = uri-host [ ":" port ]` and `:authority` carries the authority-form of a CONNECT request-target, so both are RFC 3986 § 3.2.2 and § 3.2.3 read through the one helper, and the two rules now answer with the same id for the same value out of code that shares nothing. The test asserts both halves, including which field each still names in its own words.

The CONNECT judge carries an optional def beside its message, because the rest of what it says is prose about the method's target — an authority at all, no userinfo, a port present and not empty — and no production has those defects. `request_target_form_valid` calls the same reader as a gate and has nothing to name, which closes its readers.

Two rule-local references for sections the defects already cite are deleted, and the citation floor moves down by the one converted `cited` site.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
