### PR TITLE
A percent triplet is the same defect everywhere

### DIFF
--- a/docs/rules/content_location_and_uri_consistent.md
+++ b/docs/rules/content_location_and_uri_consistent.md
@@ -28,6 +28,7 @@ For 2xx responses the rule additionally compares the value against the request t
 - [RFC 3986 §6.2.2.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-6.2.2.1): Case Normalization: scheme and host fold case, the remaining components do not, and the hexadecimal of a percent-triplet that stays encoded is folded to upper case
 - [RFC 3986 §6.2.2.2](https://www.rfc-editor.org/rfc/rfc3986.html#section-6.2.2.2): Percent-Encoding Normalization: a triplet standing for an unreserved character is decoded on both sides before comparison, so `/a~b` and `/a%7Eb` are one path. Nothing else is decoded — a delimiter would move the component boundaries (§2.4)
 - [RFC 3986 §6.2.2.3](https://www.rfc-editor.org/rfc/rfc3986.html#section-6.2.2.3): Path Segment Normalization: dot-segments are removed from both sides before comparison, after the decoding above — §2.3 names the period among the octets a normalizer decodes, so `%2E%2E` is a dot segment. §6.2.3's scheme-based normalization is NOT applied, so a default port written out and one left off read as different authorities
+- [RFC 3986 §2.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1): Percent-Encoding — `pct-encoded = "%" HEXDIG HEXDIG`, the two digits every `%` still owes
 
 ## Configuration
 

--- a/docs/rules/location_header_uri_valid.md
+++ b/docs/rules/location_header_uri_valid.md
@@ -30,6 +30,7 @@ A `%` must open a well-formed `pct-encoded` triplet, and a value that carries a 
 - [RFC 9110 §5.5](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5): Field Values: singleton fields, the care a comma needs in a field carrying a URI-reference, and the MUST to exclude leading and trailing whitespace before evaluating a field value
 - [RFC 3986 §2](https://www.rfc-editor.org/rfc/rfc3986.html#section-2): Characters: the limited set a URI is composed from — `unreserved`, `gen-delims`, `sub-delims` — and the `pct-encoded` triplet every other octet must be written as
 - [RFC 3986 §4.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-4.1): `URI-reference = URI / relative-ref`. §4.4 is why an empty value is one of them, and so why the empty-value finding here is advisory
+- [RFC 3986 §2.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1): Percent-Encoding — `pct-encoded = "%" HEXDIG HEXDIG`, the two digits every `%` still owes
 
 ## Configuration
 

--- a/docs/rules/referer_uri_valid.md
+++ b/docs/rules/referer_uri_valid.md
@@ -44,7 +44,7 @@ Reads the `Referer` request header field against the production RFC 9110 §10.1.
 - [RFC 3986 §4.2](https://www.rfc-editor.org/rfc/rfc3986.html#section-4.2): Relative Reference — `relative-part`, and why a first path segment holding a colon is not one
 - [RFC 3986 §4.3](https://www.rfc-editor.org/rfc/rfc3986.html#section-4.3): Absolute URI — the form without a fragment identifier
 - [RFC 3986 §4.4](https://www.rfc-editor.org/rfc/rfc3986.html#section-4.4): Same-Document Reference — what an empty value is
-- [RFC 3986 §2.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1): Percent-Encoding — the triplet the `%` obliges
+- [RFC 3986 §2.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1): Percent-Encoding — `pct-encoded = "%" HEXDIG HEXDIG`, the two digits every `%` still owes
 - [RFC 3986 §3.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.1): Scheme — `scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`, the name before the first colon
 
 ## Configuration

--- a/docs/rules/request_uri_percent_encoding_valid.md
+++ b/docs/rules/request_uri_percent_encoding_valid.md
@@ -24,7 +24,7 @@ Reads the characters of the request target and asks whether it is properly perce
 
 ## Specifications
 
-- [RFC 3986 §2.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1): Percent-Encoding: the triplet production, and percent-encoding as the mechanism for an octet whose character is outside the allowed set
+- [RFC 3986 §2.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1): Percent-Encoding — `pct-encoded = "%" HEXDIG HEXDIG`, the two digits every `%` still owes
 - [RFC 3986 §2](https://www.rfc-editor.org/rfc/rfc3986.html#section-2): Characters: the limited set a URI is composed from, whose terminals the notation maps back through US-ASCII
 - [RFC 3986 §2.4](https://www.rfc-editor.org/rfc/rfc3986.html#section-2.4): When to Encode or Decode: a URI on the wire is already in its percent-encoded form, a '%' meant as data is written %25, and octets decoded before their components are separated can be taken for delimiters
 - [RFC 9110 §4.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-4.1): URI References: the generic syntax's productions are adopted by name for the HTTP elements that carry a URI

--- a/lint-http-rules/src/rules/content_location_and_uri_consistent.rs
+++ b/lint-http-rules/src/rules/content_location_and_uri_consistent.rs
@@ -4,8 +4,26 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::uri::{
+    PERCENT_ENCODING_DIGITS_MISSING, PERCENT_ENCODING_MALFORMED, RFC_3986_2_1,
+};
+use crate::violations::ViolationDef;
 
 pub struct ContentLocationAndUriConsistent;
+
+/// The triplet's two defects, borrowed like every other reader of a URI
+/// reference.
+///
+/// What this rule is named for — whether the value the response gave equals the
+/// target URI — is a comparison and not a grammar, and the rest of its reading
+/// is `Content-Location = absolute-URI / partial-URI` measured piece by piece.
+/// Only the percent triplet has a subject so far; the scheme's three ids are
+/// one wrapper away and the alphabet's is § 2's character set, which no subject
+/// holds.
+static DECLARED: &[&ViolationDef] = &[
+    &PERCENT_ENCODING_DIGITS_MISSING,
+    &PERCENT_ENCODING_MALFORMED,
+];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -98,7 +116,12 @@ severity = "info"
             RFC_3986_6_2_2_1,
             RFC_3986_6_2_2_2,
             RFC_3986_6_2_2_3,
+            RFC_3986_2_1,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -259,8 +282,11 @@ impl Rule for ContentLocationAndUriConsistent {
 
                 // The `pct-encoded` production and the `scheme` production are the
                 // helpers' to state; both carry the grammar at their definitions.
-                if let Some(msg) = crate::helpers::uri::check_percent_encoding(s) {
-                    return Some(self.violation(ctx.severity, msg));
+                if let Some(defect) = crate::helpers::uri::percent_encoding_defect(s) {
+                    return Some(ctx.report_with(
+                        crate::violations::uri::percent_encoding(defect),
+                        defect.message(),
+                    ));
                 }
 
                 // Only the `absolute-URI` alternative has a scheme; the helper is a

--- a/lint-http-rules/src/rules/location_header_uri_valid.rs
+++ b/lint-http-rules/src/rules/location_header_uri_valid.rs
@@ -6,8 +6,24 @@ use crate::helpers::headers::{combined_field_value_as_written, trim_ows};
 use crate::helpers::shown::describe_octet;
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::uri::{
+    PERCENT_ENCODING_DIGITS_MISSING, PERCENT_ENCODING_MALFORMED, RFC_3986_2_1,
+};
+use crate::violations::ViolationDef;
 
 pub struct LocationHeaderUriValid;
+
+/// The triplet's two defects, which is what `Location = URI-reference` borrows
+/// before anything else.
+///
+/// § 10.2.2 defines the field as one production of another document and adds a
+/// Note about why it cannot be a list; it writes no grammar of its own, so every
+/// character question this rule asks belongs to RFC 3986. The percent triplet is
+/// the part of it that has a subject today.
+static DECLARED: &[&ViolationDef] = &[
+    &PERCENT_ENCODING_DIGITS_MISSING,
+    &PERCENT_ENCODING_MALFORMED,
+];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -76,7 +92,12 @@ severity = "warn"
             RFC_9110_5_5,
             RFC_3986_2,
             RFC_3986_4_1,
+            RFC_3986_2_1,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -250,8 +271,11 @@ impl Rule for LocationHeaderUriValid {
 
             // `%` passed the alphabet check because it opens a triplet; whether it
             // actually does is the triplet's own production, and the helper carries it.
-            if let Some(msg) = crate::helpers::uri::check_percent_encoding(value) {
-                return violation(msg);
+            if let Some(defect) = crate::helpers::uri::percent_encoding_defect(value) {
+                return Some(ctx.report_with(
+                    crate::violations::uri::percent_encoding(defect),
+                    defect.message(),
+                ));
             }
 
             // Only the `URI` alternative has a scheme; the helper is a no-op on a

--- a/lint-http-rules/src/rules/referer_uri_valid.rs
+++ b/lint-http-rules/src/rules/referer_uri_valid.rs
@@ -5,15 +5,15 @@
 use crate::helpers::headers::{combined_field_value_as_written, trim_ows};
 use crate::helpers::shown::{describe_char, shown_in_finding};
 use crate::helpers::uri::{
-    authority_component, check_percent_encoding, find_non_uri_char, scheme_authority_marker,
+    authority_component, find_non_uri_char, percent_encoding_defect, scheme_authority_marker,
     scheme_prefix, split_host_and_port, split_userinfo, validate_host_and_optional_port,
     validate_scheme_name,
 };
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
 use crate::violations::uri::{
-    RFC_3986_3_1, URI_SCHEME_CHARACTER_FORBIDDEN, URI_SCHEME_EMPTY,
-    URI_SCHEME_LEADING_LETTER_MISSING,
+    PERCENT_ENCODING_DIGITS_MISSING, PERCENT_ENCODING_MALFORMED, RFC_3986_2_1, RFC_3986_3_1,
+    URI_SCHEME_CHARACTER_FORBIDDEN, URI_SCHEME_EMPTY, URI_SCHEME_LEADING_LETTER_MISSING,
 };
 use crate::violations::ViolationDef;
 
@@ -33,6 +33,8 @@ static DECLARED: &[&ViolationDef] = &[
     &URI_SCHEME_EMPTY,
     &URI_SCHEME_LEADING_LETTER_MISSING,
     &URI_SCHEME_CHARACTER_FORBIDDEN,
+    &PERCENT_ENCODING_DIGITS_MISSING,
+    &PERCENT_ENCODING_MALFORMED,
 ];
 
 /// The value as a finding may print it: escaped, and with the password half of a
@@ -123,12 +125,6 @@ const RFC_3986_4_4: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("4.4"),
     url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-4.4",
     note: "Same-Document Reference — what an empty value is",
-};
-const RFC_3986_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 3986",
-    section: Some("2.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1",
-    note: "Percent-Encoding — the triplet the `%` obliges",
 };
 
 impl RuleMeta for RefererUriValid {
@@ -350,11 +346,17 @@ impl Rule for RefererUriValid {
                 ));
             }
 
-            if let Some(msg) = check_percent_encoding(value) {
-                return violation(format!(
-                    "Referer value '{}' is not a well-formed URI reference: {}",
-                    shown_referer(value),
-                    msg
+            // The triplet is `pct-encoded`'s, which every URI component and
+            // every field carrying one reads the same way, so the id is the
+            // production's and the sentence naming the field stays here.
+            if let Some(defect) = percent_encoding_defect(value) {
+                return Some(ctx.report_with(
+                    crate::violations::uri::percent_encoding(defect),
+                    format!(
+                        "Referer value '{}' is not a well-formed URI reference: {}",
+                        shown_referer(value),
+                        defect.message()
+                    ),
                 ));
             }
 

--- a/lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
+++ b/lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
@@ -4,18 +4,34 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::uri::{
+    PERCENT_ENCODING_DIGITS_MISSING, PERCENT_ENCODING_MALFORMED, RFC_3986_2_1,
+};
+use crate::violations::ViolationDef;
 
 pub struct RequestUriPercentEncodingValid;
+
+/// The two ways a `%` does not open a triplet, which is the whole of what this
+/// rule reads out of the request target.
+///
+/// The production is `pct-encoded = "%" HEXDIG HEXDIG` and every field carrying
+/// a URI reference measures it the same way, so the defects are the
+/// production's — a `Referer`, a `Location` and a `Content-Location` draw these
+/// same two — and what stays here is § 2.4's reading of *why* a malformed
+/// triplet in a request target matters: the target is the one URI a server
+/// dereferences.
+///
+/// The alphabet finding beside them is not one of these: an octet no URI is
+/// composed from is § 2's character set rather than the triplet's, and no
+/// subject holds it yet.
+static DECLARED: &[&ViolationDef] = &[
+    &PERCENT_ENCODING_DIGITS_MISSING,
+    &PERCENT_ENCODING_MALFORMED,
+];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_3986_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 3986",
-    section: Some("2.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1",
-    note: "Percent-Encoding: the triplet production, and percent-encoding as the mechanism for an octet whose character is outside the allowed set",
-};
 const RFC_3986_2: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 3986",
     section: Some("2"),
@@ -82,6 +98,10 @@ severity = "error"
             RFC_9110_7_1,
             RFC_5234_2_3,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -161,19 +181,15 @@ impl Rule for RequestUriPercentEncodingValid {
             // cite(RFC 3986 § 2.4): "Because the percent ("%") character serves as the indicator for percent-encoded octets, it must be percent-encoded as "%25" for that octet to be used as data within a URI."
             // cite(RFC 3986 § 2.4): "Once produced, a URI is always in its percent-encoded form."
             // cite(RFC 3986 § 2.4): "When a URI is dereferenced, the components and subcomponents significant to the scheme-specific dereferencing process (if any) must be parsed and separated before the percent-encoded octets within those components can be safely decoded, as otherwise the data may be mistaken for component delimiters."
-            if let Some(msg) = crate::helpers::uri::check_percent_encoding(target) {
-                // Read after the finding is certain: parsing the config is several
-                // map probes and a hash of the rule id, where the scan above walks a
-                // string the transaction already holds.
-                let severity = ctx.severity;
-
+            if let Some(defect) = crate::helpers::uri::percent_encoding_defect(target) {
                 // A target read back from a capture can hold characters that print
                 // as nothing or, worse, print as something else: an escape sequence
                 // in a finding is a finding nobody can read.
                 let shown = crate::helpers::shown::shown_in_finding(target);
+                let msg = defect.message();
 
-                return Some(self.violation(
-                    severity,
+                return Some(ctx.report_with(
+                    crate::violations::uri::percent_encoding(defect),
                     format!(
                         "Request target '{shown}': {msg}. The percent character is the indicator for a \
                          percent-encoded octet and opens a triplet -- itself and two hexadecimal \
@@ -261,6 +277,69 @@ mod tests {
             assert_eq!(v.rule, "request_uri_percent_encoding_valid");
             v.message
         })
+    }
+
+    /// One production, four fields, two ids. The request target, a `Referer`,
+    /// a `Location` and a `Content-Location` each read `pct-encoded` through
+    /// the same helper and each words its own sentence around the answer; what
+    /// the catalogue makes the same is which defect it is.
+    #[rstest]
+    #[case("/a%2", "percent_encoding_digits_missing")]
+    #[case("/a%zz", "percent_encoding_malformed")]
+    fn four_fields_carrying_a_uri_report_one_id(#[case] value: &str, #[case] id: &str) {
+        let mut request = crate::test_helpers::make_test_transaction();
+        request.request.uri = format!("http://example.com{value}");
+        let found = crate::test_helpers::run_rule(
+            &RequestUriPercentEncodingValid,
+            &request,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_severity(
+                "request_uri_percent_encoding_valid",
+                "warn",
+            ),
+        )
+        .expect("a finding");
+        assert_eq!(found.violation, id, "{value}");
+
+        let referer = crate::test_helpers::make_test_transaction_with_headers(&[(
+            "referer",
+            &format!("http://example.com{value}"),
+        )]);
+        let found = crate::test_helpers::run_rule(
+            &super::super::referer_uri_valid::RefererUriValid,
+            &referer,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_severity("referer_uri_valid", "warn"),
+        )
+        .expect("a finding");
+        assert_eq!(found.violation, id, "{value}");
+
+        for (rule, field) in [
+            (
+                &super::super::location_header_uri_valid::LocationHeaderUriValid
+                    as &dyn crate::rules::Rule,
+                "location",
+            ),
+            (
+                &super::super::content_location_and_uri_consistent::ContentLocationAndUriConsistent,
+                "content-location",
+            ),
+        ] {
+            let mut tx = crate::test_helpers::make_test_transaction_with_response(302, &[]);
+            tx.response.as_mut().expect("a response").headers =
+                crate::test_helpers::make_headers_from_pairs(&[(
+                    field,
+                    &format!("http://example.com{value}"),
+                )]);
+            let found = crate::test_helpers::run_rule(
+                rule,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &crate::test_helpers::make_test_config_with_severity(rule.id(), "warn"),
+            )
+            .expect("a finding");
+            assert_eq!(found.violation, id, "{field} {value}");
+        }
     }
 
     #[rstest]

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1136,9 +1136,9 @@ sources:
     snippet: Some protocol elements allow only the absolute form of a URI without a fragment identifier.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 291
+      line: 317
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 379
+      line: 381
   - label: host_and_authority_consistent
     section: § 6.2.3
     snippet: Normalization should not remove delimiters when their associated component is empty unless licensed to do so by the scheme specification.
@@ -1186,9 +1186,9 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 374
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 252
+      line: 275
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 209
+      line: 225
   - label: lint-http-rules/src/helpers/uri.rs (2)
     section: § 2.1
     snippet: A percent-encoded octet is encoded as a character triplet, consisting of the percent character "%" followed by the two hexadecimal digits representing that octet's numeric value.
@@ -1202,7 +1202,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 107
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 208
+      line: 224
   - label: lint-http-rules/src/helpers/uri.rs (4)
     section: § 2.1
     snippet: If two URIs differ only in the case of hexadecimal digits used in percent-encoded octets, they are equivalent.
@@ -1254,13 +1254,13 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 137
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 194
+      line: 217
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 357
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 574
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 285
+      line: 281
   - label: lint-http-rules/src/helpers/uri.rs (9)
     section: § 2.3
     snippet: URIs that differ in the replacement of an unreserved character with its corresponding percent-encoded US-ASCII octet are equivalent
@@ -1296,7 +1296,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 715
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 163
+      line: 183
   - label: lint-http-rules/src/helpers/uri.rs (14)
     section: § 3
     snippet: hier-part   = "//" authority path-abempty / path-absolute / path-rootless / path-empty
@@ -1320,7 +1320,7 @@ sources:
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 958
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 397
+      line: 399
     - file: lint-http-rules/src/violations/uri.rs
       line: 105
     - file: lint-http-rules/src/violations/uri.rs
@@ -1348,7 +1348,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 229
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 46
+      line: 48
   - label: lint-http-rules/src/helpers/uri.rs (19)
     section: § 3.2.1
     snippet: The user information, if present, is followed by a commercial at-sign ("@") that delimits it from the host.
@@ -1398,7 +1398,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 356
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 207
+      line: 223
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
       line: 599
     - file: lint-http-rules/src/violations/uri.rs
@@ -1434,7 +1434,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 173
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 205
+      line: 221
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
       line: 48
   - label: lint-http-rules/src/helpers/uri.rs (25)
@@ -1444,7 +1444,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 174
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 398
+      line: 400
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 91
   - label: lint-http-rules/src/helpers/uri.rs (26)
@@ -1520,7 +1520,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 802
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 362
+      line: 388
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
       line: 307
   - label: lint-http-rules/src/helpers/uri.rs (35)
@@ -1530,7 +1530,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 501
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 361
+      line: 387
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
       line: 303
   - label: lint-http-rules/src/helpers/uri.rs (36)
@@ -1550,27 +1550,27 @@ sources:
     snippet: URI-reference = URI / relative-ref
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 177
+      line: 198
   - label: location_header_uri_valid (2)
     section: § 4.4
     snippet: The most frequent examples of same-document references are relative references that are empty or include only the number sign ("#") separator followed by a fragment identifier.
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 233
+      line: 254
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 324
+      line: 320
   - label: referer_uri_valid
     section: § 3.2.1
     snippet: Use of the format "user:password" in the userinfo field is deprecated.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 432
+      line: 434
   - label: referer_uri_valid (2)
     section: § 3.5
     snippet: The fragment identifier component of a URI allows indirect identification of a secondary resource by reference to a primary resource and additional identifying information.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 380
+      line: 382
   - label: request_target_no_fragment
     section: § 2.2
     snippet: If data for a URI component would conflict with a reserved character's purpose as a delimiter, then the conflicting data must be percent-encoded before the URI is formed.
@@ -1600,31 +1600,31 @@ sources:
     snippet: The ABNF notation defines its terminal values to be non-negative integers (codepoints) based on the US-ASCII coded character set [ASCII].
     cited_by:
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 210
+      line: 226
   - label: request_uri_percent_encoding_valid (2)
     section: § 2
     snippet: the integer values used by the ABNF must be mapped back to their corresponding characters via US-ASCII in order to complete the syntax rules.
     cited_by:
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 211
+      line: 227
   - label: request_uri_percent_encoding_valid (3)
     section: § 2.4
     snippet: Because the percent ("%") character serves as the indicator for percent-encoded octets, it must be percent-encoded as "%25" for that octet to be used as data within a URI.
     cited_by:
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 161
+      line: 181
   - label: request_uri_percent_encoding_valid (4)
     section: § 2.4
     snippet: Once produced, a URI is always in its percent-encoded form.
     cited_by:
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 162
+      line: 182
   - label: query
     section: § 3.4
     snippet: query       = *( pchar / "/" / "?" )
     cited_by:
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 206
+      line: 222
   - label: well_known_uri_syntax
     section: § 3.3
     snippet: The path is terminated by the first question mark ("?") or number sign ("#") character, or by the end of the URI.
@@ -5173,7 +5173,7 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 45
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 129
+      line: 150
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
       line: 206
     - file: lint-http-rules/src/rules/redirect_status_and_location_valid.rs
@@ -5201,7 +5201,7 @@ sources:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 302
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 292
+      line: 318
     - file: lint-http-rules/src/rules/expect_header_valid.rs
       line: 401
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
@@ -5215,11 +5215,11 @@ sources:
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 504
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 178
+      line: 199
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
       line: 424
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 344
+      line: 340
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
       line: 295
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
@@ -5233,7 +5233,7 @@ sources:
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 221
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 153
+      line: 173
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
       line: 179
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
@@ -5563,7 +5563,7 @@ sources:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
       line: 282
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 220
+      line: 243
   - label: content_encoding_and_type_consistent
     section: § 15.4.5
     snippet: a sender SHOULD NOT generate representation metadata other than the above listed fields unless said metadata exists for the purpose of guiding cache updates
@@ -5607,67 +5607,67 @@ sources:
     snippet: A "partial-URI" rule is defined for protocol elements that can contain a relative URI but not a fragment component.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 289
+      line: 315
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 377
+      line: 379
   - label: content_location_and_uri_consistent (2)
     section: § 4.1
     snippet: Each protocol element in HTTP that allows a URI reference will indicate in its ABNF production whether the element allows any form of reference (URI-reference), only a URI in absolute form (absolute-URI), only the path and optional query components (partial-URI), or some combination of the above.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 290
+      line: 316
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 378
+      line: 380
   - label: content_location_and_uri_consistent (3)
     section: § 8.7
     snippet: Content-Location = absolute-URI / partial-URI
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 193
+      line: 216
   - label: content_location_and_uri_consistent (4)
     section: § 8.7
     snippet: For a response to a GET or HEAD request, this is an indication that the target URI refers to a resource that is subject to content negotiation and the Content-Location field value is a more specific identifier for the selected representation.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 394
+      line: 420
   - label: content_location_and_uri_consistent (5)
     section: § 8.7
     snippet: If Content-Location is included in a 2xx (Successful) response message and its field value refers to a URI that differs from the target URI, then the origin server claims that the URI is an identifier for a different resource corresponding to the enclosed representation.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 393
+      line: 419
   - label: content_location_and_uri_consistent (6)
     section: § 8.7
     snippet: If Content-Location is included in a 2xx (Successful) response message and its value refers (after conversion to absolute form) to a URI that is the same as the target URI, then the recipient MAY consider the content to be a current representation of that resource at the time indicated by the message origination date.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 304
+      line: 330
   - label: content_location_and_uri_consistent (7)
     section: § 8.7
     snippet: In the latter case (Section 4), the referenced URI is relative to the target URI ([URI], Section 5).
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 332
+      line: 358
   - label: content_location_and_uri_consistent (8)
     section: § 8.7
     snippet: Such a claim can only be trusted if both identifiers share the same resource owner, which cannot be programmatically determined via HTTP.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 395
+      line: 421
   - label: content_location_and_uri_consistent (9)
     section: § 8.7
     snippet: The "Content-Location" header field references a URI that can be used as an identifier for a specific resource corresponding to the representation in this message's content.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 180
+      line: 203
   - label: content_location_and_uri_consistent (10)
     section: § 8.7
     snippet: The field value is either an absolute-URI or a partial-URI.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 251
+      line: 274
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 288
+      line: 314
   - label: content_type_present
     section: § 15.3.6
     snippet: Since the 205 status code implies that no additional content will be provided, a server MUST NOT generate content in a 205 response.
@@ -5745,7 +5745,7 @@ sources:
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
       line: 222
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 238
+      line: 234
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 557
   - label: context_fields_direction (2)
@@ -5771,7 +5771,7 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 17
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 269
+      line: 265
   - label: context_fields_direction (5)
     section: § 10.1.4
     snippet: The "TE" header field describes capabilities of the client with regard to transfer codings and trailer sections.
@@ -5801,7 +5801,7 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 47
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 175
+      line: 196
     - file: lint-http-rules/src/rules/redirect_status_and_location_valid.rs
       line: 184
   - label: context_fields_direction (8)
@@ -6119,7 +6119,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 50
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 456
+      line: 458
   - label: host_header
     section: § 7.2
     snippet: A user agent MUST generate a Host header field in a request unless it sends that information as an ":authority" pseudo-header field.
@@ -7011,7 +7011,7 @@ sources:
     - file: lint-http-rules/src/rules/charset_registered.rs
       line: 322
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 221
+      line: 244
     - file: lint-http-rules/src/rules/content_type_valid.rs
       line: 243
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
@@ -7233,13 +7233,13 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 397
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 218
+      line: 239
     - file: lint-http-rules/src/rules/max_forwards_numeric.rs
       line: 177
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
       line: 243
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 301
+      line: 297
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
       line: 233
     - file: lint-http-rules/src/rules/te_header_valid.rs
@@ -7591,31 +7591,31 @@ sources:
     snippet: A Location field value cannot allow a list of members because the comma list separator is a valid data character within a URI-reference.
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 199
+      line: 220
   - label: location_header_uri_valid (2)
     section: § 10.2.2
     snippet: If an invalid message is sent with multiple Location field lines, a recipient along the path might combine those field lines into one value.
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 200
+      line: 221
   - label: Location grammar
     section: § 10.2.2
     snippet: Location = URI-reference
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 176
+      line: 197
   - label: location_header_uri_valid (3)
     section: § 16.3.2.2
     snippet: because URIs can include commas, it is not possible to reliably distinguish between a single value that includes a comma from two values
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 201
+      line: 222
   - label: location_header_uri_valid (4)
     section: § 5.5
     snippet: Fields that expect to contain a comma within a member, such as within an HTTP-date or URI-reference element, ought to be defined with delimiters around that element to distinguish any comma within that data from potential list separators.
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 198
+      line: 219
   - label: location_on_redirect_present
     section: § 10.2.2
     snippet: For 201 (Created) responses, the Location value refers to the primary resource created by the request.
@@ -8355,73 +8355,73 @@ sources:
     snippet: A user agent MUST NOT include the fragment and userinfo components of the URI reference [URI], if any, when generating the Referer field value.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 376
+      line: 378
   - label: referer_uri_valid (2)
     section: § 10.1.3
     snippet: A user agent MUST NOT send a Referer header field in an unsecured HTTP request if the referring resource was accessed with a secure protocol.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 508
+      line: 510
   - label: referer_uri_valid (3)
     section: § 10.1.3
     snippet: If the target URI was obtained from a source that does not have its own URI (e.g., input from the user keyboard, or an entry within the user's bookmarks/favorites), the user agent MUST either exclude the Referer header field or send it with a value of "about:blank".
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 325
+      line: 321
   - label: Referer grammar
     section: § 10.1.3
     snippet: Referer = absolute-URI / partial-URI
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 270
+      line: 266
   - label: referer_uri_valid (4)
     section: § 17.9
     snippet: Since the Referer header field tells a target site about the context that resulted in a request, it has the potential to reveal information about the user's immediate browsing history and any personal information that might be found in the referring resource's URI.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 513
+      line: 515
   - label: partial-URI
     section: § 4.1
     snippet: partial-URI   = relative-part [ "?" query ]
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 323
+      line: 319
   - label: referer_uri_valid (5)
     section: § 4.2.1
     snippet: A sender MUST NOT generate an "http" URI with an empty host identifier.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 454
+      line: 456
   - label: referer_uri_valid (6)
     section: § 4.2.1
     snippet: The "http" URI scheme is hereby defined for minting identifiers within the hierarchical namespace governed by a potential HTTP origin server listening for TCP ([TCP]) connections on a given port.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 511
+      line: 513
   - label: referer_uri_valid (7)
     section: § 4.2.2
     snippet: A client MUST ensure that its HTTP requests for an "https" resource are secured, prior to being communicated, and that it only accepts secured responses to those requests.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 510
+      line: 512
   - label: referer_uri_valid (8)
     section: § 4.2.2
     snippet: A sender MUST NOT generate an "https" URI with an empty host identifier.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 455
+      line: 457
   - label: referer_uri_valid (9)
     section: § 4.2.2
     snippet: Resources made available via the "https" scheme have no shared identity with the "http" scheme.  They are distinct origins with separate namespaces.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 512
+      line: 514
   - label: referer_uri_valid (10)
     section: § 4.2.2
     snippet: The "https" URI scheme is hereby defined for minting identifiers within the hierarchical namespace governed by a potential origin server listening for TCP connections on a given port and capable of establishing a TLS ([TLS13]) connection that has been secured for HTTP communication.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 509
+      line: 511
   - label: request_method_token_valid
     section: § 9.1
     snippet: All such methods ought to be registered within the "Hypertext Transfer Protocol (HTTP) Method Registry", as described in Section 16.1.
@@ -8461,7 +8461,7 @@ sources:
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 151
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 143
+      line: 163
   - label: request_target_form_valid (3)
     section: § 7.1
     snippet: There are two unusual cases for which the request target components are in a method-specific form
@@ -8499,13 +8499,13 @@ sources:
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 132
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 121
+      line: 141
   - label: request_uri_percent_encoding_valid
     section: § 4.1
     snippet: The definitions of "URI-reference", "absolute-URI", "relative-part", "authority", "port", "host", "path-abempty", "segment", and "query" are adopted from the URI generic syntax.
     cited_by:
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 152
+      line: 172
   - label: request_version_method_valid
     section: § 9.3.1
     snippet: A client SHOULD NOT generate content in a GET request unless it is made directly to an origin server that has previously indicated, in or out of band, that such a request has a purpose and will be adequately supported.
@@ -10498,7 +10498,7 @@ sources:
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 209
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 144
+      line: 164
   - label: status_101_switching_protocols
     section: § 8.6
     snippet: HTTP/2 does not support the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP]).
@@ -10815,7 +10815,7 @@ sources:
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 210
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 145
+      line: 165
 - label: RFC 9218
   url: https://www.rfc-editor.org/rfc/rfc9218.html
   fragments:


### PR DESCRIPTION
The request target, a `Referer`, a `Location` and a `Content-Location` each had their own sentence for a `%` that opens no `pct-encoded` triplet. The production is RFC 3986 § 2.1's and every one of them reads it through the same helper, so the two ids are the production's and what each rule keeps is the sentence naming the field the triplet was in — which is also why the request-target rule keeps its § 2.4 paragraph about why a malformed triplet in a target matters more than one elsewhere.

Three of the four sites called the rendered wrapper; they ask the typed reader now, which is the same swap every other converted caller made. Two rule-local references for § 2.1 go, because the subject already declares it.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
