### PR TITLE
A scheme name is one production, read by four

### DIFF
--- a/docs/rules/content_location_and_uri_consistent.md
+++ b/docs/rules/content_location_and_uri_consistent.md
@@ -29,6 +29,7 @@ For 2xx responses the rule additionally compares the value against the request t
 - [RFC 3986 §6.2.2.2](https://www.rfc-editor.org/rfc/rfc3986.html#section-6.2.2.2): Percent-Encoding Normalization: a triplet standing for an unreserved character is decoded on both sides before comparison, so `/a~b` and `/a%7Eb` are one path. Nothing else is decoded — a delimiter would move the component boundaries (§2.4)
 - [RFC 3986 §6.2.2.3](https://www.rfc-editor.org/rfc/rfc3986.html#section-6.2.2.3): Path Segment Normalization: dot-segments are removed from both sides before comparison, after the decoding above — §2.3 names the period among the octets a normalizer decodes, so `%2E%2E` is a dot segment. §6.2.3's scheme-based normalization is NOT applied, so a default port written out and one left off read as different authorities
 - [RFC 3986 §2.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1): Percent-Encoding — `pct-encoded = "%" HEXDIG HEXDIG`, the two digits every `%` still owes
+- [RFC 3986 §3.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.1): Scheme — `scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`, the name before the first colon
 
 ## Configuration
 

--- a/docs/rules/http2_pseudo_headers_valid.md
+++ b/docs/rules/http2_pseudo_headers_valid.md
@@ -42,6 +42,7 @@ HTTP/2 carries a request's control data as pseudo-header fields — `:method`, `
 - [RFC 3986 §3.2.2](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.2): Host — `host = IP-literal / IPv4address / reg-name`, where the square brackets of the IP literal are the only ones the URI syntax admits anywhere
 - [RFC 3986 §3.2.3](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.3): Port — `port = *DIGIT`, which has no lower bound, no upper bound, and admits the empty string
 - [RFC 3986 §2.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1): Percent-Encoding — `pct-encoded = "%" HEXDIG HEXDIG`, the two digits every `%` still owes
+- [RFC 3986 §3.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.1): Scheme — `scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`, the name before the first colon
 
 ## Configuration
 

--- a/docs/rules/location_header_uri_valid.md
+++ b/docs/rules/location_header_uri_valid.md
@@ -31,6 +31,7 @@ A `%` must open a well-formed `pct-encoded` triplet, and a value that carries a 
 - [RFC 3986 §2](https://www.rfc-editor.org/rfc/rfc3986.html#section-2): Characters: the limited set a URI is composed from — `unreserved`, `gen-delims`, `sub-delims` — and the `pct-encoded` triplet every other octet must be written as
 - [RFC 3986 §4.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-4.1): `URI-reference = URI / relative-ref`. §4.4 is why an empty value is one of them, and so why the empty-value finding here is advisory
 - [RFC 3986 §2.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1): Percent-Encoding — `pct-encoded = "%" HEXDIG HEXDIG`, the two digits every `%` still owes
+- [RFC 3986 §3.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.1): Scheme — `scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`, the name before the first colon
 
 ## Configuration
 

--- a/lint-http-rules/src/helpers/uri.rs
+++ b/lint-http-rules/src/helpers/uri.rs
@@ -178,9 +178,17 @@ pub fn scheme_prefix(s: &str) -> Option<&str> {
     Some(&s[..colon])
 }
 
-/// Validate a potential scheme (the characters before a scheme-delimiting ':').
-/// Returns `Some(msg)` on invalid scheme, `None` if OK or no scheme present.
-pub fn validate_scheme_if_present(s: &str) -> Option<String> {
+/// The defect of the scheme a value carries, if it carries one at all.
+///
+/// **The `Some` is the defect and not a sentence**, for the reason
+/// [`percent_encoding_defect`] gives beside its own rendered twin: a caller
+/// reporting through the catalogue answers with the `uri_scheme_*` def the
+/// variant maps to, and one wording its own finding asks
+/// [`SchemeNameDefect::message`] for the fragment. There is no rendered twin
+/// here because all three callers name the field the scheme came from, and a
+/// sentence that begins "Invalid scheme in value" inside one that already says
+/// which value it is says it twice.
+pub fn scheme_if_present(s: &str) -> Option<SchemeNameDefect<'_>> {
     // The production itself is [`validate_scheme_name`]'s and finding the
     // candidate is [`scheme_prefix`]'s. This function is only the pairing of
     // the two; what a scheme name may be made of is one question with one
@@ -189,9 +197,7 @@ pub fn validate_scheme_if_present(s: &str) -> Option<String> {
     // An empty scheme (a value opening with ':') satisfies neither `scheme`, whose
     // `ALPHA` is not optional, nor `segment-nz-nc`, which excludes ':' and so
     // cannot start a relative-path reference either.
-    validate_scheme_name(scheme_prefix(s)?)
-        .err()
-        .map(|defect| format!("Invalid scheme in value: {}", defect.message()))
+    validate_scheme_name(scheme_prefix(s)?).err()
 }
 
 /// Split an authority into its `userinfo` subcomponent and the `host [ ":" port ]`
@@ -329,7 +335,7 @@ pub fn extract_origin_if_absolute(s: &str) -> Option<String> {
     // this function's `None` says. The narrower `reg-name` alphabet is a
     // different question and not this function's: what an authority may hold is
     // asked where an authority is *validated*, and this one is reconstructing.
-    if validate_scheme_if_present(&origin).is_some() {
+    if scheme_if_present(&origin).is_some() {
         return None;
     }
     if find_non_uri_char(&origin).is_some() {
@@ -358,7 +364,7 @@ pub fn validate_origin_value(s: &str) -> Option<String> {
         if s_trim[colon_pos + 3..].contains('/') {
             return Some("Origin must not include a path".into());
         }
-        if validate_scheme_if_present(s_trim).is_some() {
+        if scheme_if_present(s_trim).is_some() {
             return Some("Invalid scheme in Origin".into());
         }
         // The alphabet, before the authority question below it. This was
@@ -965,7 +971,7 @@ pub fn parse_query_string(s: &str) -> Vec<(String, String)> {
 
 /// Validate a bare scheme name — the production alone, with no ':' to find it by.
 ///
-/// [`validate_scheme_if_present`] locates a scheme inside a larger value and then
+/// [`scheme_if_present`] locates a scheme inside a larger value and then
 /// asks this question of what it found; a field whose whole value *is* a scheme
 /// name (`Forwarded`'s `proto`) asks it directly. The production was written out
 /// twice before this function existed, and the two copies are the shape three of
@@ -1660,10 +1666,10 @@ mod tests {
 
     #[test]
     fn scheme_validation() {
-        assert!(validate_scheme_if_present("1http://ex").is_some());
-        assert!(validate_scheme_if_present("ht!tp://ex").is_some());
-        assert!(validate_scheme_if_present("/relative").is_none());
-        assert!(validate_scheme_if_present("https://ex").is_none());
+        assert!(scheme_if_present("1http://ex").is_some());
+        assert!(scheme_if_present("ht!tp://ex").is_some());
+        assert!(scheme_if_present("/relative").is_none());
+        assert!(scheme_if_present("https://ex").is_none());
     }
 
     /// The production's two halves, and the split the variants make plain:
@@ -1825,15 +1831,15 @@ mod tests {
     fn colon_inside_a_path_or_query_is_not_a_scheme_delimiter() {
         // `pchar` admits ':' inside a segment, so these are all well-formed
         // absolute-path references with no scheme at all.
-        assert_eq!(validate_scheme_if_present("/foo:bar"), None);
-        assert_eq!(validate_scheme_if_present("/v1/entities/x:batchGet"), None);
-        assert_eq!(validate_scheme_if_present("/users/urn:uuid:1"), None);
-        assert_eq!(validate_scheme_if_present("/a?x=b:c"), None);
-        assert_eq!(validate_scheme_if_present("/a#f:g"), None);
+        assert_eq!(scheme_if_present("/foo:bar"), None);
+        assert_eq!(scheme_if_present("/v1/entities/x:batchGet"), None);
+        assert_eq!(scheme_if_present("/users/urn:uuid:1"), None);
+        assert_eq!(scheme_if_present("/a?x=b:c"), None);
+        assert_eq!(scheme_if_present("/a#f:g"), None);
         // A colon in the first segment of a relative-path reference *is* read
         // as a scheme, which is why RFC 3986 forbids it there.
-        assert!(validate_scheme_if_present("this:that").is_none());
-        assert!(validate_scheme_if_present("1this:that").is_some());
+        assert!(scheme_if_present("this:that").is_none());
+        assert!(scheme_if_present("1this:that").is_some());
     }
 
     #[test]
@@ -2180,8 +2186,9 @@ mod tests {
 
     #[test]
     fn empty_scheme_is_rejected() {
-        let m = validate_scheme_if_present(":foo").expect("empty scheme must be flagged");
-        assert!(m.contains("must not be empty"));
+        let defect = scheme_if_present(":foo").expect("empty scheme must be flagged");
+        assert_eq!(defect, SchemeNameDefect::Empty);
+        assert!(defect.message().contains("must not be empty"));
     }
 
     #[test]

--- a/lint-http-rules/src/rules/content_location_and_uri_consistent.rs
+++ b/lint-http-rules/src/rules/content_location_and_uri_consistent.rs
@@ -5,7 +5,9 @@
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
 use crate::violations::uri::{
-    PERCENT_ENCODING_DIGITS_MISSING, PERCENT_ENCODING_MALFORMED, RFC_3986_2_1,
+    scheme_name, PERCENT_ENCODING_DIGITS_MISSING, PERCENT_ENCODING_MALFORMED, RFC_3986_2_1,
+    RFC_3986_3_1, URI_SCHEME_CHARACTER_FORBIDDEN, URI_SCHEME_EMPTY,
+    URI_SCHEME_LEADING_LETTER_MISSING,
 };
 use crate::violations::ViolationDef;
 
@@ -23,6 +25,9 @@ pub struct ContentLocationAndUriConsistent;
 static DECLARED: &[&ViolationDef] = &[
     &PERCENT_ENCODING_DIGITS_MISSING,
     &PERCENT_ENCODING_MALFORMED,
+    &URI_SCHEME_EMPTY,
+    &URI_SCHEME_LEADING_LETTER_MISSING,
+    &URI_SCHEME_CHARACTER_FORBIDDEN,
 ];
 
 /// The specification references this rule declares, each named so a finding
@@ -117,6 +122,7 @@ severity = "info"
             RFC_3986_6_2_2_2,
             RFC_3986_6_2_2_3,
             RFC_3986_2_1,
+            RFC_3986_3_1,
         ]
     }
 
@@ -291,8 +297,14 @@ impl Rule for ContentLocationAndUriConsistent {
 
                 // Only the `absolute-URI` alternative has a scheme; the helper is a
                 // no-op on a `partial-URI`, which is why nothing here gates on form.
-                if let Some(msg) = crate::helpers::uri::validate_scheme_if_present(s) {
-                    return Some(self.violation(ctx.severity, msg));
+                if let Some(defect) = crate::helpers::uri::scheme_if_present(s) {
+                    return Some(ctx.report_with(
+                        scheme_name(defect),
+                        format!(
+                            "Content-Location value's scheme is not one: {}",
+                            defect.message()
+                        ),
+                    ));
                 }
 
                 // The value's production is not `URI-reference`, and the fragment

--- a/lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
+++ b/lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
@@ -5,9 +5,11 @@
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
 use crate::violations::uri::{
-    host_and_port, PERCENT_ENCODING_DIGITS_MISSING, PERCENT_ENCODING_MALFORMED, RFC_3986_2_1,
-    RFC_3986_3_2_2, RFC_3986_3_2_3, URI_HOST_BRACKET_FORBIDDEN, URI_HOST_CHARACTER_FORBIDDEN,
-    URI_HOST_CLOSING_BRACKET_MISSING, URI_HOST_IP_LITERAL_MALFORMED, URI_PORT_CHARACTER_FORBIDDEN,
+    host_and_port, scheme_name, PERCENT_ENCODING_DIGITS_MISSING, PERCENT_ENCODING_MALFORMED,
+    RFC_3986_2_1, RFC_3986_3_1, RFC_3986_3_2_2, RFC_3986_3_2_3, URI_HOST_BRACKET_FORBIDDEN,
+    URI_HOST_CHARACTER_FORBIDDEN, URI_HOST_CLOSING_BRACKET_MISSING, URI_HOST_IP_LITERAL_MALFORMED,
+    URI_PORT_CHARACTER_FORBIDDEN, URI_SCHEME_CHARACTER_FORBIDDEN, URI_SCHEME_EMPTY,
+    URI_SCHEME_LEADING_LETTER_MISSING,
 };
 use crate::violations::ViolationDef;
 
@@ -34,6 +36,9 @@ static DECLARED: &[&ViolationDef] = &[
     &URI_PORT_CHARACTER_FORBIDDEN,
     &PERCENT_ENCODING_DIGITS_MISSING,
     &PERCENT_ENCODING_MALFORMED,
+    &URI_SCHEME_EMPTY,
+    &URI_SCHEME_LEADING_LETTER_MISSING,
+    &URI_SCHEME_CHARACTER_FORBIDDEN,
 ];
 
 /// One finding from the CONNECT reading, and the defect it reports as where
@@ -272,6 +277,7 @@ severity = "error"
             RFC_3986_3_2_2,
             RFC_3986_3_2_3,
             RFC_3986_2_1,
+            RFC_3986_3_1,
         ]
     }
 
@@ -481,11 +487,13 @@ impl Rule for Http2PseudoHeadersValid {
                 // carries the production. Nothing here asks whether it is one
                 // anybody serves: this pseudo-header is deliberately open.
                 // cite(RFC 9113 § 8.3.1): "":scheme" is not restricted to "http" and "https" schemed URIs."
-                if let Some(msg) = crate::helpers::uri::validate_scheme_if_present(target) {
-                    return Some(self.cited(
-                        &RFC_9113_8_3_1,
-                        ctx.severity,
-                        format!("Request target's scheme is not a scheme name: {msg}"),
+                if let Some(defect) = crate::helpers::uri::scheme_if_present(target) {
+                    return Some(ctx.report_with(
+                        scheme_name(defect),
+                        format!(
+                            "Request target's scheme is not a scheme name: {}",
+                            defect.message()
+                        ),
                     ));
                 }
 

--- a/lint-http-rules/src/rules/location_header_uri_valid.rs
+++ b/lint-http-rules/src/rules/location_header_uri_valid.rs
@@ -7,7 +7,9 @@ use crate::helpers::shown::describe_octet;
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
 use crate::violations::uri::{
-    PERCENT_ENCODING_DIGITS_MISSING, PERCENT_ENCODING_MALFORMED, RFC_3986_2_1,
+    scheme_name, PERCENT_ENCODING_DIGITS_MISSING, PERCENT_ENCODING_MALFORMED, RFC_3986_2_1,
+    RFC_3986_3_1, URI_SCHEME_CHARACTER_FORBIDDEN, URI_SCHEME_EMPTY,
+    URI_SCHEME_LEADING_LETTER_MISSING,
 };
 use crate::violations::ViolationDef;
 
@@ -23,6 +25,9 @@ pub struct LocationHeaderUriValid;
 static DECLARED: &[&ViolationDef] = &[
     &PERCENT_ENCODING_DIGITS_MISSING,
     &PERCENT_ENCODING_MALFORMED,
+    &URI_SCHEME_EMPTY,
+    &URI_SCHEME_LEADING_LETTER_MISSING,
+    &URI_SCHEME_CHARACTER_FORBIDDEN,
 ];
 
 /// The specification references this rule declares, each named so a finding
@@ -93,6 +98,7 @@ severity = "warn"
             RFC_3986_2,
             RFC_3986_4_1,
             RFC_3986_2_1,
+            RFC_3986_3_1,
         ]
     }
 
@@ -281,8 +287,11 @@ impl Rule for LocationHeaderUriValid {
             // Only the `URI` alternative has a scheme; the helper is a no-op on a
             // `relative-ref`, which is why nothing here gates on which alternative the
             // value took.
-            if let Some(msg) = crate::helpers::uri::validate_scheme_if_present(value) {
-                return violation(msg);
+            if let Some(defect) = crate::helpers::uri::scheme_if_present(value) {
+                return Some(ctx.report_with(
+                    scheme_name(defect),
+                    format!("Location value's scheme is not one: {}", defect.message()),
+                ));
             }
 
             None
@@ -449,10 +458,19 @@ mod tests {
         assert!(v.message.contains(expected), "{}", v.message);
     }
 
+    /// The scheme's three defects are RFC 3986 § 3.1's, so the id is the
+    /// production's and the field is named in the sentence around it — where
+    /// the wrapper used to prepend "Invalid scheme in value" to a message that
+    /// already said which value.
     #[test]
     fn invalid_scheme_start_is_violation() {
         let v = judge(&make_tx_with_locs(&[b"1http://ex"])).expect("expected a finding");
-        assert!(v.message.contains("Invalid scheme"), "{}", v.message);
+        assert_eq!(v.violation, "uri_scheme_leading_letter_missing");
+        assert!(
+            v.message.contains("Location value's scheme"),
+            "{}",
+            v.message
+        );
     }
 
     #[test]
@@ -460,6 +478,7 @@ mod tests {
         // "!" is a `sub-delim`, so the alphabet check passes it and the `scheme`
         // production is what rejects it — two questions, two checks.
         let v = judge(&make_tx_with_locs(&[b"ht!tp://ex"])).expect("expected a finding");
+        assert_eq!(v.violation, "uri_scheme_character_forbidden");
         assert!(v.message.contains("invalid character"), "{}", v.message);
     }
 

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1293,7 +1293,7 @@ severity = "warn"
         /// The rest are the per-rule reading that has not happened yet — the
         /// denominator is computed below, because merges and conversions both
         /// move it.
-        const FLOOR: usize = 152;
+        const FLOOR: usize = 151;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -42,19 +42,19 @@ sources:
     snippet: The origin serialization defined here is more constrained than [RFC3986]’s grammar in two substantial ways.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1346
+      line: 1352
   - label: lint-http-rules/src/helpers/uri.rs (2)
     section: § 3.2
     snippet: This supplants the definition in The Web Origin Concept
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1341
+      line: 1347
   - label: lint-http-rules/src/helpers/uri.rs (3)
     section: § 3.2
     snippet: serialized-origin = serialized-scheme "://" serialized-host [ ":" serialized-port ]
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1340
+      line: 1346
   - label: origin_matching_for_cors
     section: § 4.10
     snippet: If the result of byte-serializing a request origin with request is not origin, then return failure.
@@ -342,7 +342,7 @@ sources:
     snippet: A URL’s port is either null or a 16-bit unsigned integer that identifies a networking port.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1406
+      line: 1412
   - label: refresh_header_syntax
     section: § 1.1
     snippet: A code point is found that is not a URL unit.
@@ -1136,7 +1136,7 @@ sources:
     snippet: Some protocol elements allow only the absolute form of a URI without a fragment identifier.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 317
+      line: 329
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 381
   - label: host_and_authority_consistent
@@ -1164,7 +1164,7 @@ sources:
     - file: lint-http-rules/src/helpers/ipv6.rs
       line: 49
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1174
+      line: 1180
     - file: lint-http-rules/src/rules/host_header.rs
       line: 257
   - label: lint-http-rules/src/helpers/ipv6.rs (2)
@@ -1174,7 +1174,7 @@ sources:
     - file: lint-http-rules/src/helpers/ipv6.rs
       line: 50
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1175
+      line: 1181
     - file: lint-http-rules/src/violations/uri.rs
       line: 169
   - label: lint-http-rules/src/helpers/uri.rs
@@ -1184,9 +1184,9 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 106
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 374
+      line: 380
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 275
+      line: 281
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
       line: 225
   - label: lint-http-rules/src/helpers/uri.rs (2)
@@ -1254,7 +1254,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 137
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 217
+      line: 223
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 357
     - file: lint-http-rules/src/rules/link_header_valid.rs
@@ -1266,7 +1266,7 @@ sources:
     snippet: URIs that differ in the replacement of an unreserved character with its corresponding percent-encoded US-ASCII octet are equivalent
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 712
+      line: 718
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
       line: 72
   - label: lint-http-rules/src/helpers/uri.rs (10)
@@ -1274,7 +1274,7 @@ sources:
     snippet: percent-encoded octets in the ranges of ALPHA (%41-%5A and %61-%7A), DIGIT (%30-%39), hyphen (%2D), period (%2E), underscore (%5F), or tilde (%7E) should not be created by URI producers and, when found in a URI, should be decoded to their corresponding unreserved characters by URI normalizers
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 799
+      line: 805
   - label: lint-http-rules/src/helpers/uri.rs (11)
     section: § 2.3
     snippet: unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
@@ -1282,19 +1282,19 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 123
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 711
+      line: 717
   - label: lint-http-rules/src/helpers/uri.rs (12)
     section: § 2.4
     snippet: The only exception is for percent-encoded octets corresponding to characters in the unreserved set, which can be decoded at any time.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 798
+      line: 804
   - label: lint-http-rules/src/helpers/uri.rs (13)
     section: § 2.4
     snippet: When a URI is dereferenced, the components and subcomponents significant to the scheme-specific dereferencing process (if any) must be parsed and separated before the percent-encoded octets within those components can be safely decoded, as otherwise the data may be mistaken for component delimiters.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 715
+      line: 721
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
       line: 183
   - label: lint-http-rules/src/helpers/uri.rs (14)
@@ -1302,21 +1302,21 @@ sources:
     snippet: hier-part   = "//" authority path-abempty / path-absolute / path-rootless / path-empty
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 264
+      line: 270
   - label: lint-http-rules/src/helpers/uri.rs (15)
     section: § 3.1
     snippet: Scheme names consist of a sequence of characters beginning with a letter and followed by any combination of letters, digits, plus ("+"), period ("."), or hyphen ("-").
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 978
+      line: 984
   - label: lint-http-rules/src/helpers/uri.rs (16)
     section: § 3.1
     snippet: scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 295
+      line: 301
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 977
+      line: 983
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 958
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
@@ -1332,21 +1332,21 @@ sources:
     snippet: The authority component is preceded by a double slash ("//") and is terminated by the next slash ("/"), question mark ("?"), or number sign ("#") character, or by the end of the URI.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 266
+      line: 272
   - label: authority grammar
     section: § 3.2
     snippet: authority   = [ userinfo "@" ] host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 205
+      line: 211
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1388
+      line: 1394
   - label: lint-http-rules/src/helpers/uri.rs (18)
     section: § 3.2.1
     snippet: Applications should not render as clear text any data after the first colon (":") character found within a userinfo subcomponent unless the data after the colon is the empty string (indicating no password).
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 229
+      line: 235
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 48
   - label: lint-http-rules/src/helpers/uri.rs (19)
@@ -1354,19 +1354,19 @@ sources:
     snippet: The user information, if present, is followed by a commercial at-sign ("@") that delimits it from the host.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 207
+      line: 213
   - label: lint-http-rules/src/helpers/uri.rs (20)
     section: § 3.2.1
     snippet: userinfo    = *( unreserved / pct-encoded / sub-delims / ":" )
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 206
+      line: 212
   - label: lint-http-rules/src/helpers/uri.rs (21)
     section: § 3.2.2
     snippet: IP-literal = "[" ( IPv6address / IPvFuture  ) "]"
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1053
+      line: 1059
     - file: lint-http-rules/src/violations/uri.rs
       line: 141
     - file: lint-http-rules/src/violations/uri.rs
@@ -1376,23 +1376,23 @@ sources:
     snippet: IPvFuture  = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1144
+      line: 1150
   - label: host grammar
     section: § 3.2.2
     snippet: host        = IP-literal / IPv4address / reg-name
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 500
+      line: 506
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1049
+      line: 1055
   - label: reg-name
     section: § 3.2.2
     snippet: reg-name    = *( unreserved / pct-encoded / sub-delims )
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 267
+      line: 273
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1050
+      line: 1056
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 271
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
@@ -1408,11 +1408,11 @@ sources:
     snippet: The port subcomponent of authority is designated by an optional port number in decimal following the host and delimited from it by a single colon (":") character.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1176
+      line: 1182
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1217
+      line: 1223
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1243
+      line: 1249
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 291
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
@@ -1426,7 +1426,7 @@ sources:
     snippet: URI producers and normalizers should omit the port component and its ":" delimiter if port is empty or if its value would be the same as that of the scheme's default.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1244
+      line: 1250
   - label: pchar
     section: § 3.3
     snippet: pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
@@ -1452,19 +1452,19 @@ sources:
     snippet: A relative reference that begins with two slash characters is termed a network-path reference; such references are rarely used.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 843
+      line: 849
   - label: relative-part
     section: § 4.2
     snippet: relative-part = "//" authority path-abempty / path-absolute / path-noscheme / path-empty
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 265
+      line: 271
   - label: absolute-URI
     section: § 4.3
     snippet: absolute-URI  = scheme ":" hier-part [ "?" query ]
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 263
+      line: 269
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 65
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
@@ -1474,43 +1474,43 @@ sources:
     snippet: If the base URI has a defined authority component and an empty path, then return a string consisting of "/" concatenated with the reference's path
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 815
+      line: 821
   - label: lint-http-rules/src/helpers/uri.rs (28)
     section: § 5.2.3
     snippet: return a string consisting of the reference's path component appended to all but the last segment of the base URI's path
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 819
+      line: 825
   - label: lint-http-rules/src/helpers/uri.rs (29)
     section: § 5.2.4
     snippet: This is done after the path is extracted from a reference, whether or not the path was relative, in order to remove any invalid or extraneous dot-segments prior to forming the target URI.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 631
+      line: 637
   - label: lint-http-rules/src/helpers/uri.rs (30)
     section: § 5.4.2
     snippet: Some applications fail to separate the reference's query and/or fragment components from the path component before merging it with the base path and removing dot-segments.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 797
+      line: 803
   - label: lint-http-rules/src/helpers/uri.rs (31)
     section: § 5.4.2
     snippet: parsers must remove the dot-segments "." and ".." when they are complete components of a path, but not when they are only part of a segment.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 801
+      line: 807
   - label: lint-http-rules/src/helpers/uri.rs (32)
     section: § 6.2.2
     snippet: Syntax-based normalization includes such techniques as case normalization, percent-encoding normalization, and removal of dot-segments.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 796
+      line: 802
   - label: lint-http-rules/src/helpers/uri.rs (33)
     section: § 6.2.2.1
     snippet: For all URIs, the hexadecimal digits within a percent-encoding triplet (e.g., "%3a" versus "%3A") are case-insensitive and therefore should be normalized to use uppercase letters for the digits A-F.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 714
+      line: 720
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 92
   - label: lint-http-rules/src/helpers/uri.rs (34)
@@ -1518,9 +1518,9 @@ sources:
     snippet: The other generic syntax components are assumed to be case-sensitive unless specifically defined otherwise by the scheme (see Section 6.2.3).
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 802
+      line: 808
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 388
+      line: 400
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
       line: 307
   - label: lint-http-rules/src/helpers/uri.rs (35)
@@ -1528,9 +1528,9 @@ sources:
     snippet: the scheme and host are case-insensitive and therefore should be normalized to lowercase
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 501
+      line: 507
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 387
+      line: 399
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
       line: 303
   - label: lint-http-rules/src/helpers/uri.rs (36)
@@ -1538,25 +1538,25 @@ sources:
     snippet: These URIs should be normalized by decoding any percent-encoded octet that corresponds to an unreserved character, as described in Section 2.3.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 713
+      line: 719
   - label: lint-http-rules/src/helpers/uri.rs (37)
     section: § 6.2.2.3
     snippet: URI normalizers should remove dot-segments by applying the remove_dot_segments algorithm to the path, as described in Section 5.2.4.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 800
+      line: 806
   - label: location_header_uri_valid
     section: § 4.1
     snippet: URI-reference = URI / relative-ref
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 198
+      line: 204
   - label: location_header_uri_valid (2)
     section: § 4.4
     snippet: The most frequent examples of same-document references are relative references that are empty or include only the number sign ("#") separator followed by a fragment identifier.
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 254
+      line: 260
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 320
   - label: referer_uri_valid
@@ -2395,21 +2395,21 @@ sources:
     snippet: Reserved port numbers include values at the edges of each range, e.g., 0, 1023, 1024, etc., which may be used to extend these ranges or the overall port number space in the future.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1219
+      line: 1225
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 336
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 163
+      line: 168
   - label: lint-http-rules/src/helpers/uri.rs (2)
     section: § 6
     snippet: TCP, UDP, UDP-Lite, SCTP, and DCCP use 16-bit namespaces for their port number registries.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1218
+      line: 1224
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 335
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 162
+      line: 167
 - label: RFC 6454
   url: https://www.rfc-editor.org/rfc/rfc6454.html
   fragments:
@@ -2418,15 +2418,15 @@ sources:
     snippet: origin-list-or-null = %x6E %x75 %x6C %x6C / origin-list
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 348
+      line: 354
   - label: lint-http-rules/src/helpers/uri.rs (2)
     section: § 7.1
     snippet: serialized-origin = scheme "://" host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 355
+      line: 361
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1342
+      line: 1348
 - label: RFC 6455
   url: https://www.rfc-editor.org/rfc/rfc6455.html
   fragments:
@@ -4389,13 +4389,13 @@ sources:
     snippet: A new pseudo-header field :protocol MAY be included on request HEADERS indicating the desired protocol to be spoken on the tunnel created by CONNECT.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 413
+      line: 419
   - label: http2_pseudo_headers_valid (2)
     section: § 4
     snippet: On requests that contain the :protocol pseudo-header field, the :scheme and :path pseudo-header fields of the target URI (see Section 5) MUST also be included.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 414
+      line: 420
   - label: lint-http-rules/src/helpers/websocket.rs
     section: § 5
     snippet: Implementations using this extended CONNECT to bootstrap WebSockets do not do the processing of the Sec-WebSocket-Key and Sec-WebSocket-Accept header fields of [RFC6455] as that functionality has been superseded by the :protocol pseudo-header field.
@@ -4985,7 +4985,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 355
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 403
+      line: 409
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 192
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
@@ -5173,7 +5173,7 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 45
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 150
+      line: 156
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
       line: 206
     - file: lint-http-rules/src/rules/redirect_status_and_location_valid.rs
@@ -5201,7 +5201,7 @@ sources:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 302
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 318
+      line: 330
     - file: lint-http-rules/src/rules/expect_header_valid.rs
       line: 401
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
@@ -5215,7 +5215,7 @@ sources:
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 504
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 199
+      line: 205
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
       line: 424
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
@@ -5251,7 +5251,7 @@ sources:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 126
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 380
+      line: 386
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
       line: 319
   - label: alt_svc_header_syntax
@@ -5563,7 +5563,7 @@ sources:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
       line: 282
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 243
+      line: 249
   - label: content_encoding_and_type_consistent
     section: § 15.4.5
     snippet: a sender SHOULD NOT generate representation metadata other than the above listed fields unless said metadata exists for the purpose of guiding cache updates
@@ -5607,7 +5607,7 @@ sources:
     snippet: A "partial-URI" rule is defined for protocol elements that can contain a relative URI but not a fragment component.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 315
+      line: 327
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 379
   - label: content_location_and_uri_consistent (2)
@@ -5615,7 +5615,7 @@ sources:
     snippet: Each protocol element in HTTP that allows a URI reference will indicate in its ABNF production whether the element allows any form of reference (URI-reference), only a URI in absolute form (absolute-URI), only the path and optional query components (partial-URI), or some combination of the above.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 316
+      line: 328
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 380
   - label: content_location_and_uri_consistent (3)
@@ -5623,51 +5623,51 @@ sources:
     snippet: Content-Location = absolute-URI / partial-URI
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 216
+      line: 222
   - label: content_location_and_uri_consistent (4)
     section: § 8.7
     snippet: For a response to a GET or HEAD request, this is an indication that the target URI refers to a resource that is subject to content negotiation and the Content-Location field value is a more specific identifier for the selected representation.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 420
+      line: 432
   - label: content_location_and_uri_consistent (5)
     section: § 8.7
     snippet: If Content-Location is included in a 2xx (Successful) response message and its field value refers to a URI that differs from the target URI, then the origin server claims that the URI is an identifier for a different resource corresponding to the enclosed representation.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 419
+      line: 431
   - label: content_location_and_uri_consistent (6)
     section: § 8.7
     snippet: If Content-Location is included in a 2xx (Successful) response message and its value refers (after conversion to absolute form) to a URI that is the same as the target URI, then the recipient MAY consider the content to be a current representation of that resource at the time indicated by the message origination date.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 330
+      line: 342
   - label: content_location_and_uri_consistent (7)
     section: § 8.7
     snippet: In the latter case (Section 4), the referenced URI is relative to the target URI ([URI], Section 5).
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 358
+      line: 370
   - label: content_location_and_uri_consistent (8)
     section: § 8.7
     snippet: Such a claim can only be trusted if both identifiers share the same resource owner, which cannot be programmatically determined via HTTP.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 421
+      line: 433
   - label: content_location_and_uri_consistent (9)
     section: § 8.7
     snippet: The "Content-Location" header field references a URI that can be used as an identifier for a specific resource corresponding to the representation in this message's content.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 203
+      line: 209
   - label: content_location_and_uri_consistent (10)
     section: § 8.7
     snippet: The field value is either an absolute-URI or a partial-URI.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 274
+      line: 280
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 314
+      line: 326
   - label: content_type_present
     section: § 15.3.6
     snippet: Since the 205 status code implies that no additional content will be provided, a server MUST NOT generate content in a 205 response.
@@ -5801,7 +5801,7 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 47
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 196
+      line: 202
     - file: lint-http-rules/src/rules/redirect_status_and_location_valid.rs
       line: 184
   - label: context_fields_direction (8)
@@ -6131,7 +6131,7 @@ sources:
     snippet: For OPTIONS (Section 9.3.7), the request target can be a single asterisk ("*").
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 447
+      line: 453
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
       line: 231
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
@@ -6141,7 +6141,7 @@ sources:
     snippet: These forms MUST NOT be used with other methods.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 448
+      line: 454
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
       line: 232
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
@@ -6151,19 +6151,19 @@ sources:
     snippet: A server MUST reject a CONNECT request that targets an empty or invalid port number, typically by responding with a 400 (Bad Request) status code.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 82
+      line: 87
   - label: http2_pseudo_headers_valid (4)
     section: § 9.3.6
     snippet: CONNECT uses a special form of request target, unique to this method, consisting of only the host and port number of the tunnel destination, separated by a colon.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 80
+      line: 85
   - label: http2_pseudo_headers_valid (5)
     section: § 9.3.6
     snippet: There is no default port; a client MUST send the port number even if the CONNECT request is based on a URI reference that contains an authority component with an elided port (Section 4.1).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 81
+      line: 86
   - label: if_match_etag_syntax
     section: § 13.1.1
     snippet: 'If-Match = "*" / #entity-tag'
@@ -7011,7 +7011,7 @@ sources:
     - file: lint-http-rules/src/rules/charset_registered.rs
       line: 322
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 244
+      line: 250
     - file: lint-http-rules/src/rules/content_type_valid.rs
       line: 243
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
@@ -7233,7 +7233,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 397
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 239
+      line: 245
     - file: lint-http-rules/src/rules/max_forwards_numeric.rs
       line: 177
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
@@ -7493,7 +7493,7 @@ sources:
     snippet: A URI reference is resolved to its absolute form in order to obtain the "target URI".
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 416
+      line: 422
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
       line: 266
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
@@ -7503,7 +7503,7 @@ sources:
     snippet: Host = uri-host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1242
+      line: 1248
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 129
     - file: lint-http-rules/src/rules/host_header.rs
@@ -7515,19 +7515,19 @@ sources:
     snippet: In HTTP/2 [HTTP/2] and HTTP/3 [HTTP/3], the Host header field is, in some cases, supplanted by the ":authority" pseudo-header field of a request's control data.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 418
+      line: 424
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 316
     - file: lint-http-rules/src/rules/host_header.rs
       line: 52
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 427
+      line: 433
   - label: lint-http-rules/src/helpers/uri.rs (3)
     section: § 7.2
     snippet: The "Host" header field in a request provides the host and port information from the target URI, enabling the origin server to distinguish among resources while servicing requests for multiple host names.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 417
+      line: 423
   - label: If-None-Match weak comparison
     section: § 13.1.2
     snippet: A recipient MUST use the weak comparison function when comparing entity tags for If-None-Match
@@ -7591,31 +7591,31 @@ sources:
     snippet: A Location field value cannot allow a list of members because the comma list separator is a valid data character within a URI-reference.
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 220
+      line: 226
   - label: location_header_uri_valid (2)
     section: § 10.2.2
     snippet: If an invalid message is sent with multiple Location field lines, a recipient along the path might combine those field lines into one value.
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 221
+      line: 227
   - label: Location grammar
     section: § 10.2.2
     snippet: Location = URI-reference
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 197
+      line: 203
   - label: location_header_uri_valid (3)
     section: § 16.3.2.2
     snippet: because URIs can include commas, it is not possible to reliably distinguish between a single value that includes a comma from two values
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 222
+      line: 228
   - label: location_header_uri_valid (4)
     section: § 5.5
     snippet: Fields that expect to contain a comma within a member, such as within an HTTP-date or URI-reference element, ought to be defined with delimiters around that element to distinguish any comma within that data from potential list separators.
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 219
+      line: 225
   - label: location_on_redirect_present
     section: § 10.2.2
     snippet: For 201 (Created) responses, the Location value refers to the primary resource created by the request.
@@ -9835,7 +9835,7 @@ sources:
     snippet: authority-form = uri-host ":" port
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 79
+      line: 84
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 64
   - label: http_version_syntax
@@ -9919,7 +9919,7 @@ sources:
     snippet: A server MUST respond with a 400 (Bad Request) status code to any HTTP/1.1 request message that lacks a Host header field and to any request message that contains more than one Host header field line or a Host header field with an invalid field value.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 422
+      line: 428
     - file: lint-http-rules/src/rules/host_header.rs
       line: 200
   - label: request-target forms
@@ -9927,9 +9927,9 @@ sources:
     snippet: request-target = origin-form / absolute-form / authority-form / asterisk-form
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 454
+      line: 460
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 527
+      line: 533
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 13
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
@@ -9939,19 +9939,19 @@ sources:
     snippet: If the request-target is in authority-form, the target URI's authority component is the request-target.  Otherwise, the target URI's authority component is the field value of the Host header field.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 420
+      line: 426
   - label: lint-http-rules/src/helpers/uri.rs (3)
     section: § 3.3
     snippet: If there is no Host header field or if its field value is empty or invalid, the target URI's authority component is empty.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 421
+      line: 427
   - label: lint-http-rules/src/helpers/uri.rs (4)
     section: § 3.3
     snippet: The target URI is the request-target when the request-target is in absolute-form.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 419
+      line: 425
     - file: lint-http-rules/src/rules/post_creates_resource.rs
       line: 161
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
@@ -10284,7 +10284,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 354
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 446
+      line: 452
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 235
   - label: host_and_authority_consistent (2)
@@ -10314,7 +10314,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 337
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 478
+      line: 484
   - label: host_and_authority_consistent (6)
     section: § 8.3.1
     snippet: The values of fields need to be normalized to compare them (see Section 6.2 of [RFC3986]).
@@ -10326,37 +10326,37 @@ sources:
     snippet: A field value MUST NOT start or end with an ASCII whitespace character (ASCII SP or HTAB, 0x20 or 0x09).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 393
+      line: 399
   - label: http2_pseudo_headers_valid (2)
     section: § 8.3
     snippet: Endpoints MUST treat a request or response that contains undefined or invalid pseudo-header fields as malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 381
+      line: 387
   - label: http2_pseudo_headers_valid (3)
     section: § 8.3.1
     snippet: '":authority" MUST NOT include the deprecated userinfo subcomponent for "http" or "https" schemed URIs.'
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 518
+      line: 526
   - label: http2_pseudo_headers_valid (4)
     section: § 8.3.1
     snippet: '":scheme" is not restricted to "http" and "https" schemed URIs.'
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 483
+      line: 489
   - label: http2_pseudo_headers_valid (5)
     section: § 8.3.1
     snippet: All HTTP/2 requests MUST include exactly one valid value for the ":method", ":scheme", and ":path" pseudo-header fields, unless they are CONNECT requests (Section 8.5).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 458
+      line: 464
   - label: http2_pseudo_headers_valid (6)
     section: § 8.3.1
     snippet: The ":method" pseudo-header field includes the HTTP method (Section 9 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 376
+      line: 382
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
       line: 320
   - label: http2_pseudo_headers_valid (7)
@@ -10364,51 +10364,51 @@ sources:
     snippet: The ":scheme" pseudo-header field includes the scheme portion of the request target.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 477
+      line: 483
   - label: http2_pseudo_headers_valid (8)
     section: § 8.3.1
     snippet: This pseudo-header field MUST NOT be empty for "http" or "https" URIs; "http" or "https" URIs that do not contain a path component MUST include a value of '/'.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 457
+      line: 463
   - label: http2_pseudo_headers_valid (9)
     section: § 8.3.2
     snippet: For HTTP/2 responses, a single ":status" pseudo-header field is defined that carries the HTTP status code field (see Section 15 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 566
+      line: 574
   - label: http2_pseudo_headers_valid (10)
     section: § 8.3.2
     snippet: This pseudo-header field MUST be included in all responses, including interim responses; otherwise, the response is malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 567
+      line: 575
   - label: http2_pseudo_headers_valid (11)
     section: § 8.5
     snippet: A CONNECT request that does not conform to these restrictions is malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 419
+      line: 425
   - label: http2_pseudo_headers_valid (12)
     section: § 8.5
     snippet: A proxy that supports CONNECT establishes a TCP connection [TCP] to the host and port identified in the ":authority" pseudo-header field.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 161
+      line: 166
   - label: http2_pseudo_headers_valid (13)
     section: § 8.5
     snippet: The ":authority" pseudo-header field contains the host and port to connect to (equivalent to the authority-form of the request-target of CONNECT requests; see Section 3.2.3 of [HTTP/1.1]).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 78
+      line: 83
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 418
+      line: 424
   - label: http2_pseudo_headers_valid (14)
     section: § 8.5
     snippet: The ":method" pseudo-header field is set to CONNECT.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 404
+      line: 410
   - label: lint-http-core/src/http_version.rs
     section: § 8.3.1
     snippet: All HTTP/2 requests implicitly have a protocol version of "2.0"


### PR DESCRIPTION
`validate_scheme_if_present` located a scheme inside a larger value, asked the typed reader what was wrong with it, and rendered the answer back into a sentence beginning "Invalid scheme in value" — inside callers that each go on to say which value it was. It hands back the defect now, so a `Location`, a `Content-Location` and an HTTP/2 request target report the same three ids a `Referer`, a `Forwarded` `proto` and a `Link` target already do, and each says which field carried the scheme in its own words rather than twice.

The one converted `cited` site was citing § 8.3.1, which says `:scheme` carries the scheme portion of the target and is deliberately not restricted to http and https — the pseudo-header's own statement, kept in the rule. What the defects carry is § 3.1's production.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
