### PR TITLE
An opaque-tag is not a quoted-string

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1251,6 +1251,18 @@ severity = "warn"
 # Domain name holds whitespace or a control character
 severity = "warn"
 
+[violations.etag_character_forbidden]
+# Entity-tag holds a character etagc does not admit
+severity = "warn"
+
+[violations.etag_delimiter_missing]
+# Entity-tag is not quoted
+severity = "warn"
+
+[violations.etag_weak_indicator_invalid]
+# Weakness indicator is not written W/
+severity = "warn"
+
 [violations.http_date_malformed]
 # Timestamp derives from no HTTP-date format
 severity = "warn"

--- a/docs/rules/conditional_request_handling.md
+++ b/docs/rules/conditional_request_handling.md
@@ -16,7 +16,7 @@ Warn when conditional requests are used without a prior validator (ETag / Last-M
 - [RFC 9110 §13.1.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.2): If-None-Match: GET/HEAD with a false condition MUST get 304
 - [RFC 9110 §13.1.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.3): If-Modified-Since: a false condition SHOULD get 304
 - [RFC 9110 §13.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-13.2): Evaluation of Preconditions (precedence rules)
-- [RFC 9110 §8.8.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3): ETag header field
+- [RFC 9110 §8.8.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3): Entity Tags — `entity-tag = [ weak ] opaque-tag`, `weak = %s"W/"` (case-sensitive by the `%s` prefix), `opaque-tag = DQUOTE *etagc DQUOTE`, and `etagc` as VCHAR minus the DQUOTE plus obs-text
 - [RFC 9110 §8.8.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.2): Last-Modified header field
 
 ## Configuration

--- a/docs/rules/etag_syntax.md
+++ b/docs/rules/etag_syntax.md
@@ -12,7 +12,7 @@ Validate that the `ETag` response header contains a single, syntactically valid 
 
 ## Specifications
 
-- [RFC 9110 §8.8.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3): `ETag` header field, the `ETag = entity-tag` field production, and the `entity-tag` grammar
+- [RFC 9110 §8.8.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3): Entity Tags — `entity-tag = [ weak ] opaque-tag`, `weak = %s"W/"` (case-sensitive by the `%s` prefix), `opaque-tag = DQUOTE *etagc DQUOTE`, and `etagc` as VCHAR minus the DQUOTE plus obs-text
 - [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order: a non-list field (such as `ETag = entity-tag`) must not appear as multiple field lines
 
 ## Configuration

--- a/docs/rules/if_match_etag_syntax.md
+++ b/docs/rules/if_match_etag_syntax.md
@@ -12,7 +12,7 @@ SPDX-License-Identifier: ISC
 
 ## Specifications
 
-- [RFC 9110 §8.8.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3): ETag header field
+- [RFC 9110 §8.8.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3): Entity Tags — `entity-tag = [ weak ] opaque-tag`, `weak = %s"W/"` (case-sensitive by the `%s` prefix), `opaque-tag = DQUOTE *etagc DQUOTE`, and `etagc` as VCHAR minus the DQUOTE plus obs-text
 - [RFC 9110 §13.1.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.1): If-Match
 
 ## Configuration

--- a/docs/rules/if_none_match_etag_syntax.md
+++ b/docs/rules/if_none_match_etag_syntax.md
@@ -12,7 +12,7 @@ SPDX-License-Identifier: ISC
 
 ## Specifications
 
-- [RFC 9110 §8.8.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3): ETag header field
+- [RFC 9110 §8.8.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3): Entity Tags — `entity-tag = [ weak ] opaque-tag`, `weak = %s"W/"` (case-sensitive by the `%s` prefix), `opaque-tag = DQUOTE *etagc DQUOTE`, and `etagc` as VCHAR minus the DQUOTE plus obs-text
 - [RFC 9110 §13.1.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.2): If-None-Match
 
 ## Configuration

--- a/lint-http-rules/src/helpers/validator.rs
+++ b/lint-http-rules/src/helpers/validator.rs
@@ -13,11 +13,10 @@
 //! only ever the *weak* comparison; the prefix it discards is exactly what a
 //! strong comparison turns on, which is why it must not be used to prepare one.
 //!
-//! [`validate_entity_tag`] is the grammar underneath all of it.
+//! [`check_entity_tag`] is the grammar underneath all of it.
 
 use crate::helpers::headers::get_header_str;
 use crate::helpers::list::split_commas_respecting_quotes;
-use crate::helpers::quoted_string::validate_quoted_string;
 use hyper::HeaderMap;
 
 /// Weak-compare an `If-None-Match` header value against a known ETag.
@@ -132,23 +131,93 @@ pub fn normalize_etag(s: &str) -> String {
 /// ostensibly for — where it made `If-None-Match: "abc", *` a conforming list.
 /// **A tolerance that every honest caller has to undo is not a tolerance.**
 // cite(RFC 9110 § 8.8.3): "An entity tag consists of an opaque quoted string, possibly prefixed by a weakness indicator."
-pub fn validate_entity_tag(val: &str) -> Result<(), String> {
+pub fn check_entity_tag(val: &str) -> Result<(), EntityTagDefect> {
     // cite(RFC 9110 § 8.8.3, label: entity-tag grammar): "entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE"
     let s = val.trim();
 
     let rest = if let Some(stripped) = s.strip_prefix("W/") {
         stripped
+    } else if s.len() >= 2 && s[..2].eq_ignore_ascii_case("w/") {
+        // `%s"W/"` — the `%s` prefix is what makes the case part of the
+        // production, and RFC 5234 § 2.3 says an unprefixed string would have
+        // been case-insensitive. A `w/` is therefore a weakness indicator the
+        // sender meant and the grammar does not generate, which is a different
+        // finding from a tag that never opened its quotes.
+        // cite(RFC 5234 § 2.3): "ABNF strings are case insensitive and the character set for these strings is US-ASCII."
+        return Err(EntityTagDefect::WeakIndicatorInvalid);
     } else {
         s
     };
-    // rest must be a quoted-string
-    validate_quoted_string(rest)
+
+    // `opaque-tag = DQUOTE *etagc DQUOTE`, and the interior is **not** a
+    // `quoted-string`: `etagc` holds the backslash as an ordinary character
+    // and holds no DQUOTE at all, so nothing inside an opaque-tag is an
+    // escape. Reading one with the quoted-string reader — which this did —
+    // reported `"a\"` for a trailing escape the production generates, and
+    // accepted `"a\"b"` as an escaped DQUOTE the production cannot hold.
+    let Some(inner) = rest
+        .strip_prefix('"')
+        .and_then(|open| open.strip_suffix('"'))
+    else {
+        return Err(EntityTagDefect::DelimiterMissing);
+    };
+
+    match inner.chars().find(|&c| !is_etagc(c)) {
+        Some(c) => Err(EntityTagDefect::BadCharacter(c)),
+        None => Ok(()),
+    }
+}
+
+/// `etagc`, over a single character.
+///
+/// The class is the visible US-ASCII minus the DQUOTE that delimits the tag,
+/// plus `obs-text`. It is written as the ranges the production writes rather
+/// than as "visible, except the quote", because the exclusion at %x22 is the
+/// whole reason the tag can be scanned at all.
+fn is_etagc(c: char) -> bool {
+    // cite(RFC 9110 § 8.8.3): "etagc      = %x21 / %x23-7E / obs-text ; VCHAR except double quotes, plus obs-text"
+    c == '\u{21}' || ('\u{23}'..='\u{7e}').contains(&c) || c >= '\u{80}'
+}
+
+/// Why a value is not an `entity-tag`.
+///
+/// Three defects and no fourth: the production is a two-character prefix, two
+/// delimiters and a character class, and there is nothing else in it to fail.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EntityTagDefect {
+    /// A weakness indicator in any spelling but `W/`.
+    WeakIndicatorInvalid,
+    /// No opening DQUOTE, or nothing closing it.
+    DelimiterMissing,
+    /// A character `etagc` does not admit — a DQUOTE inside the tag, a control
+    /// octet, DEL.
+    BadCharacter(char),
+}
+
+impl EntityTagDefect {
+    /// The finding fragment. Callers name the field the tag came from and put
+    /// this after it.
+    pub fn message(self) -> String {
+        match self {
+            Self::WeakIndicatorInvalid => {
+                "weakness indicator must be written \"W/\", which is case-sensitive".to_string()
+            }
+            Self::DelimiterMissing => {
+                "entity-tag must be an opaque tag between two double quotes".to_string()
+            }
+            Self::BadCharacter(c) => format!(
+                "entity-tag holds {}, which no etagc admits",
+                crate::helpers::shown::describe_char(c)
+            ),
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use hyper::header::HeaderValue;
+    use rstest::rstest;
 
     #[test]
     fn strong_etag_and_last_modified_are_returned() {
@@ -213,19 +282,37 @@ mod tests {
 
     // Entity-tag helper tests
     #[test]
-    fn validate_entity_tag_cases() {
+    fn check_entity_tag_cases() {
         // The production is `[ weak ] opaque-tag` and neither part generates a
         // `*`. This asserted the opposite, which is how `If-None-Match: "abc", *`
         // passed as a conforming list; the `*` is the *other* alternative of the
         // two conditional fields' own grammars, and each of them decides it on
         // the whole field value now.
-        assert!(validate_entity_tag("*").is_err());
-        assert!(validate_entity_tag("\"abc\"").is_ok());
+        assert!(check_entity_tag("*").is_err());
+        assert!(check_entity_tag("\"abc\"").is_ok());
         // `etagc` admits the comma, so this is one tag and not two.
-        assert!(validate_entity_tag("\"a,b\"").is_ok());
-        assert!(validate_entity_tag("W/\"abc\"").is_ok());
-        assert!(validate_entity_tag(" W/\"abc\" ").is_ok()); // leading/trailing whitespace tolerated
-        assert!(validate_entity_tag("abc").is_err()); // missing quotes
-        assert!(validate_entity_tag("W/abc").is_err()); // weak prefix without quoted-string
+        assert!(check_entity_tag("\"a,b\"").is_ok());
+        assert!(check_entity_tag("W/\"abc\"").is_ok());
+        assert!(check_entity_tag(" W/\"abc\" ").is_ok()); // leading/trailing whitespace tolerated
+        assert!(check_entity_tag("abc").is_err()); // missing quotes
+        assert!(check_entity_tag("W/abc").is_err()); // weak prefix without an opaque-tag
+    }
+
+    /// The interior is `*etagc` and not a `quoted-string`, which is the whole
+    /// of what separates this reader from the one it replaced. A backslash is
+    /// an ordinary `etagc`, so a tag may end in one; a DQUOTE is not, so an
+    /// "escaped" one closed the tag early and left content behind.
+    #[rstest]
+    #[case("\"a\\\"", Ok(()))]
+    #[case("\"a\\\"b\"", Err(EntityTagDefect::BadCharacter('"')))]
+    #[case("w/\"abc\"", Err(EntityTagDefect::WeakIndicatorInvalid))]
+    #[case("W\"abc\"", Err(EntityTagDefect::DelimiterMissing))]
+    #[case("\"\"", Ok(()))]
+    #[case("\"", Err(EntityTagDefect::DelimiterMissing))]
+    fn an_opaque_tag_is_not_a_quoted_string(
+        #[case] value: &str,
+        #[case] expected: Result<(), EntityTagDefect>,
+    ) {
+        assert_eq!(check_entity_tag(value), expected, "{value}");
     }
 }

--- a/lint-http-rules/src/rules/conditional_request_handling.rs
+++ b/lint-http-rules/src/rules/conditional_request_handling.rs
@@ -4,6 +4,7 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::etag::RFC_9110_8_8_3;
 
 /// Stateful checks for conditional requests and their responses.
 ///
@@ -40,12 +41,6 @@ const RFC_9110_13_2: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("13.2"),
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.2",
     note: "Evaluation of Preconditions (precedence rules)",
-};
-const RFC_9110_8_8_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("8.8.3"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3",
-    note: "ETag header field",
 };
 const RFC_9110_8_8_2: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",

--- a/lint-http-rules/src/rules/etag_syntax.rs
+++ b/lint-http-rules/src/rules/etag_syntax.rs
@@ -4,6 +4,25 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::etag::{
+    entity_tag_defect, ETAG_CHARACTER_FORBIDDEN, ETAG_DELIMITER_MISSING,
+    ETAG_WEAK_INDICATOR_INVALID, RFC_9110_8_8_3,
+};
+use crate::violations::ViolationDef;
+
+/// The production's three defects, which is everything this rule says about a
+/// value that is not an entity-tag.
+///
+/// `ETag = entity-tag` and § 8.8.3 adds nothing to the production, so the ids
+/// are the production's and the two conditional-field rules answer with the
+/// same three. What stays this rule's own is what an `ETag` *field* may be: a
+/// `*` is not a tag but is the shape a server copies from the conditional
+/// fields, and more than one field line is a statement about the message.
+static DECLARED: &[&ViolationDef] = &[
+    &ETAG_WEAK_INDICATOR_INVALID,
+    &ETAG_DELIMITER_MISSING,
+    &ETAG_CHARACTER_FORBIDDEN,
+];
 
 /// Validate `ETag` header values: must be a single entity-tag (strong or weak quoted-string)
 /// per RFC 9110 §8.8.3. Also flags invalid UTF-8 and multiple header fields.
@@ -12,12 +31,6 @@ pub struct EtagSyntax;
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_9110_8_8_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("8.8.3"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3",
-    note: "`ETag` header field, the `ETag = entity-tag` field production, and the `entity-tag` grammar",
-};
 const RFC_9110_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
     section: Some("5.3"),
@@ -46,6 +59,10 @@ severity = "warn"
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[RFC_9110_8_8_3, RFC_9110_5_3]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -112,7 +129,7 @@ impl Rule for EtagSyntax {
 
                 let t = s.trim();
                 // The `*` kept its own branch, and the reason changed. It stood here
-                // because `validate_entity_tag` admitted a `*` -- which no
+                // because `check_entity_tag` admitted a `*` -- which no
                 // `entity-tag` generates, and the helper refuses now -- so the branch
                 // is no longer a correction of the helper. It stays because this
                 // finding is worth more than the helper's: `*` is the one non-tag an
@@ -124,11 +141,12 @@ impl Rule for EtagSyntax {
                                 .into()));
                 }
 
-                // The entity-tag grammar itself (§8.8.3) is owned by `validate_entity_tag`.
-                if let Err(msg) = crate::helpers::validator::validate_entity_tag(t) {
-                    return Some(
-                        self.violation(ctx.severity, format!("ETag header invalid: {}", msg)),
-                    );
+                // The entity-tag grammar itself (§8.8.3) is owned by `check_entity_tag`.
+                if let Err(defect) = crate::helpers::validator::check_entity_tag(t) {
+                    return Some(ctx.report_with(
+                        entity_tag_defect(defect),
+                        format!("ETag header invalid: {}", defect.message()),
+                    ));
                 }
             }
 
@@ -157,6 +175,49 @@ static REGISTRATION: &dyn crate::rules::Rule = &EtagSyntax;
 mod tests {
     use super::*;
     use rstest::rstest;
+
+    /// One production, three fields: an `ETag` a server sends and the two
+    /// conditional lists a client sends back draw the same id for the same
+    /// value, out of rules that share no code and read opposite directions of
+    /// the exchange.
+    #[rstest]
+    #[case("abc", "etag_delimiter_missing")]
+    #[case("w/\"abc\"", "etag_weak_indicator_invalid")]
+    #[case("\"a\"b\"", "etag_character_forbidden")]
+    fn a_validator_is_the_same_defect_in_both_directions(#[case] value: &str, #[case] id: &str) {
+        let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
+        tx.response.as_mut().expect("a response").headers =
+            crate::test_helpers::make_headers_from_pairs(&[("etag", value)]);
+        let found = crate::test_helpers::run_rule(
+            &EtagSyntax,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_severity("etag_syntax", "warn"),
+        )
+        .expect("a finding");
+        assert_eq!(found.violation, id, "{value}");
+
+        for (rule, field) in [
+            (
+                &super::super::if_match_etag_syntax::IfMatchEtagSyntax as &dyn crate::rules::Rule,
+                "if-match",
+            ),
+            (
+                &super::super::if_none_match_etag_syntax::IfNoneMatchEtagSyntax,
+                "if-none-match",
+            ),
+        ] {
+            let tx = crate::test_helpers::make_test_transaction_with_headers(&[(field, value)]);
+            let found = crate::test_helpers::run_rule(
+                rule,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &crate::test_helpers::make_test_config_with_severity(rule.id(), "warn"),
+            )
+            .expect("a finding");
+            assert_eq!(found.violation, id, "{field}: {value}");
+        }
+    }
 
     #[rstest]
     #[case(Some("\"abc\""), false)]

--- a/lint-http-rules/src/rules/if_match_etag_syntax.rs
+++ b/lint-http-rules/src/rules/if_match_etag_syntax.rs
@@ -4,21 +4,34 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::etag::{
+    entity_tag_defect, ETAG_CHARACTER_FORBIDDEN, ETAG_DELIMITER_MISSING,
+    ETAG_WEAK_INDICATOR_INVALID, RFC_9110_8_8_3,
+};
+use crate::violations::ViolationDef;
+
+/// The production's three defects, borrowed whole.
+///
+/// The field is `"*" / #entity-tag`: the `*` is the other alternative and the
+/// members are § 8.8.3's production, restated nowhere. So a member that is not
+/// a tag draws the same id an `ETag` carrying the same value draws, and what
+/// stays this rule's own is the alternation — a `*` written as a member rather
+/// than as the whole value — and the empty list element the list construct
+/// forbids.
+static DECLARED: &[&ViolationDef] = &[
+    &ETAG_WEAK_INDICATOR_INVALID,
+    &ETAG_DELIMITER_MISSING,
+    &ETAG_CHARACTER_FORBIDDEN,
+];
 
 /// `If-Match` header must be either `*` or a comma-separated list of entity-tags
 /// (possibly weak `W/"..."`). Validates the field grammar (RFC 9110 §13.1.1); the
-/// entity-tag grammar itself is RFC 9110 §8.8.3, owned by `validate_entity_tag`.
+/// entity-tag grammar itself is RFC 9110 §8.8.3, owned by `check_entity_tag`.
 pub struct IfMatchEtagSyntax;
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_9110_8_8_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("8.8.3"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3",
-    note: "ETag header field",
-};
 const RFC_9110_13_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
     section: Some("13.1.1"),
@@ -47,6 +60,10 @@ severity = "warn"
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[RFC_9110_8_8_3, RFC_9110_13_1_1]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -117,7 +134,7 @@ impl Rule for IfMatchEtagSyntax {
             // The field is `*` **or** a comma-separated list of entity-tags, and the
             // two are alternatives: `*` is the whole field value and is not a member
             // the list may hold. It was asked of each member instead -- through
-            // `validate_entity_tag`, which used to admit it -- so `If-Match:
+            // `check_entity_tag`, which used to admit it -- so `If-Match:
             // "abc", *` derived from neither alternative and passed as a conforming
             // list. `entity-tag` has no `*` in it; § 13.1.1's production is where
             // the `*` lives, and this is the construct that production governs.
@@ -159,13 +176,13 @@ impl Rule for IfMatchEtagSyntax {
                         "If-Match header contains an empty list element".into(),
                     ));
                 }
-                if let Err(msg) = crate::helpers::validator::validate_entity_tag(member) {
-                    return Some(self.violation(
-                        ctx.severity,
+                if let Err(defect) = crate::helpers::validator::check_entity_tag(member) {
+                    return Some(ctx.report_with(
+                        entity_tag_defect(defect),
                         format!(
                             "If-Match header has invalid member '{}': {}",
                             crate::helpers::shown::shown_in_finding(member),
-                            msg
+                            defect.message()
                         ),
                     ));
                 }

--- a/lint-http-rules/src/rules/if_none_match_etag_syntax.rs
+++ b/lint-http-rules/src/rules/if_none_match_etag_syntax.rs
@@ -4,21 +4,34 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::etag::{
+    entity_tag_defect, ETAG_CHARACTER_FORBIDDEN, ETAG_DELIMITER_MISSING,
+    ETAG_WEAK_INDICATOR_INVALID, RFC_9110_8_8_3,
+};
+use crate::violations::ViolationDef;
+
+/// The production's three defects, borrowed whole.
+///
+/// The field is `"*" / #entity-tag`: the `*` is the other alternative and the
+/// members are § 8.8.3's production, restated nowhere. So a member that is not
+/// a tag draws the same id an `ETag` carrying the same value draws, and what
+/// stays this rule's own is the alternation — a `*` written as a member rather
+/// than as the whole value — and the empty list element the list construct
+/// forbids.
+static DECLARED: &[&ViolationDef] = &[
+    &ETAG_WEAK_INDICATOR_INVALID,
+    &ETAG_DELIMITER_MISSING,
+    &ETAG_CHARACTER_FORBIDDEN,
+];
 
 /// `If-None-Match` header must be either `*` or a comma-separated list of entity-tags
 /// (possibly weak `W/"..."`). Validates the field grammar (RFC 9110 §13.1.2); the
-/// entity-tag grammar itself is RFC 9110 §8.8.3, owned by `validate_entity_tag`.
+/// entity-tag grammar itself is RFC 9110 §8.8.3, owned by `check_entity_tag`.
 pub struct IfNoneMatchEtagSyntax;
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_9110_8_8_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("8.8.3"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3",
-    note: "ETag header field",
-};
 const RFC_9110_13_1_2: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
     section: Some("13.1.2"),
@@ -47,6 +60,10 @@ severity = "warn"
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[RFC_9110_8_8_3, RFC_9110_13_1_2]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -117,7 +134,7 @@ impl Rule for IfNoneMatchEtagSyntax {
             // The field is `*` **or** a comma-separated list of entity-tags, and the
             // two are alternatives: `*` is the whole field value and is not a member
             // the list may hold. It was asked of each member instead -- through
-            // `validate_entity_tag`, which used to admit it -- so `If-None-Match:
+            // `check_entity_tag`, which used to admit it -- so `If-None-Match:
             // "abc", *` derived from neither alternative and passed as a conforming
             // list. `entity-tag` has no `*` in it; § 13.1.2's production is where
             // the `*` lives, and this is the construct that production governs.
@@ -160,13 +177,13 @@ impl Rule for IfNoneMatchEtagSyntax {
                         "If-None-Match header contains an empty list element".into(),
                     ));
                 }
-                if let Err(msg) = crate::helpers::validator::validate_entity_tag(member) {
-                    return Some(self.violation(
-                        ctx.severity,
+                if let Err(defect) = crate::helpers::validator::check_entity_tag(member) {
+                    return Some(ctx.report_with(
+                        entity_tag_defect(defect),
                         format!(
                             "If-None-Match header has invalid member '{}': {}",
                             crate::helpers::shown::shown_in_finding(member),
-                            msg
+                            defect.message()
                         ),
                     ));
                 }

--- a/lint-http-rules/src/rules/range_request_and_caching.rs
+++ b/lint-http-rules/src/rules/range_request_and_caching.rs
@@ -237,9 +237,9 @@ impl Rule for RangeRequestAndCaching {
             // A malformed stored tag is the server's defect and `etag_syntax`
             // reports it there. Asking the client to echo it would be this rule
             // charging one party for another's field. The `stored_etag == "*"` beside
-            // this was a workaround for `validate_entity_tag` admitting a `*`, which
+            // this was a workaround for `check_entity_tag` admitting a `*`, which
             // no `entity-tag` generates; the helper answers it now.
-            if crate::helpers::validator::validate_entity_tag(&stored_etag).is_err() {
+            if crate::helpers::validator::check_entity_tag(&stored_etag).is_err() {
                 return None;
             }
 
@@ -663,7 +663,7 @@ mod tests {
                 // date would make *both* halves false and fail the `!=` below
                 // with a message about the value not being either — so the fix
                 // is the example, not this line.
-                let tag_ok = crate::helpers::validator::validate_entity_tag(value).is_ok();
+                let tag_ok = crate::helpers::validator::check_entity_tag(value).is_ok();
                 let date_ok = crate::http_date::is_valid_imf_fixdate(value);
                 match name.to_ascii_lowercase().as_str() {
                     "etag" | "if-none-match" => {

--- a/lint-http-rules/src/violations/etag.rs
+++ b/lint-http-rules/src/violations/etag.rs
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `entity-tag` defects — the three ways a validator is not one.
+//!
+//! One production, three fields: an `ETag` a response sends, and the
+//! `If-Match` and `If-None-Match` lists a request sends back. RFC 9110 § 8.8.3
+//! writes `entity-tag = [ weak ] opaque-tag` once and the conditional fields
+//! take it by name, so a tag that never opened its quotes is the same defect
+//! whichever direction it travelled in — which is worth saying out loud here,
+//! because the two conditional rules are the pair Phase 4 will look at first
+//! and this is the part of them that was never each rule's own.
+//!
+//! **The interior is not a `quoted-string`, and reading it as one is what the
+//! reader beneath these entries had been doing.** `etagc` admits the backslash
+//! as an ordinary character and admits no DQUOTE at all: there is no escape
+//! inside an opaque-tag, so `"a\"` is a tag ending in a backslash and `"a\"b"`
+//! is a tag that closed early with `b"` left over. The quoted-string reader
+//! answered the opposite on both.
+
+use crate::helpers::validator::EntityTagDefect;
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::{defects, ViolationDef};
+
+/// The whole production and its character class, which is one section: the
+/// weakness indicator, the two delimiters and `etagc`.
+pub const RFC_9110_8_8_3: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.8.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3",
+    note: "Entity Tags — `entity-tag = [ weak ] opaque-tag`, `weak = %s\"W/\"` (case-sensitive by the `%s` prefix), `opaque-tag = DQUOTE *etagc DQUOTE`, and `etagc` as VCHAR minus the DQUOTE plus obs-text",
+};
+
+defects! {
+    /// A weakness indicator in any spelling but `W/`.
+    ///
+    /// `weak = %s"W/"`, and the `%s` is the whole of why this is a defect
+    /// rather than a preference: RFC 5234 § 2.3 makes an unprefixed ABNF string
+    /// case-insensitive, so the prefix is the author saying the case matters.
+    /// A `w/"abc"` is a sender who meant a weak validator and wrote a value the
+    /// production does not generate — which is a different finding from a tag
+    /// with no quotes at all, and was reported as one before this subject
+    /// existed.
+    ///
+    // cite(RFC 9110 § 8.8.3, label: weak indicator): "entity-tag = [ weak ] opaque-tag weak       = %s"W/""
+    ETAG_WEAK_INDICATOR_INVALID = {
+        id: "etag_weak_indicator_invalid",
+        title: "Weakness indicator is not written W/",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_8_8_3),
+    }
+
+    /// No opening DQUOTE, or nothing closing it.
+    ///
+    /// The `opaque-tag` *is* its two delimiters and what they enclose, so a
+    /// value missing one of them has no interior to examine rather than a bad
+    /// one — the same shape `quoted_string_delimiter_missing` has, at a
+    /// production that shares the delimiters and nothing else.
+    ///
+    // cite(RFC 9110 § 8.8.3, label: opaque-tag): "opaque-tag = DQUOTE *etagc DQUOTE"
+    ETAG_DELIMITER_MISSING = {
+        id: "etag_delimiter_missing",
+        title: "Entity-tag is not quoted",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_8_8_3),
+    }
+
+    /// A character `etagc` does not admit.
+    ///
+    /// One entry over the whole class, and the reason is the class: `%x21 /
+    /// %x23-7E / obs-text` is one line refusing the DQUOTE, the controls and
+    /// DEL together, and an operator who wants the tag re-quoted wants it
+    /// re-quoted whichever of them arrived. The DQUOTE is the reachable one —
+    /// a control octet cannot enter a `HeaderValue` — and it is also the
+    /// interesting one, because a tag holding a DQUOTE closed somewhere its
+    /// sender did not mean it to.
+    ///
+    // cite(RFC 9110 § 8.8.3): "etagc      = %x21 / %x23-7E / obs-text ; VCHAR except double quotes, plus obs-text"
+    ETAG_CHARACTER_FORBIDDEN = {
+        id: "etag_character_forbidden",
+        title: "Entity-tag holds a character etagc does not admit",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_8_8_3),
+    }
+}
+
+/// The defect a parsed [`EntityTagDefect`] reports as.
+pub fn entity_tag_defect(defect: EntityTagDefect) -> &'static ViolationDef {
+    match defect {
+        EntityTagDefect::WeakIndicatorInvalid => &ETAG_WEAK_INDICATOR_INVALID,
+        EntityTagDefect::DelimiterMissing => &ETAG_DELIMITER_MISSING,
+        EntityTagDefect::BadCharacter(_) => &ETAG_CHARACTER_FORBIDDEN,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Three variants, three ids: the prefix, the delimiters, the class.
+    #[test]
+    fn each_entity_tag_defect_maps_to_its_own_id() {
+        for (defect, id) in [
+            (
+                EntityTagDefect::WeakIndicatorInvalid,
+                "etag_weak_indicator_invalid",
+            ),
+            (EntityTagDefect::DelimiterMissing, "etag_delimiter_missing"),
+            (
+                EntityTagDefect::BadCharacter('"'),
+                "etag_character_forbidden",
+            ),
+        ] {
+            assert_eq!(entity_tag_defect(defect).id, id);
+        }
+    }
+
+    /// The severities came out flat, and that is a finding rather than an
+    /// omission: nothing here is invisible (a control octet cannot reach a
+    /// field value), nothing parses into something impossible, and every one of
+    /// the three is one sender writing one value the production does not
+    /// generate.
+    #[test]
+    fn the_three_defects_rank_together() {
+        for def in [
+            &ETAG_WEAK_INDICATOR_INVALID,
+            &ETAG_DELIMITER_MISSING,
+            &ETAG_CHARACTER_FORBIDDEN,
+        ] {
+            assert_eq!(def.default_severity, Severity::Warn);
+        }
+    }
+}

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -39,6 +39,7 @@ pub mod content_range;
 pub mod cookie;
 pub mod credentials;
 pub mod domain;
+pub mod etag;
 pub mod http_date;
 pub mod language;
 pub mod list;
@@ -355,7 +356,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 110;
+        const FLOOR: usize = 113;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1714,6 +1714,8 @@ sources:
       line: 232
     - file: lint-http-rules/src/helpers/uri.rs
       line: 67
+    - file: lint-http-rules/src/helpers/validator.rs
+      line: 146
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 242
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
@@ -5507,25 +5509,25 @@ sources:
     snippet: An origin server that evaluates an If-None-Match condition MUST NOT perform the requested method if the condition evaluates to false; instead, the origin server MUST respond with either a) the 304 (Not Modified) status code if the request method is GET or HEAD or b) the 412 (Precondition Failed) status code for all other request methods.
     cited_by:
     - file: lint-http-rules/src/rules/conditional_request_handling.rs
-      line: 141
+      line: 136
   - label: conditional_request_handling (2)
     section: § 13.1.2
     snippet: the 304 (Not Modified) status code if the request method is GET or HEAD
     cited_by:
     - file: lint-http-rules/src/rules/conditional_request_handling.rs
-      line: 98
+      line: 93
   - label: conditional_request_handling (3)
     section: § 13.1.3
     snippet: An origin server that evaluates an If-Modified-Since condition SHOULD NOT perform the requested method if the condition evaluates to false; instead, the origin server SHOULD generate a 304 (Not Modified) response
     cited_by:
     - file: lint-http-rules/src/rules/conditional_request_handling.rs
-      line: 170
+      line: 165
   - label: conditional_request_handling (4)
     section: § 13.2.2
     snippet: When the method is GET or HEAD, If-None-Match is not present, and If-Modified-Since is present, evaluate the If-Modified-Since precondition
     cited_by:
     - file: lint-http-rules/src/rules/conditional_request_handling.rs
-      line: 171
+      line: 166
   - label: connection_header_tokens_valid
     section: § 7.6.1
     snippet: A sender MUST NOT send a connection option corresponding to a field that is intended for all recipients of the content.  For example, Cache-Control is never appropriate as a connection option (Section 5.2 of [CACHING]).
@@ -5864,6 +5866,18 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
       line: 287
+  - label: weak indicator
+    section: § 8.8.3
+    snippet: entity-tag = [ weak ] opaque-tag weak       = %s"W/"
+    cited_by:
+    - file: lint-http-rules/src/violations/etag.rs
+      line: 47
+  - label: opaque-tag
+    section: § 8.8.3
+    snippet: opaque-tag = DQUOTE *etagc DQUOTE
+    cited_by:
+    - file: lint-http-rules/src/violations/etag.rs
+      line: 63
   - label: etag_or_last_modified_present
     section: § 8.8.2.1
     snippet: An origin server SHOULD send Last-Modified for any selected representation for which a last modification date can be reasonably and consistently determined
@@ -5881,7 +5895,7 @@ sources:
     snippet: The "ETag" field in a response provides the current entity tag for the selected representation, as determined at the conclusion of handling the request.
     cited_by:
     - file: lint-http-rules/src/rules/etag_syntax.rs
-      line: 99
+      line: 116
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 34
   - label: expect_header_valid
@@ -6171,15 +6185,7 @@ sources:
     snippet: 'If-Match = "*" / #entity-tag'
     cited_by:
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
-      line: 127
-  - label: if_match_etag_syntax (2)
-    section: § 8.8.3
-    snippet: etagc      = %x21 / %x23-7E / obs-text ; VCHAR except double quotes, plus obs-text
-    cited_by:
-    - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
-      line: 150
-    - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
-      line: 151
+      line: 144
   - label: if_modified_since_date_syntax
     section: § 13.1.3
     snippet: If-Modified-Since = HTTP-date
@@ -6205,7 +6211,7 @@ sources:
     snippet: 'If-None-Match = "*" / #entity-tag'
     cited_by:
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
-      line: 128
+      line: 145
     - file: lint-http-rules/src/rules/vary_header_cache_valid.rs
       line: 155
   - label: if_unmodified_since_date_syntax
@@ -6643,9 +6649,9 @@ sources:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 341
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
-      line: 155
+      line: 172
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
-      line: 156
+      line: 173
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 523
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
@@ -6681,9 +6687,9 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 389
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
-      line: 110
+      line: 127
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
-      line: 110
+      line: 127
     - file: lint-http-rules/src/rules/max_forwards_numeric.rs
       line: 153
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
@@ -6977,7 +6983,7 @@ sources:
     - file: lint-http-rules/src/rules/deprecation_header_syntax.rs
       line: 96
     - file: lint-http-rules/src/rules/etag_syntax.rs
-      line: 138
+      line: 156
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 369
     - file: lint-http-rules/src/rules/host_header.rs
@@ -7537,31 +7543,43 @@ sources:
     snippet: A recipient MUST use the weak comparison function when comparing entity tags for If-None-Match
     cited_by:
     - file: lint-http-rules/src/helpers/validator.rs
-      line: 32
+      line: 31
   - label: lint-http-rules/src/helpers/validator.rs
     section: § 8.8.3
     snippet: An entity tag consists of an opaque quoted string, possibly prefixed by a weakness indicator.
     cited_by:
     - file: lint-http-rules/src/helpers/validator.rs
-      line: 134
+      line: 133
     - file: lint-http-rules/src/rules/etag_syntax.rs
-      line: 121
+      line: 138
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
-      line: 128
+      line: 145
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
-      line: 129
+      line: 146
   - label: entity-tag grammar
     section: § 8.8.3
     snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/validator.rs
-      line: 136
+      line: 135
   - label: lint-http-rules/src/helpers/validator.rs (2)
+    section: § 8.8.3
+    snippet: etagc      = %x21 / %x23-7E / obs-text ; VCHAR except double quotes, plus obs-text
+    cited_by:
+    - file: lint-http-rules/src/helpers/validator.rs
+      line: 178
+    - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
+      line: 167
+    - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
+      line: 168
+    - file: lint-http-rules/src/violations/etag.rs
+      line: 82
+  - label: lint-http-rules/src/helpers/validator.rs (3)
     section: § 8.8.3.2
     snippet: two entity tags are equivalent if their opaque-tags match character-by-character, regardless of either or both being tagged as "weak".
     cited_by:
     - file: lint-http-rules/src/helpers/validator.rs
-      line: 111
+      line: 110
   - label: Vary grammar
     section: § 12.5.5
     snippet: 'Vary = #( "*" / field-name )'


### PR DESCRIPTION
`check_entity_tag` read the interior of an entity-tag with the quoted-string reader, and the two productions disagree in both directions: `etagc` admits the backslash as an ordinary character, so `"a\"` is a tag ending in one and was reported for a trailing escape; and it admits no DQUOTE at all, so `"a\"b"` is a tag that closed early with `b"` left over, and was accepted as an escaped quote. A weakness indicator written `w/` is now its own finding rather than a value that failed to open its quotes — `weak = %s"W/"`, and the `%s` prefix is what makes the case part of the production.

The three defects are declared by the `ETag` rule and by both conditional lists, which read the same production in opposite directions of the exchange and had worded it three times. What stays each rule's own is the alternation around the tag: a `*` is `ETag`'s implausible value and the conditional fields' whole field value, never a member.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
