### PR TITLE
Three subject docs name a note nobody can read

### DIFF
--- a/lint-http-rules/src/violations/bws.rs
+++ b/lint-http-rules/src/violations/bws.rs
@@ -27,8 +27,9 @@
 //! recipient's half in the same breath — a recipient MUST parse for the bad
 //! whitespace and remove it — so the value is read as intended and what is
 //! wrong is the spelling. **A requirement whose counterpart obliges the other
-//! party to cope is a requirement about hygiene**, which is 2.28's ranking read
-//! at a terminal instead of at a format.
+//! party to cope is a requirement about hygiene** — the same ranking the
+//! `http_date` subject makes for an obsolete timestamp, read at a terminal
+//! instead of at a format.
 
 use crate::lint::Severity;
 use crate::rules::SpecRef;

--- a/lint-http-rules/src/violations/http_date.rs
+++ b/lint-http-rules/src/violations/http_date.rs
@@ -27,8 +27,9 @@
 //! is retired. `not-a-date` names no instant at all, and a padded IMF-fixdate
 //! derives from a production that prints no whitespace — both are values a
 //! strict recipient refuses. So: **a value the specification obliges the other
-//! party to accept sits below one it does not**, which is 2.13's rule of thumb
-//! read through the recipient rather than through the sentence.
+//! party to accept sits below one it does not** — the ranking rule of thumb
+//! this catalogue uses, read through the recipient rather than through the
+//! sentence.
 
 use crate::http_date::HttpDateDefect;
 use crate::lint::Severity;

--- a/lint-http-rules/src/violations/token.rs
+++ b/lint-http-rules/src/violations/token.rs
@@ -101,8 +101,8 @@ defects! {
 /// The reader that found it — [`crate::helpers::token::find_invalid_token_char`]
 /// — answers with one `char` and no verdict, because the production draws no
 /// distinction inside "not a `tchar`". The catalogue does, so the sort happens
-/// here: this is the shape 2.10's bearer token settled, and the reason a coarse
-/// helper can feed a catalogue finer than itself.
+/// here: it is the shape `token68`'s bearer-token entries settled, and the
+/// reason a coarse helper can feed a catalogue finer than itself.
 pub fn token_character(c: char) -> &'static ViolationDef {
     match c.is_whitespace() || c.is_control() {
         true => &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -6283,7 +6283,7 @@ sources:
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
       line: 353
     - file: lint-http-rules/src/violations/bws.rs
-      line: 61
+      line: 62
   - label: lint-http-core/src/http_date.rs
     section: § 5.6.7
     snippet: A recipient that parses a timestamp value in an HTTP field MUST accept all three HTTP-date formats.
@@ -6301,7 +6301,7 @@ sources:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
       line: 653
     - file: lint-http-rules/src/violations/http_date.rs
-      line: 100
+      line: 101
   - label: lint-http-core/src/http_date.rs (3)
     section: § 5.6.7
     snippet: HTTP-date = IMF-fixdate / obs-date
@@ -6309,7 +6309,7 @@ sources:
     - file: lint-http-core/src/http_date.rs
       line: 31
     - file: lint-http-rules/src/violations/http_date.rs
-      line: 53
+      line: 54
   - label: lint-http-core/src/http_date.rs (4)
     section: § 5.6.7
     snippet: IMF-fixdate  = day-name "," SP date1 SP time-of-day SP GMT
@@ -6331,7 +6331,7 @@ sources:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
       line: 681
     - file: lint-http-rules/src/violations/http_date.rs
-      line: 72
+      line: 73
   - label: lint-http-core/src/http_date.rs (6)
     section: § 5.6.7
     snippet: obs-date = rfc850-date / asctime-date


### PR DESCRIPTION
Three module comments explained a ranking or a shape by pointing at a working note's numbering rather than at anything in the tree. Each now names what it meant: `token68`'s bearer-token entries, the ranking rule of thumb this catalogue uses, and the `http_date` subject that made the same one first.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
