### PR TITLE
Both halves of a product are one token

### DIFF
--- a/docs/rules/server_header_product_valid.md
+++ b/docs/rules/server_header_product_valid.md
@@ -15,6 +15,7 @@ Validate a `Server` response header against `Server = product *( RWS ( product /
 - [RFC 9110 §10.2.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.4): `Server = product *( RWS ( product / comment ) )`; the section defines the field and defers the product syntax itself to Section 10.1.5
 - [RFC 9110 §10.1.5](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.5): `product = token ["/" product-version]` and `product-version = token`, defined once under `User-Agent` and shared by `Server`
 - [RFC 9110 §5.6.5](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.5): `comment = "(" *( ctext / quoted-pair / comment ) ")"` — comments nest, and `ctext` admits `obs-text` but not the parentheses or the backslash
+- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 
 ## Configuration
 

--- a/docs/rules/user_agent_token_valid.md
+++ b/docs/rules/user_agent_token_valid.md
@@ -14,6 +14,7 @@ Validate a `User-Agent` request header against `User-Agent = product *( RWS ( pr
 
 - [RFC 9110 §10.1.5](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.5): `User-Agent = product *( RWS ( product / comment ) )`, a request context field; `product = token ["/" product-version]` is defined here once and `Server` shares it. The section's further requirements — no advertising or nonessential information in a product identifier, no needlessly fine-grained detail — are about intent and are not decidable from a field value
 - [RFC 9110 §5.6.5](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.5): `comment = "(" *( ctext / quoted-pair / comment ) ")"` — comments nest, and `ctext` admits `obs-text` but not the parentheses or the backslash
+- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 
 ## Configuration
 

--- a/lint-http-rules/src/helpers/comment.rs
+++ b/lint-http-rules/src/helpers/comment.rs
@@ -42,7 +42,7 @@ fn is_ctext(b: u8) -> bool {
 ///
 /// Takes octets rather than a `&str` because `ctext` admits `obs-text`
 /// (%x80-FF): a conforming comment need not be visible US-ASCII.
-pub fn scan_comment(v: &[u8], start: usize) -> Result<usize, String> {
+pub fn scan_comment(v: &[u8], start: usize) -> Result<usize, CommentDefect> {
     // cite(RFC 9110 § 5.6.5): "comment        = "(" *( ctext / quoted-pair / comment ) ")""
     let mut i = start + 1;
     let mut depth = 1usize;
@@ -54,13 +54,10 @@ pub fn scan_comment(v: &[u8], start: usize) -> Result<usize, String> {
             // cite(RFC 9110 § 5.6.4): "The backslash octet ("\") can be used as a single-octet quoting mechanism within quoted-string and comment constructs."
             // cite(RFC 9110 § A): "quoted-pair = "\" ( HTAB / SP / VCHAR / obs-text )"
             let Some(&next) = v.get(i + 1) else {
-                return Err("comment ends with a dangling backslash".into());
+                return Err(CommentDefect::TrailingEscape);
             };
             if !(next == b'\t' || (0x20..=0x7e).contains(&next) || next >= 0x80) {
-                return Err(format!(
-                    "comment contains an invalid quoted-pair: {}",
-                    describe_octet(next)
-                ));
+                return Err(CommentDefect::BadQuotedPair(next));
             }
             i += 2;
             continue;
@@ -74,16 +71,50 @@ pub fn scan_comment(v: &[u8], start: usize) -> Result<usize, String> {
                 return Ok(i + 1);
             }
         } else if !is_ctext(b) {
-            return Err(format!(
-                "comment contains invalid character: {}",
-                describe_octet(b)
-            ));
+            return Err(CommentDefect::BadCharacter(b));
         }
 
         i += 1;
     }
 
-    Err("unterminated parenthesized comment".into())
+    Err(CommentDefect::Unterminated)
+}
+
+/// Why a value is not a `comment`.
+///
+/// Two of the four are the production's own — a comment that never closes, an
+/// octet `ctext` does not admit — and two are `quoted-pair`'s, which § 5.6.4
+/// defines for `quoted-string` **and** for this construct. That split is why
+/// this type is not simply the quoted-string's: the escape is shared and the
+/// container is not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommentDefect {
+    /// A backslash with nothing after it.
+    TrailingEscape,
+    /// A backslash before an octet `quoted-pair` does not admit.
+    BadQuotedPair(u8),
+    /// An octet outside `ctext`, the parentheses and the backslash aside.
+    BadCharacter(u8),
+    /// The value ended with the comment still open.
+    Unterminated,
+}
+
+impl CommentDefect {
+    /// The finding fragment. Callers name the field and the member the comment
+    /// sat in, and put this after it.
+    pub fn message(self) -> String {
+        match self {
+            Self::TrailingEscape => "comment ends with a dangling backslash".to_string(),
+            Self::BadQuotedPair(b) => format!(
+                "comment contains an invalid quoted-pair: {}",
+                describe_octet(b)
+            ),
+            Self::BadCharacter(b) => {
+                format!("comment contains invalid character: {}", describe_octet(b))
+            }
+            Self::Unterminated => "unterminated parenthesized comment".to_string(),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -107,8 +138,29 @@ mod tests {
 
     #[test]
     fn an_unterminated_comment_is_an_error() {
-        assert!(scan_comment(b"(a b", 0)
-            .expect_err("no closing paren")
+        assert_eq!(
+            scan_comment(b"(a b", 0),
+            Err(CommentDefect::Unterminated),
+            "no closing paren"
+        );
+        assert!(CommentDefect::Unterminated
+            .message()
             .contains("unterminated"));
+    }
+
+    /// The four verdicts, as verdicts. Two of them are `quoted-pair`'s rather
+    /// than the comment's, which is what the type keeps apart and a rendered
+    /// sentence did not.
+    #[test]
+    fn each_way_a_comment_fails_is_its_own_verdict() {
+        assert_eq!(scan_comment(b"(a\\", 0), Err(CommentDefect::TrailingEscape));
+        assert_eq!(
+            scan_comment(b"(a\\\x01b)", 0),
+            Err(CommentDefect::BadQuotedPair(0x01))
+        );
+        assert_eq!(
+            scan_comment(b"(a\x00b)", 0),
+            Err(CommentDefect::BadCharacter(0x00))
+        );
     }
 }

--- a/lint-http-rules/src/helpers/product.rs
+++ b/lint-http-rules/src/helpers/product.rs
@@ -15,25 +15,114 @@
 // cite(RFC 9110 § A): "User-Agent = product *( RWS ( product / comment ) )"
 // cite(RFC 9110 § 10.2.4): "Each product identifier consists of a name and optional version, as defined in Section 10.1.5."
 
-use crate::helpers::comment::scan_comment;
+use crate::helpers::comment::{scan_comment, CommentDefect};
 use crate::helpers::shown::describe_octet as describe;
 use crate::helpers::token::is_tchar_byte;
+
+/// Which half of a member the reader had just finished when the value stopped
+/// deriving — the half a finding names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Part {
+    /// The `token` a product opens with.
+    Name,
+    /// The `token` after the slash.
+    Version,
+    /// A parenthesised comment.
+    Comment,
+}
+
+impl Part {
+    /// The words a finding calls this half.
+    fn label(self) -> &'static str {
+        match self {
+            Self::Name => "product token",
+            Self::Version => "product version",
+            Self::Comment => "comment",
+        }
+    }
+}
+
+/// Why a value is not `product *( RWS ( product / comment ) )`.
+///
+/// The list is longer than most readers' because the production is an assembly
+/// of three things, and only one of them — the `token` both halves of a
+/// `product` are — has a subject in the catalogue. What separates the arms is
+/// therefore not severity but ownership: `NameEmpty`, `VersionEmpty` and
+/// `Character` are `token = 1*tchar` failing, and the rest is this production
+/// saying how its parts are put together.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProductDefect {
+    /// The whole field value, once trimmed, is empty.
+    ValueEmpty,
+    /// The value opens with something that is no `product` — a comment, most
+    /// often, which the repetition only reaches *after* one.
+    DoesNotOpenWithProduct,
+    /// A `token` of no `tchar` at all where a product identifier was due,
+    /// carrying the octet that was there instead (`None` at end of value).
+    NameEmpty(Option<u8>),
+    /// A slash with no `product-version` after it.
+    VersionEmpty,
+    /// An octet no `tchar` admits, in the half named.
+    Character {
+        /// The half the octet stopped.
+        part: Part,
+        /// The octet.
+        byte: u8,
+    },
+    /// Two elements with no `RWS` between them, the second being a comment.
+    SeparatorMissingBeforeComment(Part),
+    /// Two elements with no `RWS` between them, the second being a product.
+    SeparatorMissingBeforeProduct(Part),
+    /// The comment reader's verdict, carried out whole.
+    Comment(CommentDefect),
+}
+
+impl ProductDefect {
+    /// The finding fragment. Callers name the field the value came from and put
+    /// this after it.
+    pub fn message(self) -> String {
+        match self {
+            Self::ValueEmpty => "value is empty".to_string(),
+            Self::DoesNotOpenWithProduct => {
+                "value does not begin with a product identifier".to_string()
+            }
+            Self::NameEmpty(None) => {
+                "expected a product identifier, found end of value".to_string()
+            }
+            Self::NameEmpty(Some(b)) => {
+                format!("expected a product identifier, found {}", describe(b))
+            }
+            Self::VersionEmpty => "product version is empty".to_string(),
+            Self::Character { part, byte } => format!(
+                "{} contains invalid character: {}",
+                part.label(),
+                describe(byte)
+            ),
+            Self::SeparatorMissingBeforeComment(part) => format!(
+                "missing required whitespace before a comment, after the {}",
+                part.label()
+            ),
+            Self::SeparatorMissingBeforeProduct(part) => format!(
+                "missing required whitespace before a product identifier, after the {}",
+                part.label()
+            ),
+            Self::Comment(defect) => defect.message(),
+        }
+    }
+}
 
 /// Consume the `product` starting at `start`.
 ///
 /// Returns the offset just past it and whether a `product-version` was present,
 /// so the caller can name the half a trailing invalid octet belongs to.
-fn scan_product(v: &[u8], start: usize) -> Result<(usize, bool), String> {
+fn scan_product(v: &[u8], start: usize) -> Result<(usize, bool), ProductDefect> {
     // cite(RFC 9110 § A): "product = token [ "/" product-version ] product-version = token"
     let mut i = start;
     while i < v.len() && is_tchar_byte(v[i]) {
         i += 1;
     }
     if i == start {
-        return Err(match v.get(start) {
-            None => "expected a product identifier, found end of value".into(),
-            Some(&b) => format!("expected a product identifier, found {}", describe(b)),
-        });
+        return Err(ProductDefect::NameEmpty(v.get(start).copied()));
     }
 
     if i < v.len() && v[i] == b'/' {
@@ -46,11 +135,11 @@ fn scan_product(v: &[u8], start: usize) -> Result<(usize, bool), String> {
         // be the last octet of a product and cannot be followed by a delimiter.
         if j == version_start {
             return match v.get(j) {
-                None => Err("product version is empty".into()),
-                Some(&b) => Err(format!(
-                    "product version contains invalid character: {}",
-                    describe(b)
-                )),
+                None => Err(ProductDefect::VersionEmpty),
+                Some(&b) => Err(ProductDefect::Character {
+                    part: Part::Version,
+                    byte: b,
+                }),
             };
         }
         return Ok((j, true));
@@ -65,7 +154,7 @@ fn scan_product(v: &[u8], start: usize) -> Result<(usize, bool), String> {
 /// (%x80-FF), so a conforming value need not be visible US-ASCII, and decoding
 /// the value before parsing it would reject `Server: Apache (Ünix)` -- valid --
 /// while saying nothing about where the octet actually sat.
-pub fn validate_product_list(value: &[u8]) -> Result<(), String> {
+pub fn check_product_list(value: &[u8]) -> Result<(), ProductDefect> {
     // cite(RFC 9110 § 5.5): "A field value does not include leading or trailing whitespace."
     let mut v = value;
     while let [b' ' | b'\t', rest @ ..] = v {
@@ -76,7 +165,7 @@ pub fn validate_product_list(value: &[u8]) -> Result<(), String> {
     }
 
     if v.is_empty() {
-        return Err("value is empty".into());
+        return Err(ProductDefect::ValueEmpty);
     }
 
     // The field value begins with a `product`; a comment is only reachable
@@ -86,11 +175,11 @@ pub fn validate_product_list(value: &[u8]) -> Result<(), String> {
     // cite(RFC 9110 § 10.2.4): "The Server header field value consists of one or more product identifiers, each followed by zero or more comments (Section 5.6.5), which together identify the origin server software and its significant subproducts."
     // cite(RFC 9110 § 10.1.5): "The User-Agent field value consists of one or more product identifiers, each followed by zero or more comments (Section 5.6.5), which together identify the user agent software and its significant subproducts."
     if !is_tchar_byte(v[0]) {
-        return Err("value does not begin with a product identifier".into());
+        return Err(ProductDefect::DoesNotOpenWithProduct);
     }
     let (mut i, mut previous) = match scan_product(v, 0)? {
-        (end, true) => (end, "product version"),
-        (end, false) => (end, "product token"),
+        (end, true) => (end, Part::Version),
+        (end, false) => (end, Part::Name),
     };
 
     while i < v.len() {
@@ -103,13 +192,14 @@ pub fn validate_product_list(value: &[u8]) -> Result<(), String> {
         // cite(RFC 9110 § 5.6.3): "RWS = 1*( SP / HTAB )"
         if v[i] != b' ' && v[i] != b'\t' {
             return Err(if v[i] == b'(' {
-                format!("missing required whitespace before a comment, after the {previous}")
+                ProductDefect::SeparatorMissingBeforeComment(previous)
             } else if is_tchar_byte(v[i]) {
-                format!(
-                    "missing required whitespace before a product identifier, after the {previous}"
-                )
+                ProductDefect::SeparatorMissingBeforeProduct(previous)
             } else {
-                format!("{previous} contains invalid character: {}", describe(v[i]))
+                ProductDefect::Character {
+                    part: previous,
+                    byte: v[i],
+                }
             });
         }
         while i < v.len() && (v[i] == b' ' || v[i] == b'\t') {
@@ -120,16 +210,12 @@ pub fn validate_product_list(value: &[u8]) -> Result<(), String> {
         debug_assert!(i < v.len());
 
         if v[i] == b'(' {
-            i = scan_comment(v, i)?;
-            previous = "comment";
+            i = scan_comment(v, i).map_err(ProductDefect::Comment)?;
+            previous = Part::Comment;
         } else {
             let (end, version) = scan_product(v, i)?;
             i = end;
-            previous = if version {
-                "product version"
-            } else {
-                "product token"
-            };
+            previous = if version { Part::Version } else { Part::Name };
         }
     }
 
@@ -153,7 +239,7 @@ mod tests {
     #[case("A/1 (escaped \\) paren)")]
     #[case("A/1 (a)\t(b) C/3")]
     fn accepts_conforming_values(#[case] v: &str) {
-        assert_eq!(validate_product_list(v.as_bytes()), Ok(()), "{v}");
+        assert_eq!(check_product_list(v.as_bytes()), Ok(()), "{v}");
     }
 
     #[rstest]
@@ -183,7 +269,7 @@ mod tests {
     )]
     #[case("Agent\\(1.0\\)", "product token contains invalid character: '\\'")]
     fn rejects_non_conforming_values(#[case] v: &str, #[case] expected: &str) {
-        let err = validate_product_list(v.as_bytes()).expect_err(v);
+        let err = check_product_list(v.as_bytes()).expect_err(v).message();
         assert!(err.contains(expected), "{v}: got {err}");
     }
 
@@ -195,13 +281,14 @@ mod tests {
         let mut inside = b"Apache (U".to_vec();
         inside.push(0xdc);
         inside.extend_from_slice(b"nix)");
-        assert_eq!(validate_product_list(&inside), Ok(()));
+        assert_eq!(check_product_list(&inside), Ok(()));
 
         let mut outside = b"Apac".to_vec();
         outside.push(0xdc);
         outside.extend_from_slice(b"he");
-        assert!(validate_product_list(&outside)
+        assert!(check_product_list(&outside)
             .expect_err("obs-text is not a tchar")
+            .message()
             .contains("0xDC"));
     }
 
@@ -210,17 +297,19 @@ mod tests {
     /// are the whole of the escape's reach.
     #[test]
     fn backslash_escapes_only_inside_a_comment() {
-        assert_eq!(validate_product_list(b"A/1 (\\(unclosed-looking)"), Ok(()));
-        assert!(validate_product_list(b"Agent\\ Foo")
+        assert_eq!(check_product_list(b"A/1 (\\(unclosed-looking)"), Ok(()));
+        assert!(check_product_list(b"Agent\\ Foo")
             .expect_err("a backslash outside a comment is not an escape")
+            .message()
             .contains("invalid character: '\\'"));
     }
 
     /// A CTL is not `ctext`, so a comment cannot launder one into a field value.
     #[test]
     fn control_characters_are_rejected_inside_comments() {
-        assert!(validate_product_list(b"A/1 (a\x00b)")
+        assert!(check_product_list(b"A/1 (a\x00b)")
             .expect_err("NUL is not ctext")
+            .message()
             .contains("0x00"));
     }
 }

--- a/lint-http-rules/src/rules/server_header_product_valid.rs
+++ b/lint-http-rules/src/rules/server_header_product_valid.rs
@@ -4,6 +4,30 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::token::{
+    product_defect, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN, TOKEN_EMPTY,
+    TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+};
+use crate::violations::ViolationDef;
+
+/// Both halves of a `product` are a `token`, and that is all this rule borrows.
+///
+/// `product = token [ "/" product-version ]` with `product-version = token`, so
+/// a name and a version are one production at two positions — the same shape
+/// `Upgrade`'s `protocol-name` and `protocol-version` have — and the mirror
+/// rule on the other field answers with the same ids.
+///
+/// What stays unnamed is the assembly: a value that opens with a comment, two
+/// elements with no `RWS` between them, an empty value. One reader measures all
+/// of it, and a statement a construct makes about its own parts is not a
+/// borrowed production's defect. The comment's four verdicts stay with it —
+/// two of them are `quoted-pair`'s, whose id is spelled for the other construct
+/// that shares the escape.
+static DECLARED: &[&ViolationDef] = &[
+    &TOKEN_EMPTY,
+    &TOKEN_CHARACTER_FORBIDDEN,
+    &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+];
 
 pub struct ServerHeaderProductValid;
 
@@ -45,7 +69,16 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[RFC_9110_10_2_4, RFC_9110_10_1_5, RFC_9110_5_6_5]
+        &[
+            RFC_9110_10_2_4,
+            RFC_9110_10_1_5,
+            RFC_9110_5_6_5,
+            RFC_9110_5_6_2,
+        ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -134,10 +167,12 @@ impl Rule for ServerHeaderProductValid {
                 // conforming `Server` value is not always visible US-ASCII and the
                 // decode would reject the field before the grammar could accept it.
                 // cite(RFC 9110 § 5.5): "A recipient SHOULD treat other allowed octets in field content (i.e., obs-text) as opaque data."
-                if let Err(e) = crate::helpers::product::validate_product_list(hv.as_bytes()) {
-                    return Some(
-                        self.violation(ctx.severity, format!("Invalid Server header: {}", e)),
-                    );
+                if let Err(defect) = crate::helpers::product::check_product_list(hv.as_bytes()) {
+                    let message = format!("Invalid Server header: {}", defect.message());
+                    return Some(match product_defect(defect) {
+                        Some(def) => ctx.report_with(def, message),
+                        None => self.violation(ctx.severity, message),
+                    });
                 }
             }
 
@@ -156,6 +191,49 @@ mod tests {
     use super::*;
     use hyper::header::HeaderValue;
     use rstest::rstest;
+
+    /// One production at two positions of one member, and two fields reading
+    /// it: `we@bsocket`-shaped defects in a product name and in a product
+    /// version draw the same id, and so does the same value in a `User-Agent`.
+    /// The rows ending in `None` are the assembly this rule keeps — a value
+    /// that opens with a comment, two elements with no whitespace between them
+    /// — which no borrowed production has a defect for.
+    #[rstest]
+    #[case("Bad@Srv/1.0", Some("token_character_forbidden"))]
+    #[case("Srv/1@0", Some("token_character_forbidden"))]
+    #[case("Srv/", Some("token_empty"))]
+    #[case("Srv//1.0", Some("token_character_forbidden"))]
+    #[case("(Apache)", None)]
+    #[case("nginx/1.0(Ubuntu)", None)]
+    fn both_halves_of_a_product_are_one_token(#[case] value: &str, #[case] id: Option<&str>) {
+        for (rule, field) in [
+            (
+                &ServerHeaderProductValid as &dyn crate::rules::Rule,
+                "server",
+            ),
+            (
+                &super::super::user_agent_token_valid::UserAgentTokenValid,
+                "user-agent",
+            ),
+        ] {
+            let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
+            let headers = crate::test_helpers::make_headers_from_pairs(&[(field, value)]);
+            if field == "server" {
+                tx.response.as_mut().expect("a response").headers = headers;
+            } else {
+                tx.request.headers = headers;
+            }
+            let found = crate::test_helpers::run_rule(
+                rule,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &crate::test_helpers::make_test_config_with_severity(rule.id(), "warn"),
+            )
+            .expect("a finding");
+            // An unconverted site carries no defect id at all.
+            assert_eq!(found.violation, id.unwrap_or(""), "{field}: {value}");
+        }
+    }
 
     #[rstest]
     #[case(Some("nginx/1.18.0"), false)]

--- a/lint-http-rules/src/rules/user_agent_token_valid.rs
+++ b/lint-http-rules/src/rules/user_agent_token_valid.rs
@@ -4,6 +4,30 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::token::{
+    product_defect, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN, TOKEN_EMPTY,
+    TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+};
+use crate::violations::ViolationDef;
+
+/// Both halves of a `product` are a `token`, and that is all this rule borrows.
+///
+/// `product = token [ "/" product-version ]` with `product-version = token`, so
+/// a name and a version are one production at two positions — the same shape
+/// `Upgrade`'s `protocol-name` and `protocol-version` have — and the mirror
+/// rule on the other field answers with the same ids.
+///
+/// What stays unnamed is the assembly: a value that opens with a comment, two
+/// elements with no `RWS` between them, an empty value. One reader measures all
+/// of it, and a statement a construct makes about its own parts is not a
+/// borrowed production's defect. The comment's four verdicts stay with it —
+/// two of them are `quoted-pair`'s, whose id is spelled for the other construct
+/// that shares the escape.
+static DECLARED: &[&ViolationDef] = &[
+    &TOKEN_EMPTY,
+    &TOKEN_CHARACTER_FORBIDDEN,
+    &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+];
 
 pub struct UserAgentTokenValid;
 
@@ -39,7 +63,11 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[RFC_9110_10_1_5, RFC_9110_5_6_5]
+        &[RFC_9110_10_1_5, RFC_9110_5_6_5, RFC_9110_5_6_2]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -148,10 +176,12 @@ impl Rule for UserAgentTokenValid {
                 // conforming value need not be visible US-ASCII and the decode would
                 // reject the field before the grammar could accept it.
                 // cite(RFC 9110 § 5.5): "A recipient SHOULD treat other allowed octets in field content (i.e., obs-text) as opaque data."
-                if let Err(e) = crate::helpers::product::validate_product_list(hv.as_bytes()) {
-                    return Some(
-                        self.violation(ctx.severity, format!("Invalid User-Agent header: {}", e)),
-                    );
+                if let Err(defect) = crate::helpers::product::check_product_list(hv.as_bytes()) {
+                    let message = format!("Invalid User-Agent header: {}", defect.message());
+                    return Some(match product_defect(defect) {
+                        Some(def) => ctx.report_with(def, message),
+                        None => self.violation(ctx.severity, message),
+                    });
                 }
             }
 

--- a/lint-http-rules/src/rules/via_header_syntax.rs
+++ b/lint-http-rules/src/rules/via_header_syntax.rs
@@ -437,7 +437,7 @@ fn validate_member(v: &[u8], start: usize, n: usize) -> Result<(usize, bool), St
     let after_ws = skip_ws(v, i);
     if after_ws > i && v.get(after_ws) == Some(&b'(') {
         return Ok((
-            scan_comment(v, after_ws).map_err(|e| format!("member {n}: {e}"))?,
+            scan_comment(v, after_ws).map_err(|e| format!("member {n}: {}", e.message()))?,
             true,
         ));
     }

--- a/lint-http-rules/src/violations/token.rs
+++ b/lint-http-rules/src/violations/token.rs
@@ -25,6 +25,7 @@
 //! is not measured against the other anywhere in this crate.
 
 use crate::helpers::media_type::MediaTypeDefect;
+use crate::helpers::product::{Part, ProductDefect};
 use crate::helpers::word::{TokenBwsWordDefect, WordDefect};
 use crate::lint::Severity;
 use crate::rules::SpecRef;
@@ -107,6 +108,46 @@ pub fn token_character(c: char) -> &'static ViolationDef {
     match c.is_whitespace() || c.is_control() {
         true => &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
         false => &TOKEN_CHARACTER_FORBIDDEN,
+    }
+}
+
+/// The defect a [`ProductDefect`] reports as — `None` where the answer is the
+/// production's own rather than a `token`'s.
+///
+/// A `product` is `token [ "/" product-version ]` with `product-version =
+/// token`, so both halves of it are this subject's and the field adds nothing
+/// to either. What is left over is everything the production says about how its
+/// parts are *assembled* — a value that opens with a comment, two elements with
+/// no `RWS` between them, a slash with nothing after it — and one reader
+/// answers all of it, so none of it is a subject yet.
+///
+/// The `Comment` arm is the sharpest of the `None`s. Its four verdicts are
+/// § 5.6.5's construct and § 5.6.4's escape, and the escape is the one this
+/// catalogue already names — under an id spelled for the `quoted-string` that
+/// is the other construct sharing it. Borrowing that id here would name the
+/// wrong container; writing a second would say § 5.6.4's sentence twice. The
+/// promotion is what settles it, and until then the comment's verdicts report
+/// at the rule's severity.
+///
+/// This lives here rather than in a `violations/product.rs` for the reason the
+/// media type's mapping does: a file holding a mapping and no defs carries no
+/// `// cite` and the citation ratchet reads every file under `violations/`.
+pub fn product_defect(defect: ProductDefect) -> Option<&'static ViolationDef> {
+    match defect {
+        ProductDefect::NameEmpty(_) | ProductDefect::VersionEmpty => Some(&TOKEN_EMPTY),
+        // A `product` ends where its `token` does, so an octet the run stopped
+        // on is the octet the sender wrote into a name — which is what the
+        // message has always said. The comment's is not: there the octet sits
+        // *after* a construct that closed, and what it breaks is the assembly.
+        ProductDefect::Character { part, byte } => match part {
+            Part::Comment => None,
+            _ => Some(token_character(byte as char)),
+        },
+        ProductDefect::ValueEmpty
+        | ProductDefect::DoesNotOpenWithProduct
+        | ProductDefect::SeparatorMissingBeforeComment(_)
+        | ProductDefect::SeparatorMissingBeforeProduct(_)
+        | ProductDefect::Comment(_) => None,
     }
 }
 

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -5797,7 +5797,7 @@ sources:
     - file: lint-http-rules/src/rules/user_agent_present.rs
       line: 85
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
-      line: 101
+      line: 129
   - label: context_fields_direction (7)
     section: § 10.2.2
     snippet: The "Location" header field is used in some responses to refer to a specific resource in relation to the response.
@@ -6861,7 +6861,7 @@ sources:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 237
     - file: lint-http-rules/src/helpers/product.rs
-      line: 69
+      line: 158
     - file: lint-http-rules/src/rules/host_header.rs
       line: 229
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
@@ -6915,7 +6915,7 @@ sources:
     - file: lint-http-rules/src/rules/post_creates_resource.rs
       line: 143
     - file: lint-http-rules/src/rules/server_header_product_valid.rs
-      line: 122
+      line: 155
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 386
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
@@ -6931,7 +6931,7 @@ sources:
     - file: lint-http-rules/src/rules/user_agent_present.rs
       line: 111
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
-      line: 136
+      line: 164
   - label: lint-http-rules/src/helpers/field_placement.rs (6)
     section: § 6.5.1
     snippet: Many fields cannot be processed outside the header section because their evaluation is necessary prior to receiving the content, such as those that describe message framing, routing, authentication, request modifiers, response controls, or content format.
@@ -7031,11 +7031,11 @@ sources:
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 242
     - file: lint-http-rules/src/rules/server_header_product_valid.rs
-      line: 136
+      line: 169
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 397
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
-      line: 150
+      line: 178
   - label: lint-http-rules/src/helpers/headers.rs (6)
     section: § 5.5
     snippet: Fields that only anticipate a single member as the field value are referred to as "singleton fields".
@@ -7167,7 +7167,7 @@ sources:
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
       line: 48
     - file: lint-http-rules/src/violations/token.rs
-      line: 89
+      line: 90
   - label: lint-http-rules/src/helpers/list.rs (4)
     section: § 5.6.4
     snippet: quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )
@@ -7377,11 +7377,11 @@ sources:
     snippet: The User-Agent field value consists of one or more product identifiers, each followed by zero or more comments (Section 5.6.5), which together identify the user agent software and its significant subproducts.
     cited_by:
     - file: lint-http-rules/src/helpers/product.rs
-      line: 87
+      line: 176
     - file: lint-http-rules/src/rules/user_agent_present.rs
       line: 118
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
-      line: 118
+      line: 146
   - label: lint-http-rules/src/helpers/product.rs (2)
     section: § 10.2.4
     snippet: Each product identifier consists of a name and optional version, as defined in Section 10.1.5.
@@ -7393,13 +7393,13 @@ sources:
     snippet: The Server header field value consists of one or more product identifiers, each followed by zero or more comments (Section 5.6.5), which together identify the origin server software and its significant subproducts.
     cited_by:
     - file: lint-http-rules/src/helpers/product.rs
-      line: 86
+      line: 175
   - label: lint-http-rules/src/helpers/product.rs (4)
     section: § 5.6.3
     snippet: RWS = 1*( SP / HTAB )
     cited_by:
     - file: lint-http-rules/src/helpers/product.rs
-      line: 103
+      line: 192
     - file: lint-http-rules/src/rules/via_header_syntax.rs
       line: 355
   - label: lint-http-rules/src/helpers/product.rs (5)
@@ -7407,7 +7407,7 @@ sources:
     snippet: The RWS rule is used when at least one linear whitespace octet is required to separate field tokens.
     cited_by:
     - file: lint-http-rules/src/helpers/product.rs
-      line: 102
+      line: 191
     - file: lint-http-rules/src/rules/via_header_syntax.rs
       line: 354
   - label: lint-http-rules/src/helpers/product.rs (6)
@@ -7427,7 +7427,7 @@ sources:
     snippet: product = token [ "/" product-version ] product-version = token
     cited_by:
     - file: lint-http-rules/src/helpers/product.rs
-      line: 27
+      line: 119
   - label: lint-http-rules/src/helpers/quoted_string.rs
     section: § 5.6.4
     snippet: Recipients that process the value of a quoted-string MUST handle a quoted-pair as if it were replaced by the octet following the backslash.
@@ -7495,9 +7495,9 @@ sources:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
       line: 227
     - file: lint-http-rules/src/violations/token.rs
-      line: 56
+      line: 57
     - file: lint-http-rules/src/violations/token.rs
-      line: 75
+      line: 76
   - label: lint-http-rules/src/helpers/uri.rs
     section: § 7.1
     snippet: A URI reference is resolved to its absolute form in order to obtain the "target URI".
@@ -8639,15 +8639,15 @@ sources:
     snippet: An origin server MAY generate a Server header field in its responses.
     cited_by:
     - file: lint-http-rules/src/rules/server_header_product_valid.rs
-      line: 103
+      line: 136
   - label: server_header_product_valid (2)
     section: § 5.3
     snippet: a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers)
     cited_by:
     - file: lint-http-rules/src/rules/server_header_product_valid.rs
-      line: 131
+      line: 164
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
-      line: 145
+      line: 173
   - label: hash rule expansion
     section: § 5.6.1
     snippet: '#element => [ 1#element ]'
@@ -9171,19 +9171,19 @@ sources:
     snippet: A sender SHOULD NOT generate information in product-version that is not a version identifier
     cited_by:
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
-      line: 129
+      line: 157
   - label: user_agent_token_valid (2)
     section: § 10.1.5
     snippet: A sender SHOULD limit generated product identifiers to what is necessary to identify the product; a sender MUST NOT generate advertising or other nonessential information within the product identifier.
     cited_by:
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
-      line: 128
+      line: 156
   - label: user_agent_token_valid (3)
     section: § 10.1.5
     snippet: A user agent SHOULD NOT generate a User-Agent header field containing needlessly fine-grained detail and SHOULD limit the addition of subproducts by third parties.
     cited_by:
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
-      line: 130
+      line: 158
   - label: vary_header_valid
     section: § 12.5.5
     snippet: The "Vary" header field in a response describes what parts of a request message, aside from the method and target URI, might have influenced the origin server's process for selecting the content of this response.


### PR DESCRIPTION
`product = token [ "/" product-version ]` with `product-version = token`, so a name and a version are one production at two positions, and `Server` and `User-Agent` read the same value through the same helper. The three token ids are theirs now, and the test asserts both fields answering alike for a bad octet in either half.

`check_product_list` and `scan_comment` answer with their verdicts instead of a sentence, which is what makes the token half nameable. What stays unnamed is the assembly — a value opening with a comment, two elements with no RWS between them, a slash with nothing after it — and the comment's four verdicts, two of which are the escape RFC 9110 § 5.6.4 defines for `quoted-string` and for `comment` alike: naming those wants an id that is not spelled after either container. `via_header_syntax` renders the comment's sentence at its one line.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
