### PR TITLE
A Via member is made of borrowed productions

### DIFF
--- a/docs/rules/via_header_syntax.md
+++ b/docs/rules/via_header_syntax.md
@@ -22,9 +22,11 @@ What the rule does not judge: whether a proxy sent a `Via` at all. §7.6.3's MUS
 - [RFC 9110 §7.8](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8): `received-protocol` points here for its two halves: `protocol-name = token` and `protocol-version = token`
 - [RFC 9110 §B.2](https://www.rfc-editor.org/rfc/rfc9110.html#appendix-B.2): Why a `received-by` is a token: RFC 9110 removed `uri-host` from the production, which is what makes a bracketed IPv6 literal a finding here and not under RFC 7230
 - [RFC 9110 §5.6.5](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.5): Comments — `comment = "(" *( ctext / quoted-pair / comment ) ")"`, the `ctext` class, and the self-reference that makes a comment nestable
-- [RFC 9110 §5.6.1.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1): `Via` is a `#` list, so an empty member is the sender's defect and an empty value is not
+- [RFC 9110 §5.6.1.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1): The list construct — `1#element => element *( OWS "," OWS element )`, and the sender's MUST NOT against an empty element
 - [RFC 9110 §5.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2): Several `Via` lines in one section are one field value, which is why the members are counted after they are joined
-- [RFC 3986 §3.2.3](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.3): `port = *DIGIT` — the production `received-by` reaches through RFC 9110 §4.1, with no range and no minimum digit count
+- [RFC 3986 §3.2.3](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.3): Port — `port = *DIGIT`, which has no lower bound, no upper bound, and admits the empty string
+- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
+- [RFC 9110 §5.6.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4): `quoted-string = DQUOTE *( qdtext / quoted-pair ) DQUOTE` — the two delimiters, the class between them, and the backslash escape
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1293,7 +1293,7 @@ severity = "warn"
         /// The rest are the per-rule reading that has not happened yet — the
         /// denominator is computed below, because merges and conversions both
         /// move it.
-        const FLOOR: usize = 148;
+        const FLOOR: usize = 147;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/rules/via_header_syntax.rs
+++ b/lint-http-rules/src/rules/via_header_syntax.rs
@@ -8,9 +8,83 @@ use crate::helpers::shown::describe_octet;
 use crate::helpers::token::is_tchar_byte;
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
-use crate::violations::comment::RFC_9110_5_6_5;
+use crate::violations::comment::{
+    comment_defect, COMMENT_CHARACTER_FORBIDDEN, COMMENT_DELIMITER_MISSING, RFC_9110_5_6_5,
+};
+use crate::violations::list::{LIST_MEMBER_EMPTY, RFC_9110_5_6_1_1};
+use crate::violations::quoted_pair::QUOTED_PAIR_MALFORMED;
+use crate::violations::quoted_string::RFC_9110_5_6_4;
+use crate::violations::token::{
+    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN, TOKEN_EMPTY,
+    TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+};
+use crate::violations::uri::{RFC_3986_3_2_3, URI_PORT_CHARACTER_FORBIDDEN};
+use crate::violations::ViolationDef;
 
 pub struct ViaHeaderSyntax;
+
+/// Every production this field is assembled from, and none of its assembly.
+///
+/// `Via = #( received-protocol RWS received-by [ RWS comment ] )` names four
+/// things and defines none of them: the `#` list, the two `token`s a
+/// `received-protocol` is, the `token` a `pseudonym` is, the `port` RFC 3986
+/// writes, and § 5.6.5's comment with the escape inside it. So a `Via` member
+/// holding a bad octet answers with the same id an `Upgrade`, a `Server` or a
+/// `Content-Type` parameter would.
+///
+/// What stays this rule's own is what the *member* says about its parts: a
+/// `received-by` that is missing, a second comment where the production
+/// permits one, content after a member that has ended, and the bracketed IPv6
+/// literal § B.2 took out of this production when it removed `uri-host` from
+/// it. Every one of those is a statement about assembly, and no borrowed
+/// production has a defect for it.
+static DECLARED: &[&ViolationDef] = &[
+    &LIST_MEMBER_EMPTY,
+    &TOKEN_EMPTY,
+    &TOKEN_CHARACTER_FORBIDDEN,
+    &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+    &URI_PORT_CHARACTER_FORBIDDEN,
+    &COMMENT_DELIMITER_MISSING,
+    &COMMENT_CHARACTER_FORBIDDEN,
+    &QUOTED_PAIR_MALFORMED,
+];
+
+/// One finding from the reading, and the defect it reports as where the
+/// catalogue names that defect.
+///
+/// The shape `expect_header_valid` settled. Here the unnamed half is the
+/// member's assembly, and it is the larger half by count — which is what a
+/// field that borrows every production it is made of looks like from the
+/// inside.
+struct Defect {
+    def: Option<&'static ViolationDef>,
+    message: String,
+}
+
+impl Defect {
+    /// A defect the catalogue names.
+    fn named(def: &'static ViolationDef, message: String) -> Self {
+        Self {
+            def: Some(def),
+            message,
+        }
+    }
+
+    /// A defect no subject has claimed: this production's own statement about
+    /// how its parts go together.
+    fn unnamed(message: String) -> Self {
+        Self { def: None, message }
+    }
+
+    /// The same defect with its message read from further out — the direction
+    /// the field travelled in.
+    fn in_context(self, context: impl FnOnce(String) -> String) -> Self {
+        Self {
+            def: self.def,
+            message: context(self.message),
+        }
+    }
+}
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -38,26 +112,12 @@ const RFC_9110_B_2: crate::rules::SpecRef = crate::rules::SpecRef {
            production, which is what makes a bracketed IPv6 literal a finding here and \
            not under RFC 7230",
 };
-const RFC_9110_5_6_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("5.6.1.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
-    note: "`Via` is a `#` list, so an empty member is the sender's defect and an empty \
-           value is not",
-};
 const RFC_9110_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
     section: Some("5.2"),
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2",
     note: "Several `Via` lines in one section are one field value, which is why the \
            members are counted after they are joined",
-};
-const RFC_3986_3_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 3986",
-    section: Some("3.2.3"),
-    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.3",
-    note: "`port = *DIGIT` — the production `received-by` reaches through RFC 9110 §4.1, \
-           with no range and no minimum digit count",
 };
 
 impl RuleMeta for ViaHeaderSyntax {
@@ -110,7 +170,13 @@ severity = "warn"
             RFC_9110_5_6_1_1,
             RFC_9110_5_2,
             RFC_3986_3_2_3,
+            RFC_9110_5_6_2,
+            RFC_9110_5_6_4,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -176,14 +242,19 @@ impl Rule for ViaHeaderSyntax {
         // one finding (or none) becomes the vector.
         let finding = || -> Option<Violation> {
             // cite(RFC 9110 § 7.6.3): "A proxy MUST send an appropriate Via header field, as described below, in each message that it forwards."
-            if let Some(err) = judge(&tx.request.headers, "Request") {
-                return Some(self.cited(&RFC_9110_7_6_3, ctx.severity, err));
+            let report = |defect: Defect| match defect.def {
+                Some(def) => ctx.report_with(def, defect.message),
+                None => self.cited(&RFC_9110_7_6_3, ctx.severity, defect.message),
+            };
+
+            if let Some(defect) = judge(&tx.request.headers, "Request") {
+                return Some(report(defect));
             }
 
             // cite(RFC 9110 § 7.6.3): "An HTTP-to-HTTP gateway MUST send an appropriate Via header field in each inbound request message and MAY send a Via header field in forwarded response messages."
             if let Some(resp) = &tx.response {
-                if let Some(err) = judge(&resp.headers, "Response") {
-                    return Some(self.cited(&RFC_9110_7_6_3, ctx.severity, err));
+                if let Some(defect) = judge(&resp.headers, "Response") {
+                    return Some(report(defect));
                 }
             }
 
@@ -198,11 +269,11 @@ impl Rule for ViaHeaderSyntax {
 /// The lines are joined before anything is counted, because the members of a
 /// list-based field do not belong to the line that happens to carry them — a
 /// member written empty at a line boundary is an empty member.
-fn judge(headers: &hyper::HeaderMap, side: &str) -> Option<String> {
+fn judge(headers: &hyper::HeaderMap, side: &str) -> Option<Defect> {
     let value = combined_field_value_octets(headers, "via")?;
     validate_via(&value)
         .err()
-        .map(|e| format!("{side} Via header: {e}"))
+        .map(|defect| defect.in_context(|message| format!("{side} Via header: {message}")))
 }
 
 /// Skip `OWS` -- the optional whitespace a list permits around its commas.
@@ -239,7 +310,7 @@ fn ends_a_member(b: u8) -> bool {
 /// is not visible US-ASCII, while the same octet in a `pseudonym` is not a
 /// `tchar` and has to be reported *there* -- at the production that excludes it,
 /// rather than as a claim about the whole field's encoding.
-fn validate_via(value: &[u8]) -> Result<(), String> {
+fn validate_via(value: &[u8]) -> Result<(), Defect> {
     // cite(RFC 9110 § 5.5): "A field value does not include leading or trailing whitespace."
     let mut v = value;
     while let [b' ' | b'\t', rest @ ..] = v {
@@ -267,8 +338,9 @@ fn validate_via(value: &[u8]) -> Result<(), String> {
 
         // cite(RFC 9110 § 5.6.1.1): "In any production that uses the list construct, a sender MUST NOT generate empty list elements."
         if i == v.len() || v[i] == b',' {
-            return Err(format!(
-                "member {n} is empty, and a sender must not generate empty list elements"
+            return Err(Defect::named(
+                &LIST_MEMBER_EMPTY,
+                format!("member {n} is empty, and a sender must not generate empty list elements"),
             ));
         }
 
@@ -284,7 +356,7 @@ fn validate_via(value: &[u8]) -> Result<(), String> {
             // member, so whatever is here followed a complete one. A `(` can only
             // be a second comment: an unspaced one is not a comment at all and
             // has already been reported against the `received-by` it ran into.
-            return Err(if v[i] == b'(' {
+            return Err(Defect::unnamed(if v[i] == b'(' {
                 format!("member {n} carries more than one comment, and the production permits one")
             } else if commented {
                 format!(
@@ -296,7 +368,7 @@ fn validate_via(value: &[u8]) -> Result<(), String> {
                     "member {n} has content after its received-by, starting {}",
                     describe_octet(v[i])
                 )
-            });
+            }));
         }
         i += 1;
     }
@@ -310,7 +382,7 @@ fn validate_via(value: &[u8]) -> Result<(), String> {
 /// than against the member as a whole -- including the caller's report of what
 /// follows the member, which is why it is told whether a comment was taken.
 // cite(RFC 9110 § 7.6.3): "Via = #( received-protocol RWS received-by [ RWS comment ] )"
-fn validate_member(v: &[u8], start: usize, n: usize) -> Result<(usize, bool), String> {
+fn validate_member(v: &[u8], start: usize, n: usize) -> Result<(usize, bool), Defect> {
     // A `received-protocol` is a `protocol-version` that a `protocol-name` and a
     // slash may precede, so the first token is the version until a slash proves
     // it was the name. Both halves are tokens; §7.8 is where the field's own
@@ -321,22 +393,28 @@ fn validate_member(v: &[u8], start: usize, n: usize) -> Result<(usize, bool), St
     // cite(RFC 9110 § 7.6.3): "For brevity, the protocol-name is omitted when the received protocol is HTTP."
     let mut i = scan_token(v, start);
     if i == start {
-        return Err(format!(
-            "member {n} does not begin with a received-protocol, but with {}",
-            describe_octet(v[start])
+        return Err(Defect::named(
+            &TOKEN_EMPTY,
+            format!(
+                "member {n} does not begin with a received-protocol, but with {}",
+                describe_octet(v[start])
+            ),
         ));
     }
     let mut half = "received-protocol";
     if i < v.len() && v[i] == b'/' {
         let version = scan_token(v, i + 1);
         if version == i + 1 {
-            return Err(match v.get(version) {
-                None => format!("member {n} ends with the slash of its received-protocol"),
-                Some(&b) => format!(
-                    "member {n} has an empty protocol version, with {} after the slash",
-                    describe_octet(b)
-                ),
-            });
+            return Err(Defect::named(
+                &TOKEN_EMPTY,
+                match v.get(version) {
+                    None => format!("member {n} ends with the slash of its received-protocol"),
+                    Some(&b) => format!(
+                        "member {n} has an empty protocol version, with {} after the slash",
+                        describe_octet(b)
+                    ),
+                },
+            ));
         }
         i = version;
         half = "protocol version";
@@ -349,19 +427,19 @@ fn validate_member(v: &[u8], start: usize, n: usize) -> Result<(usize, bool), St
     // cite(RFC 9110 § 5.6.3): "RWS = 1*( SP / HTAB )"
     match v.get(i) {
         None => {
-            return Err(format!(
+            return Err(Defect::unnamed(format!(
                 "member {n} has a received-protocol and no received-by"
-            ))
+            )))
         }
         Some(&b',') => {
-            return Err(format!(
+            return Err(Defect::unnamed(format!(
                 "member {n} has a received-protocol and no received-by"
-            ))
+            )))
         }
         Some(&b) if b != b' ' && b != b'\t' => {
-            return Err(format!(
-                "member {n} has a {half} containing {}",
-                describe_octet(b)
+            return Err(Defect::named(
+                token_character(b as char),
+                format!("member {n} has a {half} containing {}", describe_octet(b)),
             ))
         }
         _ => {}
@@ -380,16 +458,26 @@ fn validate_member(v: &[u8], start: usize, n: usize) -> Result<(usize, bool), St
     let pseudonym = scan_token(v, i);
     if pseudonym == i {
         return Err(match v.get(i) {
-            None => format!("member {n} has a received-protocol and no received-by"),
-            Some(&b'[') => format!(
+            None => Defect::unnamed(format!(
+                "member {n} has a received-protocol and no received-by"
+            )),
+            // The brackets are § B.2's statement rather than the token's: the
+            // production used to admit a `uri-host` and does not, so what is
+            // wrong is which production the sender wrote, not which octet.
+            Some(&b'[') => Defect::unnamed(format!(
                 "member {n} spells its received-by as a bracketed IPv6 literal, which is not a \
                  pseudonym; RFC 9110 removed uri-host from this production, so \"[\" cannot appear \
                  in a received-by"
-            ),
-            Some(&b',') => format!("member {n} has a received-protocol and no received-by"),
-            Some(&b) => format!(
-                "member {n} has a received-by beginning with {}",
-                describe_octet(b)
+            )),
+            Some(&b',') => Defect::unnamed(format!(
+                "member {n} has a received-protocol and no received-by"
+            )),
+            Some(&b) => Defect::named(
+                &TOKEN_EMPTY,
+                format!(
+                    "member {n} has a received-by beginning with {}",
+                    describe_octet(b)
+                ),
             ),
         });
     }
@@ -407,17 +495,20 @@ fn validate_member(v: &[u8], start: usize, n: usize) -> Result<(usize, bool), St
         }
         if let Some(&b) = v.get(i) {
             if !ends_a_member(b) {
-                return Err(format!(
-                    "member {n} has a port containing {}",
-                    describe_octet(b)
+                return Err(Defect::named(
+                    &URI_PORT_CHARACTER_FORBIDDEN,
+                    format!("member {n} has a port containing {}", describe_octet(b)),
                 ));
             }
         }
     } else if let Some(&b) = v.get(i) {
         if !ends_a_member(b) {
-            return Err(format!(
-                "member {n} has a received-by containing {}",
-                describe_octet(b)
+            return Err(Defect::named(
+                token_character(b as char),
+                format!(
+                    "member {n} has a received-by containing {}",
+                    describe_octet(b)
+                ),
             ));
         }
     }
@@ -431,7 +522,9 @@ fn validate_member(v: &[u8], start: usize, n: usize) -> Result<(usize, bool), St
     let after_ws = skip_ws(v, i);
     if after_ws > i && v.get(after_ws) == Some(&b'(') {
         return Ok((
-            scan_comment(v, after_ws).map_err(|e| format!("member {n}: {}", e.message()))?,
+            scan_comment(v, after_ws).map_err(|e| {
+                Defect::named(comment_defect(e), format!("member {n}: {}", e.message()))
+            })?,
             true,
         ));
     }
@@ -475,7 +568,7 @@ mod tests {
     // OWS is permitted on both sides of the separator.
     #[case("1.1 a ,\t1.0 b")]
     fn accepts_conforming_values(#[case] v: &str) {
-        assert_eq!(validate_via(v.as_bytes()), Ok(()), "{v}");
+        assert!(validate_via(v.as_bytes()).is_ok(), "{v}");
     }
 
     #[rstest]
@@ -527,7 +620,7 @@ mod tests {
         "member 1 does not begin with a received-protocol, but with '('"
     )]
     fn reports_non_conforming_values(#[case] v: &str, #[case] expected: &str) {
-        let err = validate_via(v.as_bytes()).expect_err(v);
+        let err = validate_via(v.as_bytes()).expect_err(v).message;
         assert!(err.contains(expected), "{v}: got {err}");
     }
 
@@ -537,7 +630,7 @@ mod tests {
     #[test]
     fn a_bracketed_ipv6_literal_is_not_a_pseudonym() {
         for v in ["1.1 [::1]", "1.1 [2001:db8::1]:8080"] {
-            let err = validate_via(v.as_bytes()).expect_err(v);
+            let err = validate_via(v.as_bytes()).expect_err(v).message;
             assert!(
                 err.contains("removed uri-host from this production"),
                 "{v}: got {err}"
@@ -553,13 +646,14 @@ mod tests {
         let mut inside = b"1.1 fred (U".to_vec();
         inside.push(0xdc);
         inside.extend_from_slice(b"nix)");
-        assert_eq!(validate_via(&inside), Ok(()));
+        assert!(validate_via(&inside).is_ok());
 
         let mut outside = b"1.1 fr".to_vec();
         outside.push(0xdc);
         outside.extend_from_slice(b"ed");
         assert!(validate_via(&outside)
             .expect_err("obs-text is not a tchar")
+            .message
             .contains("received-by containing 0xDC"));
     }
 
@@ -567,7 +661,31 @@ mod tests {
     /// without reading `quoted-pair` disagrees, and cuts this value in two.
     #[test]
     fn a_comma_inside_a_comment_is_not_a_separator() {
-        assert_eq!(validate_via(b"1.1 fred (a\\), b), 1.0 lucy"), Ok(()));
+        assert!(validate_via(b"1.1 fred (a\\), b), 1.0 lucy").is_ok());
+    }
+
+    /// Every production this field is made of, answering with the id it
+    /// answers with everywhere else: the list's empty member, both `token`s of
+    /// the `received-protocol`, the `pseudonym`, RFC 3986's port, and the
+    /// comment with its escape. The rows ending in `None` are the member's own
+    /// assembly, which no borrowed production has a defect for.
+    #[rstest]
+    #[case("1.1 fred, , 1.0 lucy", Some("list_member_empty"))]
+    #[case("1.1 fr@ed", Some("token_character_forbidden"))]
+    #[case("1.1@ fred", Some("token_character_forbidden"))]
+    #[case("(cached) 1.1 fred", Some("token_empty"))]
+    #[case("1.1/ fred", Some("token_empty"))]
+    #[case("1.1 fred:80x", Some("uri_port_character_forbidden"))]
+    #[case("1.1 fred (unterminated", Some("comment_delimiter_missing"))]
+    #[case("1.1 fred (a\\", Some("quoted_pair_malformed"))]
+    #[case("1.1 [::1]", None)]
+    #[case("1.1", None)]
+    fn a_via_member_borrows_every_production_it_is_made_of(
+        #[case] value: &str,
+        #[case] id: Option<&str>,
+    ) {
+        let defect = judge(&headers(&[("via", value)]), "Request").expect("a finding");
+        assert_eq!(defect.def.map(|def| def.id), id, "{value}");
     }
 
     /// The lines of one field section are one list, so a member written empty
@@ -576,7 +694,9 @@ mod tests {
     #[test]
     fn an_empty_member_at_a_line_boundary_is_found() {
         let hm = headers(&[("via", "1.1 fred"), ("via", "")]);
-        let err = judge(&hm, "Request").expect("an empty member");
+        let defect = judge(&hm, "Request").expect("an empty member");
+        assert_eq!(defect.def.expect("the list's id").id, "list_member_empty");
+        let err = defect.message;
         assert!(err.contains("member 2 is empty"), "got {err}");
     }
 
@@ -584,7 +704,7 @@ mod tests {
     /// `#element` permits.
     #[test]
     fn a_single_empty_line_is_a_list_of_no_members() {
-        assert_eq!(judge(&headers(&[("via", "")]), "Request"), None);
+        assert!(judge(&headers(&[("via", "")]), "Request").is_none());
     }
 
     /// A second field line carries the second hop at least as often as the first
@@ -593,7 +713,9 @@ mod tests {
     #[test]
     fn every_field_line_is_read() {
         let hm = headers(&[("via", "1.1 fred"), ("via", "1.0 [::1]")]);
-        let err = judge(&hm, "Request").expect("the second line is measured too");
+        let err = judge(&hm, "Request")
+            .expect("the second line is measured too")
+            .message;
         assert!(err.contains("member 2"), "got {err}");
     }
 
@@ -605,7 +727,9 @@ mod tests {
             "via",
             HeaderValue::from_bytes(b"1.1 fr\xffed").expect("a field value hyper accepts"),
         );
-        let err = judge(&hm, "Request").expect("the octet is reported where it sits");
+        let err = judge(&hm, "Request")
+            .expect("the octet is reported where it sits")
+            .message;
         assert!(err.contains("received-by containing 0xFF"), "got {err}");
     }
 
@@ -658,7 +782,7 @@ mod tests {
                         .unwrap_or_else(|| panic!("not a field line: {l:?}"))
                 })
                 .collect();
-            let found = judge(&headers(&pairs), "Request");
+            let found = judge(&headers(&pairs), "Request").map(|defect| defect.message);
             match ex.compliance {
                 Compliance::Compliant => assert!(
                     found.is_none(),

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1420,7 +1420,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 52
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 402
+      line: 490
     - file: lint-http-rules/src/violations/uri.rs
       line: 235
   - label: lint-http-rules/src/helpers/uri.rs (24)
@@ -6673,7 +6673,7 @@ sources:
     - file: lint-http-rules/src/rules/upgrade_header_syntax.rs
       line: 232
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 268
+      line: 339
     - file: lint-http-rules/src/violations/list.rs
       line: 72
   - label: lint-http-rules/src/helpers/cache_control.rs
@@ -6881,7 +6881,7 @@ sources:
     - file: lint-http-rules/src/rules/trace_method_echo.rs
       line: 46
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 243
+      line: 314
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
       line: 400
   - label: lint-http-rules/src/helpers/field_placement.rs
@@ -7407,7 +7407,7 @@ sources:
     - file: lint-http-rules/src/helpers/product.rs
       line: 192
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 349
+      line: 427
   - label: lint-http-rules/src/helpers/product.rs (5)
     section: § 5.6.3
     snippet: The RWS rule is used when at least one linear whitespace octet is required to separate field tokens.
@@ -7415,7 +7415,7 @@ sources:
     - file: lint-http-rules/src/helpers/product.rs
       line: 191
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 348
+      line: 426
   - label: lint-http-rules/src/helpers/product.rs (6)
     section: § A
     snippet: Server = product *( RWS ( product / comment ) )
@@ -7499,7 +7499,7 @@ sources:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 286
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 221
+      line: 292
     - file: lint-http-rules/src/violations/token.rs
       line: 58
     - file: lint-http-rules/src/violations/token.rs
@@ -9147,7 +9147,7 @@ sources:
     - file: lint-http-rules/src/rules/upgrade_header_syntax.rs
       line: 217
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 257
+      line: 328
   - label: upgrade_header_syntax (3)
     section: § 7.8
     snippet: A client MAY send a list of protocol names in the Upgrade header field of a request to invite the server to switch to one or more of the named protocols, in order of descending preference, before sending the final response.
@@ -9201,75 +9201,75 @@ sources:
     snippet: port = <port, see [URI], Section 3.2.3>
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 401
+      line: 489
   - label: via_header_syntax (2)
     section: § 5.6.3
     snippet: OWS = *( SP / HTAB )
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 209
+      line: 280
   - label: via_header_syntax (3)
     section: § 7.6.3
     snippet: A proxy MUST send an appropriate Via header field, as described below, in each message that it forwards.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 178
+      line: 244
   - label: via_header_syntax (4)
     section: § 7.6.3
     snippet: A sender MAY generate comments to identify the software of each recipient, analogous to the User-Agent and Server header fields.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 429
+      line: 520
   - label: via_header_syntax (5)
     section: § 7.6.3
     snippet: An HTTP-to-HTTP gateway MUST send an appropriate Via header field in each inbound request message and MAY send a Via header field in forwarded response messages.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 183
+      line: 254
   - label: via_header_syntax (6)
     section: § 7.6.3
     snippet: For brevity, the protocol-name is omitted when the received protocol is HTTP.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 321
+      line: 393
   - label: via_header_syntax (7)
     section: § 7.6.3
     snippet: However, comments in Via are optional, and a recipient MAY remove them prior to forwarding the message.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 430
+      line: 521
   - label: via_header_syntax (8)
     section: § 7.6.3
     snippet: However, if the real host is considered to be sensitive information, a sender MAY replace it with a pseudonym.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 379
+      line: 457
   - label: via_header_syntax (9)
     section: § 7.6.3
     snippet: The "Via" header field indicates the presence of intermediate protocols and recipients between the user agent and the server (on requests) or between the origin server and the client (on responses)
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 164
+      line: 230
   - label: via_header_syntax (10)
     section: § 7.6.3
     snippet: The received-by portion is normally the host and optional port number of a recipient server or client that subsequently forwarded the message.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 378
+      line: 456
   - label: via_header_syntax (11)
     section: § 7.6.3
     snippet: 'Via = #( received-protocol RWS received-by [ RWS comment ] )'
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 256
+      line: 327
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 312
+      line: 384
   - label: via_header_syntax (12)
     section: § 7.6.3
     snippet: received-by = pseudonym [ ":" port ] pseudonym = token
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 376
+      line: 454
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
       line: 604
   - label: via_header_syntax (13)
@@ -9277,25 +9277,25 @@ sources:
     snippet: received-protocol = [ protocol-name "/" ] protocol-version
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 318
+      line: 390
   - label: via_header_syntax (14)
     section: § 7.8
     snippet: protocol-name = token
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 319
+      line: 391
   - label: via_header_syntax (15)
     section: § 7.8
     snippet: protocol-version = token
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 320
+      line: 392
   - label: via_header_syntax (16)
     section: § B.2
     snippet: For simplicity, we have removed uri-host from the received-by production because it can be encompassed by the existing grammar for pseudonym.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 377
+      line: 455
   - label: warning_header_syntax
     section: § 5.6.7
     snippet: Prior to 1995, there were three different formats commonly used by servers to communicate timestamps.


### PR DESCRIPTION
`Via = #( received-protocol RWS received-by [ RWS comment ] )` names four things and defines none of them, so every character question this rule asks belongs elsewhere: the list's empty member, the two `token`s of a received-protocol, the `token` a pseudonym is, RFC 3986's port, and the comment with the escape inside it. Eight ids, none of them new, and the test asserts each against the value that draws it.

The judge chain carries an optional def beside its message, because what is left is the member's assembly — a received-by that is missing, a second comment where the production permits one, content after a member that has ended — and the bracketed IPv6 literal, which is § B.2 saying `uri-host` was taken out of this production rather than a token saying `[` is not a tchar.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
