### PR TITLE
A W3C list borrows the list's defects too

### DIFF
--- a/docs/rules/timing_allow_origin_valid.md
+++ b/docs/rules/timing_allow_origin_valid.md
@@ -21,6 +21,8 @@ serializations.
 - [Resource Timing §3.5.2](https://www.w3.org/TR/resource-timing/#sec-timing-allow-origin): `Timing-Allow-Origin` response header and its ABNF
 - [Fetch §3.2](https://fetch.spec.whatwg.org/#origin-header): `origin-or-null` and `serialized-origin`, the productions the grammar's members resolve to (`null` is case-sensitive)
 - [RFC 6454 §7.1](https://www.rfc-editor.org/rfc/rfc6454.html#section-7.1): Historical serialized-origin shape (`scheme "://" host [ ":" port ]`) the conservative validator implements; Fetch supplants the serialization
+- [RFC 9110 §5.6.1.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1): The list construct — `1#element => element *( OWS "," OWS element )`, and the sender's MUST NOT against an empty element
+- [RFC 9110 §5.6.1.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.2): The values a `1#element` production does not generate — the empty value among them — beside the recipient's instruction to ignore empty elements
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/timing_allow_origin_valid.rs
+++ b/lint-http-rules/src/rules/timing_allow_origin_valid.rs
@@ -4,9 +4,26 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::list::{
+    LIST_MEMBER_EMPTY, LIST_MEMBER_MISSING, RFC_9110_5_6_1_1, RFC_9110_5_6_1_2,
+};
+use crate::violations::ViolationDef;
 
 pub struct TimingAllowOriginValid;
 
+/// The list construct's two defects, which is what this field borrows.
+///
+/// `Timing-Allow-Origin = 1#( origin-or-null / wildcard )` is written with
+/// RFC 9110's List Extension and the document says so where it prints the ABNF,
+/// so both halves of the construct answer here exactly as they answer for an
+/// `Accept-Patch` or a `Warning`: the floor the `1#` puts under the value, and
+/// the empty element a sender must not generate. A W3C document borrowing the
+/// construct borrows its defects with it.
+///
+/// What stays this rule's own is what a *member* is — a serialized origin, the
+/// case-sensitive `null`, the wildcard — which Fetch defines and this catalogue
+/// has no subject for.
+static DECLARED: &[&ViolationDef] = &[&LIST_MEMBER_MISSING, &LIST_MEMBER_EMPTY];
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
@@ -49,7 +66,17 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[RESOURCE_TIMING_3_5_2, FETCH_3_2, RFC_6454_7_1]
+        &[
+            RESOURCE_TIMING_3_5_2,
+            FETCH_3_2,
+            RFC_6454_7_1,
+            RFC_9110_5_6_1_1,
+            RFC_9110_5_6_1_2,
+        ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -142,8 +169,8 @@ impl Rule for TimingAllowOriginValid {
                 // one member.
                 // cite(Resource Timing): "Timing-Allow-Origin = 1#( origin-or-null / wildcard )"
                 if s.trim().is_empty() {
-                    return Some(self.violation(
-                        ctx.severity,
+                    return Some(ctx.report_with(
+                        &LIST_MEMBER_MISSING,
                         "Timing-Allow-Origin header value is empty".into(),
                     ));
                 }
@@ -159,8 +186,8 @@ impl Rule for TimingAllowOriginValid {
                         // empty list element.
                         // cite(RFC 9110 § 5.6.1.1): "In any production that uses the list construct, a sender MUST NOT generate empty list elements."
                         if parts.iter().skip(i + 1).any(|p| !p.trim().is_empty()) {
-                            return Some(self.violation(
-                                ctx.severity,
+                            return Some(ctx.report_with(
+                                &LIST_MEMBER_EMPTY,
                                 "Timing-Allow-Origin header contains empty member".into(),
                             ));
                         }
@@ -202,6 +229,32 @@ static REGISTRATION: &dyn crate::rules::Rule = &TimingAllowOriginValid;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The two halves of the list construct, answering with the ids every
+    /// other `1#` field answers with — out of a rule whose own findings are a
+    /// W3C document's and whose members are Fetch's.
+    #[test]
+    fn the_list_construct_reports_the_ids_it_always_does() {
+        for (value, id) in [
+            ("  ", "list_member_missing"),
+            ("https://a, , https://b", "list_member_empty"),
+        ] {
+            let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
+            tx.response.as_mut().expect("a response").headers =
+                crate::test_helpers::make_headers_from_pairs(&[("timing-allow-origin", value)]);
+            let found = crate::test_helpers::run_rule(
+                &TimingAllowOriginValid,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &crate::test_helpers::make_test_config_with_severity(
+                    "timing_allow_origin_valid",
+                    "warn",
+                ),
+            )
+            .expect("a finding");
+            assert_eq!(found.violation, id, "{value}");
+        }
+    }
     use rstest::rstest;
 
     use crate::test_helpers::make_test_transaction;

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -90,7 +90,7 @@ sources:
     snippet: origin-or-null = serialized-origin / %s"null" ; case-sensitive
     cited_by:
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 176
+      line: 203
   - label: x_content_type_options_present
     section: § 3.6
     snippet: If values[0] is an ASCII case-insensitive match for "nosniff", then return true.
@@ -541,31 +541,31 @@ sources:
     snippet: Timing-Allow-Origin = 1#( origin-or-null / wildcard )
     cited_by:
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 143
+      line: 170
   - label: timing_allow_origin_valid (2)
     section: § 3.5.2
     snippet: Server-side applications may return the Timing-Allow-Origin HTTP response header to allow the User Agent to fully expose, to the document origin(s) specified, the values of attributes that would have been zero due to those cross-origin restrictions.
     cited_by:
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 113
+      line: 140
   - label: timing_allow_origin_valid (3)
     section: § 3.5.2
     snippet: 'The header’s value is represented by the following ABNF [RFC5234] (using List Extension, [RFC9110]):'
     cited_by:
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 154
+      line: 181
   - label: timing_allow_origin_valid (4)
     section: § 3.5.2
     snippet: The recipient MAY combine multiple Timing-Allow-Origin header fields by appending each subsequent field value to the combined field value in order, separated by a comma.
     cited_by:
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 127
+      line: 154
   - label: timing_allow_origin_valid (5)
     section: § 3.5.2
     snippet: The sender MAY generate multiple Timing-Allow-Origin header fields.
     cited_by:
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 126
+      line: 153
 - label: Server Timing
   url: https://www.w3.org/TR/server-timing/
   type: text/html
@@ -6667,7 +6667,7 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 85
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 160
+      line: 187
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
       line: 92
     - file: lint-http-rules/src/rules/upgrade_header_syntax.rs
@@ -8635,7 +8635,7 @@ sources:
     - file: lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
       line: 107
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 129
+      line: 156
     - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
       line: 114
     - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
@@ -9023,7 +9023,7 @@ sources:
     snippet: 'A recipient MUST parse and ignore a reasonable number of empty list elements: enough to handle common mistakes by senders that merge values, but not so much that they could be used as a denial-of-service mechanism'
     cited_by:
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 169
+      line: 196
   - label: token68
     section: § 11.2
     snippet: token68        = 1*( ALPHA / DIGIT / "-" / "." / "_" / "~" / "+" / "/" ) *"="


### PR DESCRIPTION
`Timing-Allow-Origin = 1#( origin-or-null / wildcard )` is written with RFC 9110's List Extension, and the Resource Timing document says so on the line above the ABNF. So the floor the `1#` puts under the value and the empty element a sender must not generate are the ids every other `1#` field reports, out of a rule whose members are Fetch's and whose own findings stay its own.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
