### PR TITLE
A Keep-Alive value is a token or a quoted-string

### DIFF
--- a/docs/rules/keep_alive_header_valid.md
+++ b/docs/rules/keep_alive_header_valid.md
@@ -43,6 +43,8 @@ Reading it from that document rather than from RFC 9110 changes three answers.
 - [RFC 9110 §2.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2): The sender MUST NOT behind every grammar finding here: a value that derives from none of the productions is a protocol element matching no ABNF rule
 - [RFC 2616 §19.6.2](https://www.rfc-editor.org/rfc/rfc2616.html#section-19.6.2): Where the grammar stopped being restated: RFC 2616 kept the compatibility discussion and sent the reader back to RFC 2068 for the field itself. The same shape as RFC 9111 §5.5 and `Warning`
 - [IANA HTTP Field Name Registry](https://www.iana.org/assignments/http-fields/http-fields.xhtml): `Keep-Alive` is registered `permanent`, with RFC 2068 as its only reference — not `obsoleted`, unlike `Warning`. Corroboration for reading an obsoleted document, not an authority this rule enforces
+- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
+- [RFC 9110 §5.6.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4): `quoted-string = DQUOTE *( qdtext / quoted-pair ) DQUOTE` — the two delimiters, the class between them, and the backslash escape
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/keep_alive_header_valid.rs
+++ b/lint-http-rules/src/rules/keep_alive_header_valid.rs
@@ -9,6 +9,16 @@ use crate::helpers::shown::{describe_char, shown_in_finding};
 use crate::helpers::word::{token_or_quoted_string, WordDefect};
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::quoted_pair::QUOTED_PAIR_MALFORMED;
+use crate::violations::quoted_string::{
+    quoted_string_defect, QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
+    QUOTED_STRING_DELIMITER_MISSING, QUOTED_STRING_QUOTE_ESCAPE_MISSING, RFC_9110_5_6_4,
+};
+use crate::violations::token::{
+    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
+    TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+};
+use crate::violations::ViolationDef;
 
 #[derive(Debug, Clone)]
 pub struct MessageKeepAliveConfig {
@@ -65,6 +75,64 @@ fn parse_keep_alive_config(
 }
 
 pub struct KeepAliveHeaderValid;
+
+/// The `value` half of a `keepalive-param`, and nothing else this rule says.
+///
+/// RFC 2068 § 3.7 writes `value = token | quoted-string` and § 2.2 defines both
+/// — the same pair RFC 9110 § 5.6.2 and § 5.6.4 write, which
+/// [`validate_param_value`] documents rather than re-derives. So an octet the
+/// value may not hold answers here with the id an `Accept` parameter, an
+/// `auth-param` or a `Content-Type` parameter answers with.
+///
+/// Everything else is this document's own and stays: a member with no `=` at
+/// all (the expired draft would have allowed it and the document in force does
+/// not), a member that names no parameter, a `timeout` that is not
+/// `delta-seconds`, a `timeout` above the bound an operator configured, and the
+/// connection option the field must travel with. **The empty value is unnamed
+/// too** — `word_defect` declines that verdict because six fields answered it
+/// four ways, and this one answers it in its own words.
+static DECLARED: &[&ViolationDef] = &[
+    &TOKEN_CHARACTER_FORBIDDEN,
+    &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+    &QUOTED_STRING_DELIMITER_MISSING,
+    &QUOTED_STRING_QUOTE_ESCAPE_MISSING,
+    &QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
+    &QUOTED_PAIR_MALFORMED,
+];
+
+/// One finding from the reading, and the defect it reports as where the
+/// catalogue names that defect.
+///
+/// The shape `expect_header_valid` settled. Two arms of the value's reader are
+/// named and everything else this rule says is RFC 2068's or the deployment's.
+struct Defect {
+    def: Option<&'static ViolationDef>,
+    message: String,
+}
+
+impl Defect {
+    /// A defect the catalogue names.
+    fn named(def: &'static ViolationDef, message: String) -> Self {
+        Self {
+            def: Some(def),
+            message,
+        }
+    }
+
+    /// A defect no subject has claimed: this document's own statement.
+    fn unnamed(message: String) -> Self {
+        Self { def: None, message }
+    }
+
+    /// The same defect with its message read from further out — the member it
+    /// was in, the direction the field travelled in.
+    fn in_context(self, context: impl FnOnce(String) -> String) -> Self {
+        Self {
+            def: self.def,
+            message: context(self.message),
+        }
+    }
+}
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -278,7 +346,13 @@ max_timeout_seconds = 3600
             RFC_9110_2_2,
             RFC_2616_19_6_2,
             IANA_HTTP_FIELD_NAME_REGISTRY,
+            RFC_9110_5_6_2,
+            RFC_9110_5_6_4,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -393,7 +467,10 @@ impl Rule for KeepAliveHeaderValid {
                 })
             })?;
 
-            Some(self.violation(config.severity, message))
+            Some(match message.def {
+                Some(def) => ctx.report_with(def, message.message),
+                None => self.violation(config.severity, message.message),
+            })
         };
         Vec::from_iter(finding())
     }
@@ -417,13 +494,13 @@ fn judge(
     version: &str,
     side: &str,
     max_timeout_seconds: u64,
-) -> Option<String> {
+) -> Option<Defect> {
     let value = combined_field_value_as_written(headers, "keep-alive")?;
 
     validate_keep_alive(&value, max_timeout_seconds)
         .err()
-        .or_else(|| missing_connection_option(headers, version))
-        .map(|e| format!("{side} Keep-Alive header: {e}"))
+        .or_else(|| missing_connection_option(headers, version).map(Defect::unnamed))
+        .map(|defect| defect.in_context(|message| format!("{side} Keep-Alive header: {message}")))
 }
 
 /// The field's one requirement on a sender: it travels with its connection
@@ -457,7 +534,7 @@ fn missing_connection_option(headers: &hyper::HeaderMap, version: &str) -> Optio
 /// Validate a whole `Keep-Alive` field value.
 // cite(RFC 9110 § 2.2): "A sender MUST NOT generate protocol elements that do not match the grammar defined by the corresponding ABNF rules."
 // cite(RFC 2068 § 19.7.1.1): "Keep-Alive-header = "Keep-Alive" ":" 0# keepalive-param"
-fn validate_keep_alive(value: &str, max_timeout_seconds: u64) -> Result<(), String> {
+fn validate_keep_alive(value: &str, max_timeout_seconds: u64) -> Result<(), Defect> {
     // cite(RFC 9110 § 5.5): "A field value does not include leading or trailing whitespace."
     let v = trim_ows(value);
 
@@ -480,7 +557,7 @@ fn validate_keep_alive(value: &str, max_timeout_seconds: u64) -> Result<(), Stri
         }
 
         validate_keepalive_param(member, max_timeout_seconds)
-            .map_err(|e| format!("member {n} {e}"))?;
+            .map_err(|defect| defect.in_context(|message| format!("member {n} {message}")))?;
     }
 
     Ok(())
@@ -509,7 +586,7 @@ fn validate_keep_alive(value: &str, max_timeout_seconds: u64) -> Result<(), Stri
 /// [`parse_token_bws_word`]: crate::helpers::word::parse_token_bws_word
 // cite(RFC 2068 § 19.7.1.1): "keepalive-param = param-name "=" value"
 // cite(draft-thomson-hybi-http-timeout-03 § 2): "keep-alive-extension = token [ "=" ( token / quoted-string ) ]"
-fn validate_keepalive_param(member: &str, max_timeout_seconds: u64) -> Result<(), String> {
+fn validate_keepalive_param(member: &str, max_timeout_seconds: u64) -> Result<(), Defect> {
     // The production writes one `"="`, so the first one is it and everything
     // after belongs to the value -- which is judged whole, so a `quoted-string`
     // carrying more of them keeps them. `=` is one of the `tspecials` the
@@ -519,11 +596,11 @@ fn validate_keepalive_param(member: &str, max_timeout_seconds: u64) -> Result<()
     // no escape for that.)
     // cite(RFC 2068 § 2.1): "At least one delimiter (tspecials) must exist between any two tokens, since they would otherwise be interpreted as a single token."
     let Some(eq) = member.find('=') else {
-        return Err(format!(
+        return Err(Defect::unnamed(format!(
             "is `{}`, which has no \"=\" and no value after it; the draft that named these \
              parameters would have allowed that and the document specifying the field does not",
             shown_in_finding(member)
-        ));
+        )));
     };
 
     // Whitespace either side of the `=` is not slack this rule is granting: the
@@ -540,7 +617,9 @@ fn validate_keepalive_param(member: &str, max_timeout_seconds: u64) -> Result<()
     // absence is a different question: a member that is only a value names no
     // parameter at all.
     if name.is_empty() {
-        return Err("begins with its \"=\", so it names no parameter".into());
+        return Err(Defect::unnamed(
+            "begins with its \"=\", so it names no parameter".into(),
+        ));
     }
 
     validate_param_value(value)?;
@@ -587,33 +666,37 @@ fn validate_keepalive_param(member: &str, max_timeout_seconds: u64) -> Result<()
 // cite(RFC 2068 § 2.2): "token          = 1*<any CHAR except CTLs or tspecials>"
 // cite(RFC 2068 § 2.2): "quoted-string  = ( <"> *(qdtext) <"> )"
 // cite(RFC 2068 § 2.2): "The backslash character ("\") may be used as a single-character quoting mechanism only within quoted-string and comment constructs."
-fn validate_param_value(value: &str) -> Result<(), String> {
+fn validate_param_value(value: &str) -> Result<(), Defect> {
     match token_or_quoted_string(value) {
         Ok(_) => Ok(()),
         // Neither alternative derives the empty string -- `token` is `1*<...>`
         // and a `quoted-string` is at least its two DQUOTEs -- so a member
         // ending on its `=` has a value the grammar cannot generate. No
         // sentence in this document tolerates it, so it is a finding here.
-        Err(WordDefect::Empty) => Err(
+        Err(WordDefect::Empty) => Err(Defect::unnamed(
             "has nothing after its \"=\", and neither a token nor a quoted-string derives the \
              empty string"
                 .into(),
-        ),
-        Err(WordDefect::NotToken(c)) => Err(format!(
-            "has {} in its value, and a value that is not a quoted-string is a token",
-            describe_char(c)
+        )),
+        Err(WordDefect::NotToken(c)) => Err(Defect::named(
+            token_character(c),
+            format!(
+                "has {} in its value, and a value that is not a quoted-string is a token",
+                describe_char(c)
+            ),
         )),
         // The reader builds this half of its message and puts the value into it
         // raw. The only octets a `HeaderValue` can carry that `describe_octet`
         // would have named are `obs-text`, and those are `qdtext` -- so one
         // reaches a finding here only inside a quoted-string that is already
         // malformed. Rendering them is the helper's to fix, at its callers.
-        Err(WordDefect::NotQuotedString(defect)) => {
-            let defect = defect.message(value);
-            Err(format!(
-                "has a value that is not a well-formed quoted-string: {defect}"
-            ))
-        }
+        Err(WordDefect::NotQuotedString(defect)) => Err(Defect::named(
+            quoted_string_defect(defect),
+            format!(
+                "has a value that is not a well-formed quoted-string: {}",
+                defect.message(value)
+            ),
+        )),
     }
 }
 
@@ -625,16 +708,16 @@ fn validate_param_value(value: &str) -> Result<(), String> {
 /// advising a smaller number.
 // cite(draft-thomson-hybi-http-timeout-03 § 2.1): "The value of the "timeout" parameter is a single integer in seconds."
 // cite(RFC 9111 § 1.2.2): "delta-seconds  = 1*DIGIT"
-fn validate_timeout(value: &str, max_timeout_seconds: u64) -> Result<(), String> {
+fn validate_timeout(value: &str, max_timeout_seconds: u64) -> Result<(), Defect> {
     // Every character against the production before any of it reaches a number
     // parser: `u64::from_str` accepts a leading `+`, and no `delta-seconds`
     // does.
     if let Some(c) = value.chars().find(|c| !c.is_ascii_digit()) {
-        return Err(format!(
+        return Err(Defect::unnamed(format!(
             "has {} in its timeout, and the only published grammar for the parameter writes a \
              delta-seconds, which is 1*DIGIT",
             describe_char(c)
-        ));
+        )));
     }
 
     // The value is all digits, so a parse failure here is arithmetic rather than
@@ -642,10 +725,10 @@ fn validate_timeout(value: &str, max_timeout_seconds: u64) -> Result<(), String>
     // an operator can configure.
     let seconds = value.parse::<u64>().unwrap_or(u64::MAX);
     if seconds > max_timeout_seconds {
-        return Err(format!(
+        return Err(Defect::unnamed(format!(
             "has a timeout of {value} seconds, above the max_timeout_seconds of \
              {max_timeout_seconds} this deployment configured; no document states a maximum"
-        ));
+        )));
     }
 
     Ok(())
@@ -655,6 +738,36 @@ fn validate_timeout(value: &str, max_timeout_seconds: u64) -> Result<(), String>
 mod tests {
     use super::*;
     use rstest::rstest;
+
+    /// The `value` half is RFC 2068's `token | quoted-string`, which is
+    /// RFC 9110's pair under another name — the fourth reading of that
+    /// equivalence in this tree, and the first that does not have to state it,
+    /// because the ids do. Everything else this rule reports is the document's
+    /// own and carries no defect id.
+    #[rstest]
+    #[case("timeout=5@0", Some("token_character_forbidden"))]
+    #[case("ext=\"unterminated", Some("quoted_string_delimiter_missing"))]
+    // A backslash that eats the closing DQUOTE: the value is quoted and the
+    // escape is two octets short of a `quoted-pair`.
+    #[case("ext=\"a\\\"", Some("quoted_pair_malformed"))]
+    #[case("timeout=", None)]
+    #[case("timeout", None)]
+    #[case("=5", None)]
+    #[case("timeout=5x", None)]
+    fn the_value_half_borrows_and_the_rest_does_not(#[case] value: &str, #[case] id: Option<&str>) {
+        let tx = crate::test_helpers::make_test_transaction_with_headers(&[
+            ("connection", "keep-alive"),
+            ("keep-alive", value),
+        ]);
+        let found = crate::test_helpers::run_rule(
+            &KeepAliveHeaderValid,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg_with_max(3600),
+        )
+        .expect("a finding");
+        assert_eq!(found.violation, id.unwrap_or(""), "{value}");
+    }
 
     /// The rule's config table, with `max_timeout_seconds` written only when the
     /// case supplies one — the `None` shape is what the required-key tests need,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -750,19 +750,19 @@ sources:
     snippet: keep-alive-extension = token [ "=" ( token / quoted-string ) ]
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 511
+      line: 588
   - label: keep_alive_header_valid (2)
     section: § 2
     snippet: keep-alive-info      =   "timeout" "=" delta-seconds
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 552
+      line: 631
   - label: keep_alive_header_valid (3)
     section: § 2.1
     snippet: The value of the "timeout" parameter is a single integer in seconds.
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 626
+      line: 709
 - label: MDN Content-Type
   url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Type
   fragments:
@@ -998,85 +998,85 @@ sources:
     snippet: HTTP/1.1 does not define any parameters.
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 553
+      line: 632
   - label: keep_alive_header_valid (2)
     section: § 19.7.1.1
     snippet: If the Keep-Alive header is sent, the corresponding connection token MUST be transmitted.
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 446
+      line: 523
   - label: keep_alive_header_valid (3)
     section: § 19.7.1.1
     snippet: Keep-Alive-header = "Keep-Alive" ":" 0# keepalive-param
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 459
+      line: 536
   - label: keep_alive_header_valid (4)
     section: § 19.7.1.1
     snippet: The Keep-Alive header itself is optional, and is used only if a parameter is being sent.
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 477
+      line: 554
   - label: keep_alive_header_valid (5)
     section: § 19.7.1.1
     snippet: When the Keep-Alive connection-token has been transmitted with a request or a response, a Keep-Alive header field MAY also be included.
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 351
+      line: 425
   - label: keep_alive_header_valid (6)
     section: § 19.7.1.1
     snippet: keepalive-param = param-name "=" value
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 510
+      line: 587
   - label: keep_alive_header_valid (7)
     section: § 2.1
     snippet: At least one delimiter (tspecials) must exist between any two tokens, since they would otherwise be interpreted as a single token.
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 520
+      line: 597
   - label: keep_alive_header_valid (8)
     section: § 2.1
     snippet: Wherever this construct is used, null elements are allowed, but do not contribute
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 476
+      line: 553
   - label: keep_alive_header_valid (9)
     section: § 2.1
     snippet: linear whitespace (LWS) can be included between any two adjacent words (token or quoted-string), and between adjacent tokens and delimiters (tspecials), without changing the interpretation of a field.
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 533
+      line: 610
   - label: LWS grammar
     section: § 2.2
     snippet: LWS            = [CRLF] 1*( SP | HT )
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 534
+      line: 611
   - label: keep_alive_header_valid (10)
     section: § 2.2
     snippet: The backslash character ("\") may be used as a single-character quoting mechanism only within quoted-string and comment constructs.
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 589
+      line: 668
   - label: keep_alive_header_valid (11)
     section: § 2.2
     snippet: quoted-string  = ( <"> *(qdtext) <"> )
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 588
+      line: 667
   - label: keep_alive_header_valid (12)
     section: § 2.2
     snippet: token          = 1*<any CHAR except CTLs or tspecials>
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 587
+      line: 666
   - label: keep_alive_header_valid (13)
     section: § 3.7
     snippet: value          = token | quoted-string
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 586
+      line: 665
 - label: RFC 2616
   url: https://www.rfc-editor.org/rfc/rfc2616.html
   fragments:
@@ -5215,7 +5215,7 @@ sources:
     - file: lint-http-rules/src/rules/http_version_syntax.rs
       line: 170
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 458
+      line: 535
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 504
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
@@ -6227,7 +6227,7 @@ sources:
     snippet: Keep-Alive (Section 19.7.1 of [RFC2068])
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 440
+      line: 517
   - label: language_tag_syntax
     section: § 8.5
     snippet: 'Content-Language = #language-tag'
@@ -6871,7 +6871,7 @@ sources:
     - file: lint-http-rules/src/rules/host_header.rs
       line: 229
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 461
+      line: 538
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 507
     - file: lint-http-rules/src/rules/refresh_header_syntax.rs
@@ -9486,7 +9486,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 303
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 627
+      line: 710
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
       line: 100
   - label: lint-http-rules/src/helpers/cache_control.rs


### PR DESCRIPTION
RFC 2068 § 3.7 writes `value = token | quoted-string` and § 2.2 defines both; the file already records that the pair is RFC 9110's under another name, and the ids now say it instead of the comment having to. Two arms of the value's reader report through the catalogue and the rest of what this rule says stays its own: a member with no `=` at all, a member naming no parameter, a `timeout` that is not delta-seconds, a `timeout` above the bound an operator configured, and the connection option the field must travel with.

The empty value stays unnamed too, which is the shared reader's own answer: six fields settled that verdict four ways and this one settles it in its own words.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
