### PR TITLE
Comments name what they mean, not a number

### DIFF
--- a/lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
+++ b/lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
@@ -25,8 +25,9 @@ pub struct AcceptEncodingParameterValid;
 /// `codings [ weight ]` owns all of it: a separator introducing a weight that
 /// is not there, two of something there may be at most one of, a member whose
 /// non-optional half is missing, and a `name=value` pair no derivation of the
-/// field produces. That is 2.38's residue — what a construct says about its own
-/// assembly — and it is the whole of what this rule is named for.
+/// field produces. That is the residue every borrowed construct leaves — what
+/// a construct says about its own assembly — and it is the whole of what this
+/// rule is named for.
 static DECLARED: &[&ViolationDef] = &[
     &TOKEN_CHARACTER_FORBIDDEN,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,

--- a/lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
+++ b/lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
@@ -12,16 +12,15 @@ use crate::violations::ViolationDef;
 
 pub struct ContentEncodingAndTypeConsistent;
 
-/// The `token` pair, and it is the same field 2.37 converted read by a second
-/// rule asking a different question.
+/// The `token` pair, and it is the same field
+/// [`content_encoding_registered`](crate::rules::content_encoding_registered)
+/// reads, asked a different question.
 ///
-/// 2.37 took `Content-Encoding` and `Accept-Encoding` for the rule that asks
-/// which coding *names* exist; this takes them for the rule that asks which
-/// were applied twice, and the octet no `tchar` admits comes out with the same
-/// id from both. The two even say it in the same words — one of S6's duplicate
-/// templates, written in two files that share no code — so here the id retires
-/// a duplication the prose still carries, which is the state Phase 5's dedup
-/// was deferred to act on.
+/// That rule takes `Content-Encoding` and `Accept-Encoding` for which coding
+/// *names* exist; this takes them for which were applied twice, and the octet
+/// no `tchar` admits comes out with the same id from both. The two even say it
+/// in the same words — one message written twice in two files that share no
+/// code — so here the id retires a duplication the prose still carries.
 ///
 /// **Nothing this rule is named for changed.** A coding repeated, a `*` where
 /// none is defined, a member whose coding half is missing, and the field on a
@@ -240,8 +239,9 @@ mod tests {
 
     /// The six fields spelling `content-coding = token` now answer for it with
     /// one pair of ids, and the last two arrive from the rules that ask the
-    /// fields a *different* question. Asserted against 2.37's rule, which reads
-    /// the same field for which names exist and shares no code with this one.
+    /// fields a *different* question. Asserted against the registry rule, which
+    /// reads the same field for which names exist and shares no code with this
+    /// one.
     #[test]
     fn a_coding_name_is_a_token_whatever_the_rule_is_asking() {
         let judge = |rule: &dyn crate::rules::Rule,
@@ -292,8 +292,8 @@ mod tests {
         assert_eq!(here.violation, "token_character_forbidden");
         assert_eq!(registered.violation, "token_character_forbidden");
         // And the sentence is *the same one*, written twice in two files that
-        // share no code -- one of the duplicate templates S6 counted, retired
-        // by the id and left as two strings for Phase 5's dedup to collapse.
+        // share no code -- retired by the id and left as two strings for a
+        // later dedup pass to collapse.
         assert_eq!(here.message, registered.message);
     }
 

--- a/lint-http-rules/src/rules/date_and_time_headers_consistent.rs
+++ b/lint-http-rules/src/rules/date_and_time_headers_consistent.rs
@@ -356,7 +356,7 @@ mod tests {
     /// ask the *recipient's* question — can this value be read as a timestamp
     /// at all — so all four answer `http_date_malformed`.
     ///
-    /// The two `Sunset` readings are also one of S6's fourteen duplicate
+    /// The two `Sunset` readings are also one of the tree's duplicate message
     /// templates: byte-identical prose from two rules, which until now was two
     /// findings under two names and is now two findings under one.
     #[test]

--- a/lint-http-rules/src/rules/expect_header_valid.rs
+++ b/lint-http-rules/src/rules/expect_header_valid.rs
@@ -57,8 +57,9 @@ static DECLARED: &[&ViolationDef] = &[
 /// One finding the reading produced: its wording, and the defect it reports as
 /// where the catalogue has a name for that defect.
 ///
-/// The judge shape 2.13 settled returns `(&'static ViolationDef, String)`,
-/// because every arm of that judge had an entry. This rule's judges are half
+/// The first judge converted in this tree — `x_forwarded_consistent`'s —
+/// returns `(&'static ViolationDef, String)`, because every arm of it had an
+/// entry. This rule's judges are half
 /// converted — an `expectation`'s own two failures are its field's and no
 /// subject holds them — so the def is an `Option`, and the site that reports
 /// picks the API from it. **A partially converted judge says which arms are
@@ -468,7 +469,7 @@ pub(crate) fn parse_expectation(member: &str) -> Result<Expectation<'_>, Defect>
         // follows has to be `parameters`.
         let end = token_run_end(rest);
         if end == 0 {
-            // Also unnamed, and for 2.17's reason: an *expectation's* value
+            // Also unnamed, and for the alternation's reason: an *expectation's* value
             // being empty is a per-field verdict, not the alternation's, and
             // `parameter_value_empty` answers for a parameter rather than for
             // whatever else `( token / quoted-string )` is read as.

--- a/lint-http-rules/src/rules/server_timing_header_syntax.rs
+++ b/lint-http-rules/src/rules/server_timing_header_syntax.rs
@@ -153,8 +153,8 @@ pub struct ServerTimingHeaderSyntax;
 ///
 /// **What the document adds is its own and stays unnamed** — four sentences and
 /// one absence. A `;` with no parameter behind it and a parameter with no `=`
-/// are `server-timing-param`'s assembly, which is 2.38's residue for the fourth
-/// and fifth time; a parameter named twice is § 2's SHOULD NOT, the only
+/// are `server-timing-param`'s assembly, which is the residue a borrowed
+/// construct leaves, for the fourth and fifth time; a parameter named twice is § 2's SHOULD NOT, the only
 /// sentence in the document measuring a server; a `dur` that is not a valid
 /// floating-point number and a `desc` spelled in another case are what the two
 /// getters do with what they are given. None of them is a shape a borrowed
@@ -164,8 +164,8 @@ pub struct ServerTimingHeaderSyntax;
 /// reason is written at the site: this parameter is not § 5.6.6's. Its value is
 /// mandatory where § 5.6.6's is optional and its production *prints* the `OWS`
 /// § 5.6.6's Note forbids, so the def's sentence answers a different question
-/// from the one this field asks. 2.39's judgment, at a document that is not even
-/// an RFC.
+/// from the one this field asks — a sentence in another document is not the
+/// same sentence, read here at a document that is not even an RFC.
 ///
 /// Three of the four `quoted_string_*` defs are declared and unreachable
 /// through this rule, and the fourth is reached before any metric is read: a
@@ -575,7 +575,7 @@ fn check_param<'a>(metric: &str, param: &'a str, seen: &mut Vec<&'a str>) -> Opt
     // *"per lenient parsing"*, which is the user agent's job description and
     // not a sentence about what a server may write.
     //
-    // A statement about a repetition's own shape, which is what 2.38's
+    // A statement about a repetition's own shape, which is what `Upgrade`'s
     // `protocol` residue was: no subject holds "this construct generates no such
     // separator", and one rule reading it is not a subject.
     if param.is_empty() {

--- a/lint-http-rules/src/violations/base64.rs
+++ b/lint-http-rules/src/violations/base64.rs
@@ -113,7 +113,8 @@ defects! {
     /// value decodes, and to exactly the octets it meant; what is wrong is that
     /// the same octets have a canonical spelling and this is not it.
     ///
-    /// **`info`, and the ranking is 2.28's read through the recipient again.**
+    /// **`info`, and the ranking is the `http_date` subject's read through the
+    /// recipient again.**
     /// The other three entries name values a decoder is instructed to reject;
     /// § 3.5 leaves a decoder a choice in the same breath it states the
     /// requirement — *"MAY chose to reject an encoding if the pad bits have not
@@ -146,8 +147,9 @@ defects! {
 /// subject nothing has written, and the rule reporting it keeps its own words
 /// until something does.
 ///
-/// The mapping lives here rather than in a file named after the helper for
-/// 2.19's reason — the first thing this reader measures is the encoding, and a
+/// The mapping lives here rather than in a file named after the helper for the
+/// reason every mapping in this catalogue is shelved that way — the first thing
+/// this reader measures is the encoding, and a
 /// subject file holding nothing but a mapping fn would carry no `// cite` and
 /// fail the citation ratchet on the spot.
 pub fn sec_websocket_key_defect(defect: &SecWebSocketKeyDefect) -> Option<&'static ViolationDef> {

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1696,7 +1696,7 @@ sources:
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 211
     - file: lint-http-rules/src/violations/base64.rs
-      line: 129
+      line: 130
 - label: RFC 5234
   url: https://www.rfc-editor.org/rfc/rfc5234.html
   fragments:
@@ -4745,7 +4745,7 @@ sources:
     snippet: The content negotiation fields defined by this specification use a common parameter, named "q" (case-insensitive), to assign a relative "weight" to the preference for that associated kind of content.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 275
+      line: 276
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 404
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
@@ -4755,7 +4755,7 @@ sources:
     snippet: weight = OWS ";" OWS "q=" qvalue
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 178
+      line: 179
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
       line: 149
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
@@ -4769,19 +4769,19 @@ sources:
     snippet: 'Accept-Encoding  = #( codings [ weight ] ) codings          = content-coding / "identity" / "*"'
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 177
+      line: 178
   - label: accept_encoding_parameter_valid (4)
     section: § 12.5.3
     snippet: An "identity" token is used as a synonym for "no encoding" in order to communicate when no encoding is preferred.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 221
+      line: 222
   - label: accept_encoding_parameter_valid (5)
     section: § 12.5.3
     snippet: An Accept-Encoding header field with a field value that is empty implies that the user agent does not want any content coding in response.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 199
+      line: 200
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
       line: 127
   - label: accept_encoding_parameter_valid (6)
@@ -4789,13 +4789,13 @@ sources:
     snippet: Each codings value MAY be given an associated quality value (weight) representing the preference for that encoding, as defined in Section 12.4.2.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 254
+      line: 255
   - label: accept_encoding_parameter_valid (7)
     section: § 12.5.3
     snippet: The asterisk "*" symbol in an Accept-Encoding field matches any available content coding not explicitly listed in the field.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 220
+      line: 221
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
       line: 160
   - label: accept_encoding_parameter_valid (8)
@@ -4803,13 +4803,13 @@ sources:
     snippet: The field value is evaluated the same way as in a request.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 160
+      line: 161
   - label: accept_encoding_parameter_valid (9)
     section: § 12.5.3
     snippet: When sent by a user agent in a request, Accept-Encoding indicates the content codings acceptable in a response.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 158
+      line: 159
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
       line: 119
   - label: accept_encoding_parameter_valid (10)
@@ -4817,13 +4817,13 @@ sources:
     snippet: When the Accept-Encoding header field is present in a response, it indicates what content codings the resource was willing to accept in the associated request.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 159
+      line: 160
   - label: accept_encoding_parameter_valid (11)
     section: § 8.4.1
     snippet: content-coding   = token
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 219
+      line: 220
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 142
   - label: accept_encoding_present
@@ -5207,7 +5207,7 @@ sources:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
       line: 332
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 401
+      line: 402
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
       line: 303
     - file: lint-http-rules/src/rules/http_version_syntax.rs
@@ -5437,7 +5437,7 @@ sources:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 141
     - file: lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
-      line: 118
+      line: 117
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
       line: 145
   - label: compression_and_transfer_encoding_consistent (5)
@@ -5573,7 +5573,7 @@ sources:
     snippet: a sender SHOULD NOT generate representation metadata other than the above listed fields unless said metadata exists for the purpose of guiding cache updates
     cited_by:
     - file: lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
-      line: 191
+      line: 190
   - label: content_encoding_registered
     section: § 12.5.3
     snippet: codings = content-coding / "identity" / "*"
@@ -5745,7 +5745,7 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 14
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 192
+      line: 193
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
       line: 222
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
@@ -5759,7 +5759,7 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 15
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 208
+      line: 209
   - label: context_fields_direction (3)
     section: § 10.1.2
     snippet: The "From" header field contains an Internet email address for a human user who controls the requesting user agent.
@@ -5903,57 +5903,57 @@ sources:
     snippet: A "100-continue" expectation informs recipients that the client is about to send (presumably large) content in this request
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 296
+      line: 297
   - label: expect_header_valid (2)
     section: § 10.1.1
     snippet: A client MUST NOT generate a 100-continue expectation in a request that does not include content.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 295
+      line: 296
   - label: expect_header_valid (3)
     section: § 10.1.1
     snippet: A client that receives a 417 (Expectation Failed) status code in response to a request containing a 100-continue expectation SHOULD repeat that request without a 100-continue expectation, since the 417 response merely indicates that the response chain does not support expectations (e.g., it passes through an HTTP/1.0 server).
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 314
+      line: 315
   - label: expect_header_valid (4)
     section: § 10.1.1
     snippet: A server that receives an Expect field value containing a member other than 100-continue MAY respond with a 417 (Expectation Failed) status code to indicate that the unexpected expectation cannot be met.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 337
+      line: 338
   - label: expect_header_valid (5)
     section: § 10.1.1
     snippet: The Expect field value is case-insensitive.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 91
+      line: 92
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 259
+      line: 260
   - label: expect_header_valid (6)
     section: § 10.1.1
     snippet: The only expectation defined by this specification is "100-continue" (with no defined parameters).
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 90
+      line: 91
   - label: expect_header_valid (7)
     section: § 10.1.1
     snippet: expectation = token [ "=" ( token / quoted-string ) parameters ]
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 400
+      line: 401
   - label: expect_header_valid (8)
     section: § 15.5.18
     snippet: The 417 (Expectation Failed) status code indicates that the expectation given in the request's Expect header field (Section 10.1.1) could not be met by at least one of the inbound servers.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 313
+      line: 314
   - label: expect_header_valid (9)
     section: § 5.6.6
     snippet: 'Note: Parameters do not allow whitespace (not even "bad" whitespace) around the "=" character.'
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 569
+      line: 570
     - file: lint-http-rules/src/violations/parameter.rs
       line: 119
   - label: expect_header_valid (10)
@@ -5961,19 +5961,19 @@ sources:
     snippet: Expect = [ expectation *( OWS "," OWS expectation ) ]
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 244
+      line: 245
   - label: expect_header_valid (11)
     section: § B.3
     snippet: List-based grammar for Expect has been restored for compatibility with RFC 2616.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 223
+      line: 224
   - label: expect_header_valid (12)
     section: § B.3
     snippet: Parameters in media type, media range, and expectation can be empty via one or more trailing semicolons.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 537
+      line: 538
   - label: extension_headers_registered
     section: § 16.3
     snippet: Most fields are designed with the expectation that a recipient can safely ignore (but forward downstream) any field not recognized
@@ -7139,7 +7139,7 @@ sources:
     - file: lint-http-rules/src/helpers/list.rs
       line: 84
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 200
+      line: 201
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 207
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
@@ -7285,7 +7285,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 383
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 501
+      line: 502
   - label: parameter-value grammar
     section: § 5.6.6
     snippet: parameter-value = ( token / quoted-string )
@@ -7295,7 +7295,7 @@ sources:
     - file: lint-http-rules/src/helpers/word.rs
       line: 26
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 502
+      line: 503
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 89
     - file: lint-http-rules/src/violations/parameter.rs
@@ -7313,7 +7313,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 221
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 499
+      line: 500
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
       line: 264
   - label: lint-http-rules/src/helpers/media_type.rs (5)
@@ -7375,7 +7375,7 @@ sources:
     - file: lint-http-rules/src/helpers/parameter.rs
       line: 107
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 500
+      line: 501
     - file: lint-http-rules/src/violations/parameter.rs
       line: 69
   - label: lint-http-rules/src/helpers/product.rs
@@ -7463,7 +7463,7 @@ sources:
     - file: lint-http-rules/src/helpers/qvalue.rs
       line: 31
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 304
+      line: 305
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
       line: 223
     - file: lint-http-rules/src/violations/qvalue.rs


### PR DESCRIPTION
Fourteen doc comments and inline notes across six files explained a decision by citing a working note's numbering — "the shape 2.13 settled", "2.38's residue", "one of S6's duplicate templates". A reader of this repository can open none of those, and the form reads like a citation while resolving to nothing. Each now names the thing it meant: the first converted judge, the residue a borrowed construct leaves, a message written twice in two files.

The earlier pass over this looked for `N.M's` alone, which is why "2.13 settled" and every `S6` survived it. The grep that finds them all also has to allow for a verb after the number and for the spike labels.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
