### PR TITLE
A coding name is octets, not an encoding

### DIFF
--- a/docs/rules/content_encoding_and_type_consistent.md
+++ b/docs/rules/content_encoding_and_type_consistent.md
@@ -16,6 +16,8 @@ Repeating a coding is likewise a judgement call rather than a conformance failur
 
 **Note:** despite the rule's name, no `Content-Type` consistency check is performed; the rule inspects `Content-Encoding` only.
 
+**The value is read as octets and over the whole field section.** Every character of a `token` is visible US-ASCII, so an `obs-text` octet in a coding name is reported for what it is — a character the production does not admit, named as the byte it is — rather than as a verdict about the field's encoding. It used to be the second: a value the string reader refused was reported as *not valid UTF-8*, which is a claim about the whole value where the defect is one character of one member. The lines of a section are joined first, because `#content-coding` makes them one list.
+
 ## Specifications
 
 - [RFC 9110 §8.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4): `Content-Encoding = #content-coding` — the list the member checks walk. Note it does not forbid repeating a coding, so the duplicate check is this rule's judgement

--- a/docs/rules/content_encoding_registered.md
+++ b/docs/rules/content_encoding_registered.md
@@ -14,6 +14,8 @@ Validate `Content-Encoding` and `Accept-Encoding` header values: each content-co
 
 The two headers do not share a vocabulary. `Accept-Encoding` additionally admits `*` (matching any coding not listed) and `identity` (meaning no encoding); both are preference vocabulary and neither is a content-coding, so in `Content-Encoding` they are flagged — `identity` explicitly so, since RFC 9110 §8.4 reserves it for its Accept-Encoding role and says it SHOULD NOT be included.
 
+**Both fields are read as octets and over the whole field section.** A coding name holding an octet outside visible US-ASCII is not a `token` and is reported as that; the reader this replaces refused such a value outright, so the field went unread and unreported. It also took only the first field line, where `#content-coding` makes every line of a section one list.
+
 ## Specifications
 
 - [RFC 9110 §8.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4): `Content-Encoding = #content-coding`, and the reservation of `identity` for Accept-Encoding — the reason it is flagged here

--- a/lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
+++ b/lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
@@ -60,7 +60,7 @@ severity = "warn"
     }
 
     fn description(&self) -> &'static str {
-        "Validate `Content-Encoding` header members for common correctness issues: members must be valid `token`s, a wildcard `*` is rejected (it belongs to `Accept-Encoding`), and a coding repeated within the field is flagged.\n\nResponses that carry no content (1xx, 204, 304) are flagged for sending `Content-Encoding` at all. For 304 this follows RFC 9110 §15.4.5, which tells a sender not to include representation metadata beyond a listed set; for 1xx and 204 it is this rule's inference that a coding describing absent content is a misconfiguration.\n\nRepeating a coding is likewise a judgement call rather than a conformance failure — `gzip, gzip` legitimately expresses gzip applied twice — but in practice it usually means two layers each added the header.\n\n**Note:** despite the rule's name, no `Content-Type` consistency check is performed; the rule inspects `Content-Encoding` only."
+        "Validate `Content-Encoding` header members for common correctness issues: members must be valid `token`s, a wildcard `*` is rejected (it belongs to `Accept-Encoding`), and a coding repeated within the field is flagged.\n\nResponses that carry no content (1xx, 204, 304) are flagged for sending `Content-Encoding` at all. For 304 this follows RFC 9110 §15.4.5, which tells a sender not to include representation metadata beyond a listed set; for 1xx and 204 it is this rule's inference that a coding describing absent content is a misconfiguration.\n\nRepeating a coding is likewise a judgement call rather than a conformance failure — `gzip, gzip` legitimately expresses gzip applied twice — but in practice it usually means two layers each added the header.\n\n**Note:** despite the rule's name, no `Content-Type` consistency check is performed; the rule inspects `Content-Encoding` only.\n\n**The value is read as octets and over the whole field section.** Every character of a `token` is visible US-ASCII, so an `obs-text` octet in a coding name is reported for what it is — a character the production does not admit, named as the byte it is — rather than as a verdict about the field's encoding. It used to be the second: a value the string reader refused was reported as *not valid UTF-8*, which is a claim about the whole value where the defect is one character of one member. The lines of a section are joined first, because `#content-coding` makes them one list."
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
@@ -138,9 +138,18 @@ impl Rule for ContentEncodingAndTypeConsistent {
                         ));
                     }
                     if let Some(c) = crate::helpers::token::find_invalid_token_char(token) {
+                        // Rendered rather than written through: the value is
+                        // read as octets, so what stopped the scan may be an
+                        // `obs-text` byte a recipient is told to treat as
+                        // opaque -- and `0xE9` is what that byte is, where `é`
+                        // is a reading of it.
                         return Some(ctx.report_with(
                             token_character(c),
-                            format!("Invalid token '{}' in {} header", c, hdr_name),
+                            format!(
+                                "Invalid token {} in {} header",
+                                crate::helpers::shown::describe_char(c),
+                                hdr_name
+                            ),
                         ));
                     }
                     // Repeating a coding is not forbidden anywhere: §8.4 has the sender list
@@ -160,17 +169,19 @@ impl Rule for ContentEncodingAndTypeConsistent {
                 None
             };
 
-            // Check request Content-Encoding header(s) (track across multiple header fields)
+            // The lines of a section are one list, read as octets. `to_str`
+            // refuses everything outside visible US-ASCII, which folded an
+            // `obs-text` octet in a coding name into a verdict about the
+            // field's encoding -- a claim about the whole value where the
+            // defect is one character of one member, and one this rule already
+            // had an id for. Reading the octets is what lets that id answer.
             {
                 let mut seen = std::collections::HashSet::new();
-                for hv in tx.request.headers.get_all("content-encoding").iter() {
-                    let Ok(val) = hv.to_str() else {
-                        return Some(self.violation(
-                            ctx.severity,
-                            "Content-Encoding header value is not valid UTF-8".into(),
-                        ));
-                    };
-                    if let Some(v) = check_encoding_header("Content-Encoding", val, &mut seen) {
+                if let Some(val) = crate::helpers::headers::combined_field_value_as_written(
+                    &tx.request.headers,
+                    "content-encoding",
+                ) {
+                    if let Some(v) = check_encoding_header("Content-Encoding", &val, &mut seen) {
                         return Some(v);
                     }
                 }
@@ -208,14 +219,11 @@ impl Rule for ContentEncodingAndTypeConsistent {
                 }
 
                 let mut seen = std::collections::HashSet::new();
-                for hv in resp.headers.get_all("content-encoding").iter() {
-                    let Ok(val) = hv.to_str() else {
-                        return Some(self.violation(
-                            ctx.severity,
-                            "Content-Encoding header value is not valid UTF-8".into(),
-                        ));
-                    };
-                    if let Some(v) = check_encoding_header("Content-Encoding", val, &mut seen) {
+                if let Some(val) = crate::helpers::headers::combined_field_value_as_written(
+                    &resp.headers,
+                    "content-encoding",
+                ) {
+                    if let Some(v) = check_encoding_header("Content-Encoding", &val, &mut seen) {
                         return Some(v);
                     }
                 }
@@ -389,7 +397,7 @@ mod tests {
     }
 
     #[test]
-    fn non_utf8_value_reports_violation() {
+    fn an_obs_text_octet_is_a_token_defect_not_an_encoding_verdict() {
         let rule = ContentEncodingAndTypeConsistent;
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.response = Some(crate::http_transaction::ResponseInfo {
@@ -411,12 +419,9 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
-        assert!(violation.is_some());
-        let v = violation.unwrap();
-        assert_eq!(
-            v.message,
-            "Content-Encoding header value is not valid UTF-8"
-        );
+        let v = violation.expect("a finding");
+        assert_eq!(v.violation, "token_character_forbidden");
+        assert_eq!(v.message, "Invalid token 0xFF in Content-Encoding header");
     }
     #[test]
     fn request_trailing_comma_accepted() {
@@ -534,7 +539,7 @@ mod tests {
     }
 
     #[test]
-    fn request_non_utf8_value_reports_violation() -> anyhow::Result<()> {
+    fn a_requests_obs_text_octet_is_the_same_token_defect() -> anyhow::Result<()> {
         let rule = ContentEncodingAndTypeConsistent;
         let mut tx = crate::test_helpers::make_test_transaction();
         use hyper::header::HeaderValue;
@@ -548,12 +553,9 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
-        assert!(v.is_some());
-        let v = v.unwrap();
-        assert_eq!(
-            v.message,
-            "Content-Encoding header value is not valid UTF-8"
-        );
+        let v = v.expect("a finding");
+        assert_eq!(v.violation, "token_character_forbidden");
+        assert_eq!(v.message, "Invalid token 0xFF in Content-Encoding header");
         Ok(())
     }
 

--- a/lint-http-rules/src/rules/content_encoding_registered.rs
+++ b/lint-http-rules/src/rules/content_encoding_registered.rs
@@ -88,7 +88,7 @@ allowed = ["aes128gcm", "br", "compress", "dcb", "dcz", "deflate", "exi", "gzip"
     }
 
     fn description(&self) -> &'static str {
-        "Validate `Content-Encoding` and `Accept-Encoding` header values: each content-coding must be a valid `token` and must appear in the `allowed` array you configure.\n\n**It does not consult the IANA registry**, despite the rule's name. RFC 9110 says content codings *ought to* be registered, which is the motivation, but a coding is recognised here exactly when your `allowed` array covers it. Comparisons are case-insensitive.\n\nThe two headers do not share a vocabulary. `Accept-Encoding` additionally admits `*` (matching any coding not listed) and `identity` (meaning no encoding); both are preference vocabulary and neither is a content-coding, so in `Content-Encoding` they are flagged — `identity` explicitly so, since RFC 9110 §8.4 reserves it for its Accept-Encoding role and says it SHOULD NOT be included."
+        "Validate `Content-Encoding` and `Accept-Encoding` header values: each content-coding must be a valid `token` and must appear in the `allowed` array you configure.\n\n**It does not consult the IANA registry**, despite the rule's name. RFC 9110 says content codings *ought to* be registered, which is the motivation, but a coding is recognised here exactly when your `allowed` array covers it. Comparisons are case-insensitive.\n\nThe two headers do not share a vocabulary. `Accept-Encoding` additionally admits `*` (matching any coding not listed) and `identity` (meaning no encoding); both are preference vocabulary and neither is a content-coding, so in `Content-Encoding` they are flagged — `identity` explicitly so, since RFC 9110 §8.4 reserves it for its Accept-Encoding role and says it SHOULD NOT be included.\n\n**Both fields are read as octets and over the whole field section.** A coding name holding an octet outside visible US-ASCII is not a `token` and is reported as that; the reader this replaces refused such a value outright, so the field went unread and unreported. It also took only the first field line, where `#content-coding` makes every line of a section one list."
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
@@ -180,10 +180,16 @@ impl Rule for ContentEncodingRegistered {
                     if let Some(c) = crate::helpers::token::find_invalid_token_char(token) {
                         // `content-coding = token` adds nothing to the
                         // production, so which of the two ids the octet draws is
-                        // `token`'s question and not this field's.
+                        // `token`'s question and not this field's. Rendered for
+                        // the reason its neighbour renders it: the value is read
+                        // as octets and an `obs-text` byte is named, not shown.
                         return Some(ctx.report_with(
                             token_character(c),
-                            format!("Invalid token '{}' in {} header", c, hdr_name),
+                            format!(
+                                "Invalid token {} in {} header",
+                                crate::helpers::shown::describe_char(c),
+                                hdr_name
+                            ),
                         ));
                     }
                     // Folded to lowercase because the codings are case-insensitive. As
@@ -204,22 +210,30 @@ impl Rule for ContentEncodingRegistered {
                 None
             };
 
-            // Check response Content-Encoding
+            // Both fields are read as octets and over the whole section. The
+            // reader this replaces took the first field line and refused every
+            // value outside visible US-ASCII, so a coding name holding an
+            // `obs-text` byte was not reported at all -- the field simply
+            // stopped existing for this rule -- and a second field line was
+            // never looked at, though `#content-coding` makes the lines one
+            // list.
             if let Some(resp) = &tx.response {
-                if let Some(val) =
-                    crate::helpers::headers::get_header_str(&resp.headers, "content-encoding")
-                {
-                    if let Some(v) = check_value("Content-Encoding", val, &config.allowed, false) {
+                if let Some(val) = crate::helpers::headers::combined_field_value_as_written(
+                    &resp.headers,
+                    "content-encoding",
+                ) {
+                    if let Some(v) = check_value("Content-Encoding", &val, &config.allowed, false) {
                         return Some(v);
                     }
                 }
             }
 
             // Check request Accept-Encoding
-            if let Some(val) =
-                crate::helpers::headers::get_header_str(&tx.request.headers, "accept-encoding")
-            {
-                if let Some(v) = check_value("Accept-Encoding", val, &config.allowed, true) {
+            if let Some(val) = crate::helpers::headers::combined_field_value_as_written(
+                &tx.request.headers,
+                "accept-encoding",
+            ) {
+                if let Some(v) = check_value("Accept-Encoding", &val, &config.allowed, true) {
                     return Some(v);
                 }
             }
@@ -604,12 +618,17 @@ mod tests {
         Ok(())
     }
 
+    /// This used to assert the opposite -- that a value outside visible
+    /// US-ASCII is *ignored* -- which was the reader's behaviour rather than a
+    /// reading of the field: `content-coding = token`, and no `tchar` is above
+    /// %x7E, so an `obs-text` octet in a coding name is a defect of the name
+    /// and not a property of the field. Both directions now say so, with the
+    /// id every other reader of the production uses.
     #[test]
-    fn non_utf8_header_values_are_ignored() {
+    fn an_obs_text_octet_in_a_coding_name_is_a_token_defect() {
         let rule = ContentEncodingRegistered;
         let cfg = make_cfg();
 
-        // Non-utf8 response header value should be ignored and produce no violation
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         let mut hm = hyper::HeaderMap::new();
         hm.insert(
@@ -622,10 +641,11 @@ mod tests {
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-        );
-        assert!(v.is_none());
+        )
+        .expect("a finding");
+        assert_eq!(v.violation, "token_character_forbidden");
+        assert_eq!(v.message, "Invalid token 0xFF in Content-Encoding header");
 
-        // Non-utf8 request header value should be ignored
         let mut tx2 = crate::test_helpers::make_test_transaction();
         let mut hm2 = hyper::HeaderMap::new();
         hm2.insert("accept-encoding", HeaderValue::from_bytes(b"\xff").unwrap());
@@ -635,8 +655,10 @@ mod tests {
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-        );
-        assert!(v2.is_none());
+        )
+        .expect("a finding");
+        assert_eq!(v2.violation, "token_character_forbidden");
+        assert_eq!(v2.message, "Invalid token 0xFF in Accept-Encoding header");
     }
     #[test]
     fn request_custom_allowed_is_accepted() -> anyhow::Result<()> {

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -5465,7 +5465,7 @@ sources:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 161
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
-      line: 193
+      line: 199
   - label: conditional_headers_consistent
     section: § 13.1.3
     snippet: A recipient MUST ignore If-Modified-Since if the request contains an If-None-Match header field
@@ -5573,7 +5573,7 @@ sources:
     snippet: a sender SHOULD NOT generate representation metadata other than the above listed fields unless said metadata exists for the purpose of guiding cache updates
     cited_by:
     - file: lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
-      line: 190
+      line: 201
   - label: content_encoding_registered
     section: § 12.5.3
     snippet: codings = content-coding / "identity" / "*"


### PR DESCRIPTION
Both readers of `content-coding = token` went through the string reader, which refuses everything outside visible US-ASCII: one rule reported that as *not valid UTF-8* — a claim about the whole value where the defect is one character of one member — and the other reported nothing at all, because the field simply stopped existing for it. No `tchar` is above %x7E, so an `obs-text` octet in a coding name is the name's defect, and both rules already had the id for it.

The value is now read over the whole field section, as octets, and the byte is named as a byte: `0xFF` rather than the character it would be a reading of. Joining the lines first is `#content-coding` — the reader that took only the first line was answering about a list that has more of it.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
