### PR TITLE
A directive name is octets, not an encoding

### DIFF
--- a/docs/rules/pragma_token_valid.md
+++ b/docs/rules/pragma_token_valid.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: ISC
 ## Description
 
 The `Pragma` header directives must follow directive syntax: a `token` optionally followed by `=token` or `="quoted-string"`.
-This rule flags malformed directives, invalid token characters, empty members, and non-UTF8 header values.
+This rule flags malformed directives, invalid token characters and empty members. The value is read as octets over the whole field section, so an octet outside visible US-ASCII in a directive name is reported as the character the production does not admit — not as a verdict about the field's encoding, which is what the reader this replaces made of it.
 `Pragma` is deprecated by RFC 9111 §5.4, which no longer specifies its grammar; this validates the historical HTTP/1.0 directive syntax (originally RFC 7234 §5.4).
 
 ## Specifications

--- a/lint-http-rules/src/helpers/cache_control.rs
+++ b/lint-http-rules/src/helpers/cache_control.rs
@@ -189,8 +189,16 @@ impl MemberDefect<'_> {
             Self::NameEmpty(member) => {
                 format!("Empty directive name in Cache-Control member: '{}'", member)
             }
+            // Named rather than written through: the callers read the field
+            // as octets, so this may be an `obs-text` byte a recipient is told
+            // to treat as opaque -- `0xE9` is what it is, `é` a reading of it.
+            // Every octet the old string reader could deliver renders exactly
+            // as it did, because the quotes are the helper's.
             Self::NameCharacter(c) => {
-                format!("Directive name contains invalid character: '{}'", c)
+                format!(
+                    "Directive name contains invalid character: {}",
+                    crate::helpers::shown::describe_char(c)
+                )
             }
         }
     }

--- a/lint-http-rules/src/rules/cache_control_directive_valid.rs
+++ b/lint-http-rules/src/rules/cache_control_directive_valid.rs
@@ -28,10 +28,6 @@ pub struct CacheControlDirectiveValid;
 /// measures is one another field already reports through. What stays unnamed is
 /// the part its neighbour does not read — what each *named* directive means by
 /// its argument — which is the only thing left here that no production says.
-///
-/// The non-UTF-8 site stays on the old API, with open question 1's reasoning:
-/// the verdict names an encoding where the defect is an octet the grammar does
-/// not admit, and the right conversion is an octet-wise reader first.
 static DECLARED: &[&ViolationDef] = &[
     &LIST_MEMBER_EMPTY,
     &TOKEN_EMPTY,
@@ -94,35 +90,31 @@ impl Defect {
 impl CacheControlDirectiveValid {
     /// The first defect in one message's `Cache-Control` field, if it has one.
     ///
-    /// Read line by line rather than over the whole section, because an
-    /// unreadable line is one of the findings and the field line is what that
-    /// finding is about. Where the members come from, and which of them the
-    /// grammar's `#element` even admits, is
-    /// [`crate::helpers::cache_control`]'s answer.
+    /// Read over the whole section and as octets. `Cache-Control =
+    /// #cache-directive` makes the field lines of a section one list, and a
+    /// directive name holding an octet outside visible US-ASCII is a `token`
+    /// defect rather than a fact about the field's encoding — which is what
+    /// reading line by line through the string reader made it. Where the
+    /// members come from, and which of them the grammar's `#element` even
+    /// admits, is [`crate::helpers::cache_control`]'s answer.
     fn defect(
         &self,
         headers: &hyper::HeaderMap,
         side: &str,
         ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        for line in headers.get_all("cache-control").iter() {
-            let Ok(line) = line.to_str() else {
-                return Some(self.violation(
-                    ctx.severity,
-                    "Cache-Control header contains non-UTF8 value".into(),
-                ));
-            };
-            for member in crate::helpers::cache_control::members_of(line) {
-                if let Some(defect) = member_defect(member) {
-                    let message = format!(
-                        "Invalid Cache-Control header in {}: {}",
-                        side, defect.message
-                    );
-                    return Some(match defect.def {
-                        Some(def) => ctx.report_with(def, message),
-                        None => self.violation(ctx.severity, message),
-                    });
-                }
+        let value =
+            crate::helpers::headers::combined_field_value_as_written(headers, "cache-control")?;
+        for member in crate::helpers::cache_control::members_of(&value) {
+            if let Some(defect) = member_defect(member) {
+                let message = format!(
+                    "Invalid Cache-Control header in {}: {}",
+                    side, defect.message
+                );
+                return Some(match defect.def {
+                    Some(def) => ctx.report_with(def, message),
+                    None => self.violation(ctx.severity, message),
+                });
             }
         }
         None
@@ -464,7 +456,7 @@ mod tests {
     }
 
     #[test]
-    fn non_utf8_value_is_violation() -> anyhow::Result<()> {
+    fn an_obs_text_octet_in_a_directive_name_is_a_token_defect() -> anyhow::Result<()> {
         use hyper::header::HeaderValue;
         let rule = CacheControlDirectiveValid;
         let mut tx = crate::test_helpers::make_test_transaction();
@@ -478,7 +470,12 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
-        assert!(v.is_some());
+        let v = v.expect("a finding");
+        assert_eq!(v.violation, "token_character_forbidden");
+        assert_eq!(
+            v.message,
+            "Invalid Cache-Control header in request: Directive name contains invalid character: 0xFF"
+        );
         Ok(())
     }
 
@@ -709,7 +706,7 @@ mod tests {
     }
 
     #[test]
-    fn response_non_utf8_value_is_violation() -> anyhow::Result<()> {
+    fn a_responses_obs_text_octet_is_the_same_token_defect() -> anyhow::Result<()> {
         use hyper::header::HeaderValue;
         let rule = CacheControlDirectiveValid;
         let mut tx = crate::test_helpers::make_test_transaction();
@@ -730,7 +727,12 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
-        assert!(v.is_some());
+        let v = v.expect("a finding");
+        assert_eq!(v.violation, "token_character_forbidden");
+        assert_eq!(
+            v.message,
+            "Invalid Cache-Control header in response: Directive name contains invalid character: 0xFF"
+        );
         Ok(())
     }
 

--- a/lint-http-rules/src/rules/cache_control_token_valid.rs
+++ b/lint-http-rules/src/rules/cache_control_token_valid.rs
@@ -30,10 +30,6 @@ pub struct CacheControlTokenValid;
 /// each rule had to word a finding about a production neither of them owns.
 /// They are one id apiece now, which is the state Phase 5's dedup can act on and
 /// a rule-shaped catalogue could not reach.
-///
-/// The non-UTF-8 site stays on the old API, with open question 1's reasoning:
-/// the verdict names an encoding where the defect is an octet the grammar does
-/// not admit, and the right conversion is an octet-wise reader first.
 static DECLARED: &[&ViolationDef] = &[
     &LIST_MEMBER_EMPTY,
     &TOKEN_EMPTY,
@@ -58,31 +54,27 @@ const RFC_9111_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
 impl CacheControlTokenValid {
     /// The first defect in one message's `Cache-Control` field, if it has one.
     ///
-    /// Read line by line rather than over the whole section, because an
-    /// unreadable line is one of the findings and the field line is what that
-    /// finding is about. Where the members come from, and which of them the
-    /// grammar's `#element` even admits, is
-    /// [`crate::helpers::cache_control`]'s answer.
+    /// Read over the whole section and as octets. `Cache-Control =
+    /// #cache-directive` makes the field lines of a section one list, and a
+    /// directive name holding an octet outside visible US-ASCII is a `token`
+    /// defect rather than a fact about the field's encoding — which is what
+    /// reading line by line through the string reader made it. Where the
+    /// members come from, and which of them the grammar's `#element` even
+    /// admits, is [`crate::helpers::cache_control`]'s answer.
     fn defect(
         &self,
         headers: &hyper::HeaderMap,
         side: &str,
         ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        for line in headers.get_all("cache-control").iter() {
-            let Ok(line) = line.to_str() else {
-                return Some(self.violation(
-                    ctx.severity,
-                    "Cache-Control header contains non-UTF8 value".into(),
+        let value =
+            crate::helpers::headers::combined_field_value_as_written(headers, "cache-control")?;
+        for member in crate::helpers::cache_control::members_of(&value) {
+            if let Some((def, message)) = member_defect(member) {
+                return Some(ctx.report_with(
+                    def,
+                    format!("Invalid Cache-Control header in {}: {}", side, message),
                 ));
-            };
-            for member in crate::helpers::cache_control::members_of(line) {
-                if let Some((def, message)) = member_defect(member) {
-                    return Some(ctx.report_with(
-                        def,
-                        format!("Invalid Cache-Control header in {}: {}", side, message),
-                    ));
-                }
             }
         }
         None
@@ -281,7 +273,7 @@ mod tests {
     }
 
     #[test]
-    fn non_utf8_value_is_violation() -> anyhow::Result<()> {
+    fn an_obs_text_octet_in_a_directive_name_is_a_token_defect() -> anyhow::Result<()> {
         use hyper::header::HeaderValue;
         let rule = CacheControlTokenValid;
         let mut tx = crate::test_helpers::make_test_transaction();
@@ -295,7 +287,12 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
-        assert!(v.is_some());
+        let v = v.expect("a finding");
+        assert_eq!(v.violation, "token_character_forbidden");
+        assert_eq!(
+            v.message,
+            "Invalid Cache-Control header in request: Directive name contains invalid character: 0xFF"
+        );
         Ok(())
     }
 
@@ -421,7 +418,7 @@ mod tests {
     }
 
     #[test]
-    fn response_non_utf8_value_is_violation() -> anyhow::Result<()> {
+    fn a_responses_obs_text_octet_is_the_same_token_defect() -> anyhow::Result<()> {
         use hyper::header::HeaderValue;
         let rule = CacheControlTokenValid;
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
@@ -435,7 +432,12 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
-        assert!(v.is_some());
+        let v = v.expect("a finding");
+        assert_eq!(v.violation, "token_character_forbidden");
+        assert_eq!(
+            v.message,
+            "Invalid Cache-Control header in response: Directive name contains invalid character: 0xFF"
+        );
         Ok(())
     }
 

--- a/lint-http-rules/src/rules/pragma_token_valid.rs
+++ b/lint-http-rules/src/rules/pragma_token_valid.rs
@@ -29,11 +29,6 @@ use crate::violations::ViolationDef;
 /// words, which is one of the fourteen duplicate templates the campaign's
 /// measurement found; when it converts, the two rules will report one id apiece
 /// rather than two identical sentences under two rule names.
-///
-/// The non-UTF-8 site stays on the old API. Its verdict is the wrong claim —
-/// `to_str` refuses every octet outside visible US-ASCII, so the finding names
-/// an encoding where the defect is an octet the grammar does not admit — and
-/// the right conversion is an octet-wise reader first, not a def for the claim.
 static DECLARED: &[&ViolationDef] = &[
     &LIST_MEMBER_EMPTY,
     &TOKEN_EMPTY,
@@ -47,7 +42,7 @@ static DECLARED: &[&ViolationDef] = &[
 
 /// `Pragma` header directives must follow `directive = token ["=" ( token / quoted-string )]`
 /// and be syntactically valid. This rule flags invalid tokens, malformed quoted-strings,
-/// non-UTF8 header values, and empty list members.
+/// empty list members, and directive names holding an octet no `tchar` admits.
 ///
 /// RFC 9111 §5.4 defines `Pragma` (an HTTP/1.0 request field) but *deprecates* it and no
 /// longer specifies a grammar for it; the `token ["=" (token / quoted-string)]` directive
@@ -78,7 +73,7 @@ severity = "warn"
     }
 
     fn description(&self) -> &'static str {
-        "The `Pragma` header directives must follow directive syntax: a `token` optionally followed by `=token` or `=\"quoted-string\"`.\nThis rule flags malformed directives, invalid token characters, empty members, and non-UTF8 header values.\n`Pragma` is deprecated by RFC 9111 §5.4, which no longer specifies its grammar; this validates the historical HTTP/1.0 directive syntax (originally RFC 7234 §5.4)."
+        "The `Pragma` header directives must follow directive syntax: a `token` optionally followed by `=token` or `=\"quoted-string\"`.\nThis rule flags malformed directives, invalid token characters and empty members. The value is read as octets over the whole field section, so an octet outside visible US-ASCII in a directive name is reported as the character the production does not admit — not as a verdict about the field's encoding, which is what the reader this replaces made of it.\n`Pragma` is deprecated by RFC 9111 §5.4, which no longer specifies its grammar; this validates the historical HTTP/1.0 directive syntax (originally RFC 7234 §5.4)."
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
@@ -129,60 +124,54 @@ impl Rule for PragmaTokenValid {
     ) -> Vec<Violation> {
         // Single-finding body behind an Option: `?` ends it early, and the
         // one finding (or none) becomes the vector.
-        let finding =
-            || -> Option<Violation> {
-                // Validate request headers
-                // cite(RFC 9111 § 5.4): "The "Pragma" request header field was defined for HTTP/1.0 caches, so that clients could specify a "no-cache" request"
-                for header_val in tx.request.headers.get_all("pragma").iter() {
-                    if let Some(v) = header_val.to_str().ok().map(|s| s.trim()) {
-                        // An entirely empty Pragma value is a legal zero-element list, distinct from
-                        // an empty element *within* a list (flagged in check_pragma_value). Skip it.
-                        if v.is_empty() {
-                            continue;
-                        }
-                        if let Some((def, msg)) = check_pragma_value(v) {
-                            return Some(ctx.report_with(
-                                def,
-                                format!("Invalid Pragma header in request: {}", msg),
-                            ));
-                        }
-                    } else {
-                        return Some(self.violation(
-                            ctx.severity,
-                            "Pragma header contains non-UTF8 value".into(),
+        let finding = || -> Option<Violation> {
+            // Validate request headers
+            // cite(RFC 9111 § 5.4): "The "Pragma" request header field was defined for HTTP/1.0 caches, so that clients could specify a "no-cache" request"
+            // Read as octets, and over the section: the historical
+            // production is a `#`-list, so the field lines of one section
+            // are one list, and an octet outside visible US-ASCII in a
+            // directive name is the `token`'s defect rather than a verdict
+            // about the field's encoding.
+            if let Some(v) = crate::helpers::headers::combined_field_value_as_written(
+                &tx.request.headers,
+                "pragma",
+            ) {
+                // An entirely empty Pragma value is a legal zero-element list, distinct from
+                // an empty element *within* a list (flagged in check_pragma_value). Skip it.
+                let v = v.trim();
+                if !v.is_empty() {
+                    if let Some((def, msg)) = check_pragma_value(v) {
+                        return Some(ctx.report_with(
+                            def,
+                            format!("Invalid Pragma header in request: {}", msg),
                         ));
                     }
                 }
+            }
 
-                // Validate response headers too. Pragma is a deprecated request field whose meaning in
-                // responses was never specified (§5.4 Note), so this is a pure well-formedness check for
-                // a field that should not appear here at all.
-                // cite(RFC 9111 § 5.4): "As a result, this specification deprecates Pragma."
-                if let Some(resp) = &tx.response {
-                    for header_val in resp.headers.get_all("pragma").iter() {
-                        if let Some(v) = header_val.to_str().ok().map(|s| s.trim()) {
-                            // An entirely empty Pragma value is a legal zero-element list, distinct from
-                            // an empty element *within* a list (flagged in check_pragma_value). Skip it.
-                            if v.is_empty() {
-                                continue;
-                            }
-                            if let Some((def, msg)) = check_pragma_value(v) {
-                                return Some(ctx.report_with(
-                                    def,
-                                    format!("Invalid Pragma header in response: {}", msg),
-                                ));
-                            }
-                        } else {
-                            return Some(self.violation(
-                                ctx.severity,
-                                "Pragma header contains non-UTF8 value".into(),
+            // Validate response headers too. Pragma is a deprecated request field whose meaning in
+            // responses was never specified (§5.4 Note), so this is a pure well-formedness check for
+            // a field that should not appear here at all.
+            // cite(RFC 9111 § 5.4): "As a result, this specification deprecates Pragma."
+            if let Some(resp) = &tx.response {
+                if let Some(v) = crate::helpers::headers::combined_field_value_as_written(
+                    &resp.headers,
+                    "pragma",
+                ) {
+                    let v = v.trim();
+                    if !v.is_empty() {
+                        if let Some((def, msg)) = check_pragma_value(v) {
+                            return Some(ctx.report_with(
+                                def,
+                                format!("Invalid Pragma header in response: {}", msg),
                             ));
                         }
                     }
                 }
+            }
 
-                None
-            };
+            None
+        };
         Vec::from_iter(finding())
     }
 }
@@ -218,7 +207,10 @@ fn check_pragma_value(s: &str) -> Option<(&'static ViolationDef, String)> {
         if let Some(c) = crate::helpers::token::find_invalid_token_char(name) {
             return Some((
                 token_character(c),
-                format!("Directive name contains invalid character: '{}'", c),
+                format!(
+                    "Directive name contains invalid character: {}",
+                    crate::helpers::shown::describe_char(c)
+                ),
             ));
         }
 
@@ -478,7 +470,7 @@ mod tests {
     }
 
     #[test]
-    fn non_utf8_value_is_violation() -> anyhow::Result<()> {
+    fn an_obs_text_octet_in_a_directive_name_is_a_token_defect() -> anyhow::Result<()> {
         use hyper::header::HeaderValue;
         let rule = PragmaTokenValid;
         let mut tx = crate::test_helpers::make_test_transaction();
@@ -492,7 +484,12 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
-        assert!(v.is_some());
+        let v = v.expect("a finding");
+        assert_eq!(v.violation, "token_character_forbidden");
+        assert_eq!(
+            v.message,
+            "Invalid Pragma header in request: Directive name contains invalid character: 0xFF"
+        );
         Ok(())
     }
 
@@ -510,7 +507,7 @@ mod tests {
     }
 
     #[test]
-    fn response_non_utf8_value_is_violation() -> anyhow::Result<()> {
+    fn a_responses_obs_text_octet_is_the_same_token_defect() -> anyhow::Result<()> {
         use hyper::header::HeaderValue;
         let rule = PragmaTokenValid;
         let mut tx = crate::test_helpers::make_test_transaction();
@@ -530,7 +527,12 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
-        assert!(v.is_some());
+        let v = v.expect("a finding");
+        assert_eq!(v.violation, "token_character_forbidden");
+        assert_eq!(
+            v.message,
+            "Invalid Pragma header in response: Directive name contains invalid character: 0xFF"
+        );
         Ok(())
     }
 

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -5349,7 +5349,7 @@ sources:
     snippet: A field name labels the corresponding field value as having the semantics defined by that name.
     cited_by:
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 312
+      line: 304
   - label: cache_validation_chain
     section: § 13.1.2
     snippet: The "If-None-Match" header field makes the request method conditional on a recipient cache or origin server either not having any current representation of the target resource, when the field value is "*"
@@ -6655,7 +6655,7 @@ sources:
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 609
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
-      line: 197
+      line: 186
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
       line: 343
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
@@ -6709,7 +6709,7 @@ sources:
     - file: lint-http-rules/src/helpers/cache_control.rs
       line: 112
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 339
+      line: 331
   - label: lint-http-rules/src/helpers/comment.rs
     section: § 5.6.4
     snippet: The backslash octet ("\") can be used as a single-octet quoting mechanism within quoted-string and comment constructs.
@@ -7489,7 +7489,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 407
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
-      line: 208
+      line: 197
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
       line: 205
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
@@ -9314,7 +9314,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 315
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 261
+      line: 253
   - label: age_header_numeric (2)
     section: § 1.2.2
     snippet: or the greatest positive integer it can conveniently represent.
@@ -9324,7 +9324,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 316
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 262
+      line: 254
   - label: age_header_numeric (3)
     section: § 5.1
     snippet: Although it is defined as a singleton header field, a cache encountering a message with a list-based Age field value SHOULD use the first member of the field value, discarding subsequent ones.
@@ -9346,7 +9346,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 304
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 235
+      line: 227
   - label: cache_coherence
     section: § 4.2.4
     snippet: A cache MUST NOT generate a stale response unless it is disconnected or doing so is explicitly permitted by the client or origin server
@@ -9366,27 +9366,27 @@ sources:
     - file: lint-http-rules/src/rules/cache_control_and_pragma_consistent.rs
       line: 84
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
-      line: 135
+      line: 129
   - label: cache_control_directive_valid
     section: § 5.2
     snippet: The "Cache-Control" header field is used to list directives for caches along the request/response chain.
     cited_by:
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 194
+      line: 186
     - file: lint-http-rules/src/rules/cache_control_token_valid.rs
-      line: 153
+      line: 145
   - label: cache_control_directive_valid (2)
     section: § 5.2.2.7
     snippet: If a qualified private response directive is present, with an argument that lists one or more field names
     cited_by:
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 269
+      line: 261
   - label: private argument syntax
     section: § 5.2.2.7
     snippet: This directive uses the quoted-string form of the argument syntax.
     cited_by:
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 311
+      line: 303
   - label: cache_control_present
     section: § 4.2.2
     snippet: Since origin servers do not always provide explicit expiration times, a cache MAY assign a heuristic expiration time when an explicit time is not specified, employing algorithms that use other field values (such as the Last-Modified time) to estimate a plausible expiration time.
@@ -9494,25 +9494,25 @@ sources:
     snippet: If the max-age response directive (Section 5.2.2.1) is present, use its value, or If the Expires response header field (Section 5.3) is present, use its value minus the value of the Date response header field (using the time the message was received if it is not present, as per Section 6.6.1 of [HTTP]), or
     cited_by:
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 351
+      line: 359
   - label: lint-http-rules/src/helpers/cache_control.rs (2)
     section: § 4.2.1
     snippet: Note that this calculation is intended to reduce clock skew by using the clock information provided by the origin server whenever possible.
     cited_by:
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 361
+      line: 369
   - label: lint-http-rules/src/helpers/cache_control.rs (3)
     section: § 4.2.3
     snippet: corrected_initial_age = max(apparent_age, corrected_age_value)
     cited_by:
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 316
+      line: 324
   - label: lint-http-rules/src/helpers/cache_control.rs (4)
     section: § 5.1
     snippet: The "Age" response header field conveys the sender's estimate of the time since the response was generated or successfully validated at the origin server
     cited_by:
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 315
+      line: 323
     - file: lint-http-rules/src/rules/age_header_numeric.rs
       line: 68
     - file: lint-http-rules/src/rules/max_age_directive_valid.rs
@@ -9538,15 +9538,15 @@ sources:
     - file: lint-http-rules/src/helpers/cache_control.rs
       line: 151
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 211
+      line: 203
     - file: lint-http-rules/src/rules/cache_control_token_valid.rs
-      line: 170
+      line: 162
   - label: lint-http-rules/src/helpers/cache_control.rs (8)
     section: § 5.2.2.4
     snippet: The no-cache response directive, in its unqualified form (without an argument), indicates that the response MUST NOT be used to satisfy any other request without forwarding it for validation and receiving a successful response
     cited_by:
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 238
+      line: 246
     - file: lint-http-rules/src/rules/no_cache_revalidation.rs
       line: 134
   - label: lint-http-rules/src/helpers/cache_control.rs (9)
@@ -9556,7 +9556,7 @@ sources:
     - file: lint-http-rules/src/helpers/cache_control.rs
       line: 72
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 239
+      line: 247
     - file: lint-http-rules/src/rules/no_cache_revalidation.rs
       line: 150
   - label: lint-http-rules/src/helpers/cache_control.rs (10)
@@ -9564,7 +9564,7 @@ sources:
     snippet: The no-store response directive indicates that a cache MUST NOT store any part of either the immediate request or the response and MUST NOT use the response to satisfy any other request.
     cited_by:
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 237
+      line: 245
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
       line: 150
     - file: lint-http-rules/src/rules/no_store_enforced.rs
@@ -9638,7 +9638,7 @@ sources:
     snippet: As a result, this specification deprecates Pragma.
     cited_by:
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
-      line: 160
+      line: 155
   - label: range_request_and_caching
     section: § 3.3
     snippet: A cache MAY complete a stored incomplete response by making a subsequent range request (Section 14.2 of [HTTP]) and combining the successful response with the stored response, as defined in Section 3.4.


### PR DESCRIPTION
The three rules reading `Cache-Control` and `Pragma` members went line by line through the string reader and reported a value it refused as *contains non-UTF8 value*. Each had said in its own comment that this is the wrong claim: the reader refuses everything outside visible US-ASCII, and what is wrong is an octet no `tchar` admits in a directive name — which all three already declare an id for and none of them could reach.

The field lines of a section are now joined first, which the `#`-list says they are, and the octet is named as a byte rather than shown as the character it would be a reading of. A value with an obs-text octet inside a quoted directive argument stops being reported at all: `qdtext` admits it, and only the name is measured against the token production.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
