### PR TITLE
An authentication octet belongs to a production

### DIFF
--- a/docs/rules/auth_scheme_registered.md
+++ b/docs/rules/auth_scheme_registered.md
@@ -13,8 +13,11 @@ Validate authentication schemes used in `WWW-Authenticate` and `Authorization` h
 ## Specifications
 
 - [RFC 9110 §11.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-11.1): Authentication Scheme — `auth-scheme = token`, and where new schemes are registered
+- [RFC 9110 §11.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-11.2): Authentication Parameters — `auth-scheme = token`, `auth-param = token BWS "=" BWS ( token / quoted-string )`, and `token68`'s alphabet
 - [RFC 9110 §11.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-11.3): Challenge and Response — `challenge = auth-scheme [ 1*SP ( token68 / #auth-param ) ]`
+- [RFC 9110 §11.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-11.4): Credentials — `credentials = auth-scheme [ 1*SP ( token68 / #auth-param ) ]`, the request-side mirror of `challenge`
 - [RFC 9110 §11.6.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-11.6.1): `WWW-Authenticate = #challenge` — the list whose members are grouped into challenges before any of them is read
+- [RFC 9110 §11.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-11.6.2): Authorization — the field's value *consists of* credentials, which is stricter than § 11.4's optional second half
 - [RFC 9110 §16.4.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-16.4.1): Authentication Scheme Registry
 - [IANA HTTP Authentication Schemes](https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml): IANA HTTP Authentication Scheme Registry
 

--- a/lint-http-rules/src/rules/auth_scheme_registered.rs
+++ b/lint-http-rules/src/rules/auth_scheme_registered.rs
@@ -4,21 +4,42 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::auth_scheme::{AUTH_SCHEME_CHARACTER_FORBIDDEN, RFC_9110_11_2};
 use crate::violations::challenge::{
     challenge_defect, CHALLENGE_MEMBER_EMPTY, CHALLENGE_SCHEME_MISSING, RFC_9110_11_3,
     RFC_9110_11_6_1,
+};
+use crate::violations::credentials::{
+    credentials_defect, CREDENTIALS_CONTROL_CHARACTER_FORBIDDEN, CREDENTIALS_EMPTY,
+    CREDENTIALS_MISSING, RFC_9110_11_4, RFC_9110_11_6_2,
 };
 use crate::violations::ViolationDef;
 
 pub struct AuthSchemeRegistered;
 
-/// The two defects this rule reports so far, and neither is about a registry:
-/// they are the `#challenge` list's, reported here because reading a scheme out
-/// of `WWW-Authenticate` means grouping its members first.
-/// `www_authenticate_challenge_syntax` declares the same two, which is what a
-/// shared subject is for — one `[violations.challenge_member_empty]` answers
-/// for both rules. The registry findings themselves are still on the old API.
-static DECLARED: &[&ViolationDef] = &[&CHALLENGE_MEMBER_EMPTY, &CHALLENGE_SCHEME_MISSING];
+/// Everything this rule measures about the *grammar*, and none of what it is
+/// named for.
+///
+/// The list's two defects come from grouping `WWW-Authenticate`'s members
+/// before a scheme can be read out of them; the scheme's own octet is
+/// `auth-scheme = token`, one production written once and read from both
+/// directions of the framework, so it answers with the same id here as it does
+/// inside a challenge or a set of credentials; and the three
+/// `credentials_*` entries are what an `Authorization` value fails to be before
+/// any scheme is looked up.
+///
+/// **What stays this rule's own is the registry question**, which is the whole
+/// of what its name is about: a scheme spelled correctly and absent from the
+/// operator's `allowed` list is not a defect of any production, and no sentence
+/// in RFC 9110 makes it one — § 11.1 says schemes *ought to* be registered.
+static DECLARED: &[&ViolationDef] = &[
+    &CHALLENGE_MEMBER_EMPTY,
+    &CHALLENGE_SCHEME_MISSING,
+    &AUTH_SCHEME_CHARACTER_FORBIDDEN,
+    &CREDENTIALS_EMPTY,
+    &CREDENTIALS_MISSING,
+    &CREDENTIALS_CONTROL_CHARACTER_FORBIDDEN,
+];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -79,8 +100,11 @@ allowed = ["Basic", "Bearer", "Digest"]
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
             RFC_9110_11_1,
+            RFC_9110_11_2,
             RFC_9110_11_3,
+            RFC_9110_11_4,
             RFC_9110_11_6_1,
+            RFC_9110_11_6_2,
             RFC_9110_16_4_1,
             IANA_HTTP_AUTHENTICATION_SCHEMES,
         ]
@@ -128,9 +152,16 @@ impl Rule for AuthSchemeRegistered {
                     // An auth-scheme is a token; the tchar set is helper-owned.
                     // cite(RFC 9110 § 11.1): "It uses a case-insensitive token to identify the authentication scheme"
                     if let Some(c) = crate::helpers::token::find_invalid_token_char(scheme) {
-                        return Some(AuthSchemeRegistered.violation(
-                            ctx.severity,
-                            format!("Invalid character '{}' in {} auth-scheme", c, hdr_name),
+                        // Named rather than shown: both fields are read as
+                        // octets, so this may be an `obs-text` byte, and a byte
+                        // is what the finding says it is.
+                        return Some(ctx.report_with(
+                            &AUTH_SCHEME_CHARACTER_FORBIDDEN,
+                            format!(
+                                "Invalid character {} in {} auth-scheme",
+                                crate::helpers::shown::describe_char(c),
+                                hdr_name
+                            ),
                         ));
                     }
                     // The guidance the allowlist stands for: schemes ought to be registered.
@@ -152,16 +183,17 @@ impl Rule for AuthSchemeRegistered {
 
             // Check WWW-Authenticate challenges in responses
             if let Some(resp) = &tx.response {
-                for hv in resp.headers.get_all("www-authenticate").iter() {
-                    let Ok(s) = hv.to_str() else {
-                        return Some(self.violation(
-                            ctx.severity,
-                            "WWW-Authenticate header contains non-UTF8 value".into(),
-                        ));
-                    };
-
+                // Read as octets and over the section: `WWW-Authenticate =
+                // #challenge` makes the field lines one list, and an octet
+                // outside visible US-ASCII belongs to whichever production it
+                // landed in -- the scheme's `token`, a parameter's value --
+                // rather than being a verdict about the field's encoding.
+                if let Some(s) = crate::helpers::headers::combined_field_value_as_written(
+                    &resp.headers,
+                    "www-authenticate",
+                ) {
                     // split into assembled challenges
-                    match crate::helpers::auth::split_and_group_challenges(s) {
+                    match crate::helpers::auth::split_and_group_challenges(&s) {
                         Ok(challenges) => {
                             for challenge in challenges {
                                 let scheme =
@@ -183,18 +215,16 @@ impl Rule for AuthSchemeRegistered {
                 }
             }
 
-            // Check Authorization header in requests
+            // Check Authorization header in requests. `Authorization =
+            // credentials` is one value rather than a list, so the first field
+            // line is the field -- read as octets, for the reason above.
             if let Some(hv) = tx.request.headers.get_all("authorization").iter().next() {
-                let Ok(v) = hv.to_str() else {
-                    return Some(self.violation(
-                        ctx.severity,
-                        "Authorization header contains non-UTF8 value".into(),
-                    ));
-                };
+                let v = crate::helpers::headers::field_line_as_written(hv);
+                let v = v.as_str();
                 // validate basic syntax first
                 if let Err(defect) = crate::helpers::auth::validate_authorization_syntax(v) {
-                    return Some(self.violation(
-                        ctx.severity,
+                    return Some(ctx.report_with(
+                        credentials_defect(defect),
                         format!("Invalid Authorization header: {}", defect.message()),
                     ));
                 }
@@ -347,7 +377,7 @@ mod tests {
     }
 
     #[test]
-    fn www_authenticate_non_utf8_reports_violation() {
+    fn an_obs_text_octet_is_read_where_it_lands_in_a_challenge() {
         use hyper::header::HeaderName;
         use hyper::header::HeaderValue;
         use hyper::HeaderMap;
@@ -355,26 +385,37 @@ mod tests {
         let rule = AuthSchemeRegistered;
         let cfg = make_cfg();
 
-        let mut tx = crate::test_helpers::make_test_transaction_with_response(401, &[]);
-        let mut hm = HeaderMap::new();
-        hm.insert(
-            HeaderName::from_static("www-authenticate"),
-            HeaderValue::from_bytes(b"Basic \xff").unwrap(),
-        );
-        tx.response.as_mut().unwrap().headers = hm;
+        let judge = |value: &[u8]| {
+            let mut tx = crate::test_helpers::make_test_transaction_with_response(401, &[]);
+            let mut hm = HeaderMap::new();
+            hm.insert(
+                HeaderName::from_static("www-authenticate"),
+                HeaderValue::from_bytes(value).unwrap(),
+            );
+            tx.response.as_mut().unwrap().headers = hm;
+            crate::test_helpers::run_rule(
+                &rule,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &cfg,
+            )
+        };
 
-        let v = crate::test_helpers::run_rule(
-            &rule,
-            &tx,
-            &crate::transaction_history::TransactionHistory::empty(),
-            &cfg,
+        // An octet in the `token68` is not this rule's question — the scheme
+        // is spelled correctly and is in the allowlist, and what the credential
+        // holds is `www_authenticate_challenge_syntax`'s. An octet in the
+        // scheme is, because the scheme is all this rule reads.
+        assert!(judge(b"Basic \xff").is_none());
+        assert_eq!(
+            judge(b"Ba\xffsic realm=\"x\"")
+                .expect("a finding")
+                .violation,
+            "challenge_scheme_missing"
         );
-        assert!(v.is_some());
-        assert!(v.unwrap().message.contains("non-UTF8"));
     }
 
     #[test]
-    fn authorization_non_utf8_reports_violation() {
+    fn an_obs_text_octet_is_read_where_it_lands_in_credentials() {
         use hyper::header::HeaderName;
         use hyper::header::HeaderValue;
         use hyper::HeaderMap;
@@ -382,22 +423,29 @@ mod tests {
         let rule = AuthSchemeRegistered;
         let cfg = make_cfg();
 
-        let mut tx = crate::test_helpers::make_test_transaction();
-        let mut hm = HeaderMap::new();
-        hm.insert(
-            HeaderName::from_static("authorization"),
-            HeaderValue::from_bytes(b"Basic \xff").unwrap(),
-        );
-        tx.request.headers = hm;
+        let judge = |value: &[u8]| {
+            let mut tx = crate::test_helpers::make_test_transaction();
+            let mut hm = HeaderMap::new();
+            hm.insert(
+                HeaderName::from_static("authorization"),
+                HeaderValue::from_bytes(value).unwrap(),
+            );
+            tx.request.headers = hm;
+            crate::test_helpers::run_rule(
+                &rule,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &cfg,
+            )
+        };
 
-        let v = crate::test_helpers::run_rule(
-            &rule,
-            &tx,
-            &crate::transaction_history::TransactionHistory::empty(),
-            &cfg,
+        // The same split on the request side: the credential's octets belong
+        // to the scheme's own document, and the scheme's belong here.
+        assert!(judge(b"Basic \xff").is_none());
+        assert_eq!(
+            judge(b"Ba\xffsic abc").expect("a finding").violation,
+            "auth_scheme_character_forbidden"
         );
-        assert!(v.is_some());
-        assert!(v.unwrap().message.contains("non-UTF8"));
     }
 
     #[test]

--- a/lint-http-rules/src/rules/authorization_credentials_present.rs
+++ b/lint-http-rules/src/rules/authorization_credentials_present.rs
@@ -20,10 +20,10 @@ pub struct AuthorizationCredentialsPresent;
 /// server's `WWW-Authenticate`, because `auth-scheme = token` is written once
 /// and used from both directions.
 ///
-/// The non-UTF-8 finding below is not here on purpose: the verdict it reports
-/// names an encoding where the defect is an octet the field's grammar does not
-/// admit, and the conversion it needs is an octet-wise reader rather than a
-/// name for the claim as it stands.
+/// **There is no non-UTF-8 finding any more.** The verdict it reported named an
+/// encoding where the defect is an octet the field's grammar does not admit; the
+/// value is read as octets now, and each octet reaches the production that
+/// refuses it — or, in the credentials, the scheme's own document next door.
 static DECLARED: &[&ViolationDef] = &[
     &CREDENTIALS_EMPTY,
     &CREDENTIALS_MISSING,
@@ -117,30 +117,24 @@ impl Rule for AuthorizationCredentialsPresent {
         // Single-finding body behind an Option: `?` ends it early, and the
         // one finding (or none) becomes the vector.
         let finding = || -> Option<Violation> {
+            // Read as octets. `to_str` refuses everything outside visible
+            // US-ASCII, which made an octet in the credentials a verdict about
+            // the field's encoding; the productions here own that octet -- the
+            // scheme's `token`, and each scheme's own credential grammar next
+            // door.
             for hv in tx.request.headers.get_all("authorization").iter() {
-                match hv.to_str() {
-                    Ok(s) => {
-                        // The Authorization value is credentials — an auth-scheme with its
-                        // authentication information — which is the structure validated here.
-                        // The "credentials must actually be present" half is scheme-derived
-                        // (the framework grammar permits a bare scheme); the helper owns that
-                        // reasoning and the §11.4 structure cite.
-                        // cite(RFC 9110 § 11.6.2): "Its value consists of credentials containing the authentication information of the user agent for the realm of the resource being requested"
-                        if let Err(defect) = crate::helpers::auth::validate_authorization_syntax(s)
-                        {
-                            return Some(ctx.report_with(
-                                credentials_defect(defect),
-                                format!("Invalid Authorization header: {}", defect.message()),
-                            ));
-                        }
-                    }
-                    Err(_) => {
-                        return Some(self.cited(
-                            &RFC_9110_11_6_2,
-                            ctx.severity,
-                            "Authorization header contains non-UTF8 value".into(),
-                        ))
-                    }
+                let s = crate::helpers::headers::field_line_as_written(hv);
+                // The Authorization value is credentials — an auth-scheme with its
+                // authentication information — which is the structure validated here.
+                // The "credentials must actually be present" half is scheme-derived
+                // (the framework grammar permits a bare scheme); the helper owns that
+                // reasoning and the §11.4 structure cite.
+                // cite(RFC 9110 § 11.6.2): "Its value consists of credentials containing the authentication information of the user agent for the realm of the resource being requested"
+                if let Err(defect) = crate::helpers::auth::validate_authorization_syntax(&s) {
+                    return Some(ctx.report_with(
+                        credentials_defect(defect),
+                        format!("Invalid Authorization header: {}", defect.message()),
+                    ));
                 }
             }
             None
@@ -251,27 +245,36 @@ mod tests {
         );
     }
 
+    /// An octet outside visible US-ASCII is read rather than refused, and
+    /// where it lands decides whether this rule has anything to say. In the
+    /// scheme it is the `token`'s defect and reports here; in the credentials
+    /// it is the scheme's own grammar's — `b64token`, a Base64 alphabet, a set
+    /// of `auth-param`s — and this rule is silent, because the framework
+    /// production it enforces is satisfied. The value used to be reported as
+    /// *non-UTF8* either way, which named the reader rather than the field.
     #[test]
-    fn non_utf8_header_reports_violation() -> anyhow::Result<()> {
+    fn an_obs_text_octet_is_read_where_it_lands() -> anyhow::Result<()> {
         let rule = AuthorizationCredentialsPresent;
         use crate::test_helpers::make_test_transaction;
         use hyper::header::HeaderValue;
 
-        let mut tx = make_test_transaction();
-        tx.request.headers.append(
-            "authorization",
-            HeaderValue::from_bytes(b"Bearer \xff").unwrap(),
-        );
+        let judge = |value: &[u8]| {
+            let mut tx = make_test_transaction();
+            tx.request
+                .headers
+                .append("authorization", HeaderValue::from_bytes(value).unwrap());
+            crate::test_helpers::run_rule(
+                &rule,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            )
+        };
 
-        let v = crate::test_helpers::run_rule(
-            &rule,
-            &tx,
-            &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-        );
-        assert!(v.is_some());
-        let msg = v.unwrap().message;
-        assert!(msg.contains("non-UTF8") || msg.contains("Invalid Authorization"));
+        assert!(judge(b"Bearer \xff").is_none());
+
+        let v = judge(b"B\xffarer abc").expect("a finding");
+        assert_eq!(v.violation, "auth_scheme_character_forbidden");
         Ok(())
     }
 

--- a/lint-http-rules/src/rules/basic_auth_base64_valid.rs
+++ b/lint-http-rules/src/rules/basic_auth_base64_valid.rs
@@ -97,51 +97,43 @@ impl Rule for BasicAuthBase64Valid {
         // Single-finding body behind an Option: `?` ends it early, and the
         // one finding (or none) becomes the vector.
         let finding = || -> Option<Violation> {
+            // Read as octets: the credential is Base64, whose alphabet is
+            // where an octet outside visible US-ASCII belongs, and the reader
+            // that refused the value outright reported it as the field's
+            // encoding instead.
             for hv in tx.request.headers.get_all("authorization").iter() {
-                match hv.to_str() {
-                    Ok(s) => {
-                        // Scheme names match case-insensitively.
-                        // cite(RFC 9110 § 11.1): "It uses a case-insensitive token to identify the authentication scheme"
-                        let mut parts = s.splitn(2, char::is_whitespace);
-                        let scheme = parts.next().unwrap_or("").trim();
-                        if scheme.eq_ignore_ascii_case("Basic") {
-                            let creds = parts.next().unwrap_or("").trim();
-                            if creds.is_empty() {
-                                // The framework's defect rather than this
-                                // scheme's: a scheme with nothing after it is
-                                // what `credentials` says must not happen,
-                                // whichever scheme was named.
-                                return Some(ctx.report_with(
-                                    &CREDENTIALS_MISSING,
-                                    "Basic Authorization missing credentials".into(),
-                                ));
-                            }
-                            // The rule's own claim: the credential the client sends encodes a
-                            // user-id and password. How that value is built and checked — the
-                            // Base64 alphabet, the ":" separator, control characters — is owned
-                            // by validate_basic_credentials (RFC 7617 §2 / RFC 4648).
-                            // cite(RFC 7617 § 2): "The value is computed based on user-id and password as defined below."
-                            if let Err(defect) =
-                                crate::helpers::auth::validate_basic_credentials(creds)
-                            {
-                                return Some(ctx.report_with(
-                                    basic_credentials_defect(&defect),
-                                    format!(
-                                        "Invalid Basic credentials: {} (RFC 7617)",
-                                        defect.message()
-                                    ),
-                                ));
-                            }
-                        }
+                let s = crate::helpers::headers::field_line_as_written(hv);
+                let s = s.as_str();
+                // Scheme names match case-insensitively.
+                // cite(RFC 9110 § 11.1): "It uses a case-insensitive token to identify the authentication scheme"
+                let mut parts = s.splitn(2, char::is_whitespace);
+                let scheme = parts.next().unwrap_or("").trim();
+                if scheme.eq_ignore_ascii_case("Basic") {
+                    let creds = parts.next().unwrap_or("").trim();
+                    if creds.is_empty() {
+                        // The framework's defect rather than this
+                        // scheme's: a scheme with nothing after it is
+                        // what `credentials` says must not happen,
+                        // whichever scheme was named.
+                        return Some(ctx.report_with(
+                            &CREDENTIALS_MISSING,
+                            "Basic Authorization missing credentials".into(),
+                        ));
                     }
-                    Err(_) => {
-                        return Some(self.violation(
-                            ctx.severity,
-                            "Authorization header contains non-UTF8 value".into(),
-                        ))
+                    // The rule's own claim: the credential the client sends encodes a
+                    // user-id and password. How that value is built and checked — the
+                    // Base64 alphabet, the ":" separator, control characters — is owned
+                    // by validate_basic_credentials (RFC 7617 §2 / RFC 4648).
+                    // cite(RFC 7617 § 2): "The value is computed based on user-id and password as defined below."
+                    if let Err(defect) = crate::helpers::auth::validate_basic_credentials(creds) {
+                        return Some(ctx.report_with(
+                            basic_credentials_defect(&defect),
+                            format!("Invalid Basic credentials: {} (RFC 7617)", defect.message()),
+                        ));
                     }
                 }
             }
+
             None
         };
         Vec::from_iter(finding())
@@ -307,8 +299,12 @@ mod tests {
         assert!(v2.unwrap().message.contains("missing credentials"));
     }
 
+    /// An octet outside visible US-ASCII is an octet the Base64 alphabet does
+    /// not hold, which is what the credential is measured against — not a
+    /// verdict about the field's encoding, which is what the reader this
+    /// replaces reported.
     #[test]
-    fn non_utf8_authorization_reports_violation() {
+    fn an_obs_text_octet_is_outside_the_base64_alphabet() {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers.append(
             "authorization",
@@ -320,9 +316,9 @@ mod tests {
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-        );
-        assert!(v.is_some());
-        assert!(v.unwrap().message.contains("non-UTF8"));
+        )
+        .expect("a finding");
+        assert_eq!(v.violation, "base64_malformed");
     }
 
     #[test]

--- a/lint-http-rules/src/rules/bearer_token_syntax.rs
+++ b/lint-http-rules/src/rules/bearer_token_syntax.rs
@@ -98,13 +98,12 @@ impl Rule for BearerTokenSyntax {
         // Single-finding body behind an Option: `?` ends it early, and the
         // one finding (or none) becomes the vector.
         let finding = || -> Option<Violation> {
+            // Read as octets: `b64token`'s alphabet is where an octet outside
+            // visible US-ASCII belongs, and the reader that refused the value
+            // outright reported it as the field's encoding instead.
             for hv in tx.request.headers.get_all("authorization").iter() {
-                let Ok(s) = hv.to_str() else {
-                    return Some(self.violation(
-                        ctx.severity,
-                        "Authorization header contains non-UTF8 value".into(),
-                    ));
-                };
+                let s = crate::helpers::headers::field_line_as_written(hv);
+                let s = s.as_str();
 
                 // Split scheme and credentials. Auth-scheme names match case-insensitively.
                 // cite(RFC 9110 § 11.1): "It uses a case-insensitive token to identify the authentication scheme"
@@ -238,7 +237,10 @@ mod tests {
     }
 
     #[test]
-    fn non_utf8_header_reports_violation() -> anyhow::Result<()> {
+    /// An octet outside visible US-ASCII is outside `b64token`'s alphabet,
+    /// which is the production this rule reads — not a verdict about the
+    /// field's encoding, which is what the reader this replaces reported.
+    fn an_obs_text_octet_is_outside_the_b64token_alphabet() -> anyhow::Result<()> {
         let rule = BearerTokenSyntax;
         use crate::test_helpers::make_test_transaction;
         use hyper::header::HeaderValue;
@@ -255,13 +257,8 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
-        assert!(v.is_some());
-        let msg = v.unwrap().message;
-        assert!(
-            msg.contains("non-UTF8")
-                || msg.contains("Invalid Bearer token")
-                || msg.contains("missing token")
-        );
+        let v = v.expect("a finding");
+        assert_eq!(v.violation, "token68_character_forbidden");
         Ok(())
     }
 

--- a/lint-http-rules/src/rules/digest_auth_valid.rs
+++ b/lint-http-rules/src/rules/digest_auth_valid.rs
@@ -138,200 +138,196 @@ impl Rule for DigestAuthValid {
         // Single-finding body behind an Option: `?` ends it early, and the
         // one finding (or none) becomes the vector.
         let finding = || -> Option<Violation> {
+            // Read as octets: an octet outside visible US-ASCII belongs to
+            // whichever of this scheme's parts it landed in -- an `auth-param`
+            // name that is a `token`, a value that is a `quoted-string` -- and
+            // the reader that refused the value outright reported it as the
+            // field's encoding instead.
             for hv in tx.request.headers.get_all("authorization").iter() {
-                match hv.to_str() {
-                    Ok(s) => {
-                        let s = s.trim();
-                        if s.is_empty() {
-                            continue;
-                        }
-                        // Only care about the Digest scheme; auth-scheme names are
-                        // matched case-insensitively.
-                        // cite(RFC 9110 § 11.1): "It uses a case-insensitive token to identify the authentication scheme"
-                        let mut parts = s.splitn(2, char::is_whitespace);
-                        let scheme = parts.next().unwrap();
-                        if !scheme.eq_ignore_ascii_case("digest") {
-                            continue;
-                        }
-                        let rest = match parts.next() {
-                            Some(r) => r.trim(),
-                            None => {
-                                return Some(self.violation(
-                                    ctx.severity,
-                                    "Authorization Digest scheme missing parameters".into(),
-                                ))
-                            }
-                        };
+                let s = crate::helpers::headers::field_line_as_written(hv);
+                let s = s.trim();
+                if s.is_empty() {
+                    continue;
+                }
+                // Only care about the Digest scheme; auth-scheme names are
+                // matched case-insensitively.
+                // cite(RFC 9110 § 11.1): "It uses a case-insensitive token to identify the authentication scheme"
+                let mut parts = s.splitn(2, char::is_whitespace);
+                let scheme = parts.next().unwrap();
+                if !scheme.eq_ignore_ascii_case("digest") {
+                    continue;
+                }
+                let rest = match parts.next() {
+                    Some(r) => r.trim(),
+                    None => {
+                        return Some(self.violation(
+                            ctx.severity,
+                            "Authorization Digest scheme missing parameters".into(),
+                        ))
+                    }
+                };
 
-                        // parse auth-param list into map
-                        match crate::helpers::auth::parse_auth_params(rest) {
-                            Ok(map) => {
-                                // Required fields: username, realm, nonce, uri, response. §3.4 lists the
-                                // parameters and names the consequence for missing required ones, but
-                                // labels no "required" set; these five are the ones the response
-                                // computation (§3.4.1) cannot be verified without whatever the
-                                // credential's vintage. cnonce and nc are demanded below, behind the
-                                // observable line that keeps RFC 2617-style credentials checkable.
-                                // cite(RFC 7616 § 3.4): "If a parameter or its value is improper, or required parameters are missing, the proper response is a 4xx error code."
-                                let required = ["username", "realm", "nonce", "uri", "response"];
-                                for &k in &required {
-                                    match map.get(k) {
-                                        Some(v) => {
-                                            // treat empty unquoted values or quoted-strings with empty inner content
-                                            let is_empty = if v.is_empty() {
-                                                true
-                                            } else if v.starts_with('"') {
-                                                // if quoted-string is syntactically invalid, default to 'false' so
-                                                // it will be reported by the later quoted-string validation
-                                                crate::helpers::quoted_string::quoted_string_inner_trimmed_is_empty(v).unwrap_or_default()
-                                            } else {
-                                                false
-                                            };
-
-                                            if is_empty {
-                                                return Some(self.violation(ctx.severity, format!(
-                                                        "Digest Authorization missing or empty required parameter '{}'",
-                                                        k
-                                                    )))
-                                            }
-                                        }
-                                        None => {
-                                            return Some(self.violation(ctx.severity, format!(
-                                                    "Digest Authorization missing or empty required parameter '{}'",
-                                                    k
-                                                )))
-                                        }
-                                    }
-                                }
-                                // The two parameters RFC 7616 §3.4 marks "MUST be used by all
-                                // implementations", demanded where the credential's own qop makes
-                                // the demand observable. RFC 2617 computes a qop-less response
-                                // without either, so requiring them of every Digest credential
-                                // would reject that document's otherwise-checkable shape — but a
-                                // credential that *carries* qop is inside both documents' MUSTs at
-                                // once: RFC 2617's conditional is met by the message itself, and
-                                // both compute the response value over cnonce and nc, so their
-                                // absence leaves the response unverifiable by the recipient it was
-                                // written for. The qop-less decline is published in
-                                // `description()`.
-                                // cite(RFC 7616 § 3.4, label: cnonce): "This parameter MUST be used by all implementations."
-                                // cite(RFC 2617 § 3.2.2): "This MUST be specified if a qop directive is sent (see above), and MUST NOT be specified if the server did not send a qop directive in the WWW-Authenticate header field."
-                                if map.contains_key("qop") {
-                                    for &k in &["cnonce", "nc"] {
-                                        if !map.contains_key(k) {
-                                            return Some(self.violation(ctx.severity, format!(
-                                                    "Digest Authorization sends 'qop' and no '{k}': RFC 7616 \u{a7}3.4 marks the parameter \"MUST be used by all implementations\", RFC 2617 \u{a7}3.2.2 requires it whenever a qop directive is sent, and both documents compute the response value over it, so without it the credential cannot be verified"
-                                                )));
-                                        }
-                                    }
-                                }
-
-                                // validate tokensexp and quoted values basic syntax
-                                for (k, v) in map.iter() {
-                                    // param names must be tokens
-                                    // An `auth-param` name is a `token`, which is
-                                    // § 5.6.2's production imported unchanged --
-                                    // so the two ids here are the ones every
-                                    // other reader of it answers with.
-                                    //
-                                    // **This branch still cannot fire**, and the
-                                    // reason is two lines up rather than anywhere
-                                    // in this document: `parse_auth_params`
-                                    // measures the name against the same reader
-                                    // and returns `Err` first, so a `user@name`
-                                    // is answered there. It is kept because the
-                                    // two answers now agree by construction --
-                                    // the helper's mapping hands back this same
-                                    // id -- and because a reader that stopped
-                                    // measuring the name would leave this the
-                                    // only check of it.
-                                    if let Some(inv) =
-                                        crate::helpers::token::find_invalid_token_char(k)
-                                    {
-                                        return Some(ctx.report_with(
-                                            token_character(inv),
-                                            format!(
-                                                "Invalid character '{}' in Digest auth-param name",
-                                                inv
-                                            ),
-                                        ));
-                                    }
-                                    // §3.4's two per-parameter quoting MUSTs, enforced in both
-                                    // directions. The historical reason is the point: recipients
-                                    // of these parameters were deployed against one spelling each,
-                                    // so the wrong spelling is a credential some verifiers will
-                                    // not read. The seven-name list is why the old `uri` branch —
-                                    // which deliberately accepted an unquoted value — is gone: an
-                                    // unquoted uri is exactly what the first sentence forbids.
-                                    // `username*`, `userhash` and unknown extensions are in
-                                    // neither list, and only their present spelling is judged.
-                                    // cite(RFC 7616 § 3.4): "For historical reasons, a sender MUST only generate the quoted string syntax for the following parameters: username, realm, nonce, uri, response, cnonce, and opaque."
-                                    // cite(RFC 7616 § 3.4): "For historical reasons, a sender MUST NOT generate the quoted string syntax for the following parameters: algorithm, qop, and nc."
-                                    const MUST_QUOTE: &[&str] = &[
-                                        "username", "realm", "nonce", "uri", "response", "cnonce",
-                                        "opaque",
-                                    ];
-                                    const MUST_NOT_QUOTE: &[&str] = &["algorithm", "qop", "nc"];
-
-                                    let quoted = v.starts_with('"');
-                                    if MUST_QUOTE.contains(&k.as_str()) && !quoted {
-                                        return Some(self.cited(&RFC_7616_3_4, ctx.severity, format!(
-                                                "Digest Authorization sends '{k}' unquoted, and RFC 7616 \u{a7}3.4 admits only the quoted string syntax for it (\"a sender MUST only generate the quoted string syntax for the following parameters: username, realm, nonce, uri, response, cnonce, and opaque\")"
-                                            )));
-                                    }
-                                    if MUST_NOT_QUOTE.contains(&k.as_str()) && quoted {
-                                        return Some(self.violation(ctx.severity, format!(
-                                                "Digest Authorization sends '{k}' as a quoted string, and RFC 7616 \u{a7}3.4 forbids that spelling for it (\"a sender MUST NOT generate the quoted string syntax for the following parameters: algorithm, qop, and nc\")"
-                                            )));
-                                    }
-
-                                    // A value that opens with a quote is validated as a quoted-string
-                                    // (grammar helper-owned, RFC 9110 §5.6.4).
-                                    if quoted {
-                                        if let Err(defect) =
-                                            crate::helpers::quoted_string::check_quoted_string(v)
-                                        {
-                                            return Some(ctx.report_with(quoted_string_defect(defect), format!(
-                                                    "Invalid quoted-string in Digest auth-param '{}': {}",
-                                                    k, defect.message(v)
-                                                )));
-                                        }
+                // parse auth-param list into map
+                match crate::helpers::auth::parse_auth_params(rest) {
+                    Ok(map) => {
+                        // Required fields: username, realm, nonce, uri, response. §3.4 lists the
+                        // parameters and names the consequence for missing required ones, but
+                        // labels no "required" set; these five are the ones the response
+                        // computation (§3.4.1) cannot be verified without whatever the
+                        // credential's vintage. cnonce and nc are demanded below, behind the
+                        // observable line that keeps RFC 2617-style credentials checkable.
+                        // cite(RFC 7616 § 3.4): "If a parameter or its value is improper, or required parameters are missing, the proper response is a 4xx error code."
+                        let required = ["username", "realm", "nonce", "uri", "response"];
+                        for &k in &required {
+                            match map.get(k) {
+                                Some(v) => {
+                                    // treat empty unquoted values or quoted-strings with empty inner content
+                                    let is_empty = if v.is_empty() {
+                                        true
+                                    } else if v.starts_with('"') {
+                                        // if quoted-string is syntactically invalid, default to 'false' so
+                                        // it will be reported by the later quoted-string validation
+                                        crate::helpers::quoted_string::quoted_string_inner_trimmed_is_empty(v).unwrap_or_default()
                                     } else {
-                                        // Unquoted values are tokens. The `uri` carve-out that
-                                        // stood here (allow anything without control characters)
-                                        // is unreachable now: an unquoted `uri` returns above.
-                                        if let Some(inv) =
-                                            crate::helpers::token::find_invalid_token_char(v)
-                                        {
-                                            return Some(ctx.report_with(token_character(inv), format!(
-                                                    "Invalid character '{}' in Digest auth-param value for '{}'",
-                                                    inv, k
-                                                )));
-                                        }
+                                        false
+                                    };
+
+                                    if is_empty {
+                                        return Some(self.violation(ctx.severity, format!(
+                                                "Digest Authorization missing or empty required parameter '{}'",
+                                                k
+                                            )))
                                     }
                                 }
+                                None => {
+                                    return Some(self.violation(ctx.severity, format!(
+                                            "Digest Authorization missing or empty required parameter '{}'",
+                                            k
+                                        )))
+                                }
                             }
-                            // The reader is typed now, so three of its four
-                            // verdicts arrive with a name: an empty member is
-                            // the list's, an empty name and a bad character are
-                            // the `token`'s. The fourth — a member with no `=`
-                            // — is § 11.2's own sentence about `auth-param`,
-                            // and § 5.6.6's `parameter` does not answer for it.
-                            Err(defect) => {
-                                let message =
-                                    format!("Invalid Digest auth parameters: {}", defect.message());
-                                return Some(match auth_param_member(defect) {
-                                    Some(def) => ctx.report_with(def, message),
-                                    None => self.violation(ctx.severity, message),
-                                });
+                        }
+                        // The two parameters RFC 7616 §3.4 marks "MUST be used by all
+                        // implementations", demanded where the credential's own qop makes
+                        // the demand observable. RFC 2617 computes a qop-less response
+                        // without either, so requiring them of every Digest credential
+                        // would reject that document's otherwise-checkable shape — but a
+                        // credential that *carries* qop is inside both documents' MUSTs at
+                        // once: RFC 2617's conditional is met by the message itself, and
+                        // both compute the response value over cnonce and nc, so their
+                        // absence leaves the response unverifiable by the recipient it was
+                        // written for. The qop-less decline is published in
+                        // `description()`.
+                        // cite(RFC 7616 § 3.4, label: cnonce): "This parameter MUST be used by all implementations."
+                        // cite(RFC 2617 § 3.2.2): "This MUST be specified if a qop directive is sent (see above), and MUST NOT be specified if the server did not send a qop directive in the WWW-Authenticate header field."
+                        if map.contains_key("qop") {
+                            for &k in &["cnonce", "nc"] {
+                                if !map.contains_key(k) {
+                                    return Some(self.violation(ctx.severity, format!(
+                                            "Digest Authorization sends 'qop' and no '{k}': RFC 7616 \u{a7}3.4 marks the parameter \"MUST be used by all implementations\", RFC 2617 \u{a7}3.2.2 requires it whenever a qop directive is sent, and both documents compute the response value over it, so without it the credential cannot be verified"
+                                        )));
+                                }
+                            }
+                        }
+
+                        // validate tokensexp and quoted values basic syntax
+                        for (k, v) in map.iter() {
+                            // param names must be tokens
+                            // An `auth-param` name is a `token`, which is
+                            // § 5.6.2's production imported unchanged --
+                            // so the two ids here are the ones every
+                            // other reader of it answers with.
+                            //
+                            // **This branch still cannot fire**, and the
+                            // reason is two lines up rather than anywhere
+                            // in this document: `parse_auth_params`
+                            // measures the name against the same reader
+                            // and returns `Err` first, so a `user@name`
+                            // is answered there. It is kept because the
+                            // two answers now agree by construction --
+                            // the helper's mapping hands back this same
+                            // id -- and because a reader that stopped
+                            // measuring the name would leave this the
+                            // only check of it.
+                            if let Some(inv) = crate::helpers::token::find_invalid_token_char(k) {
+                                return Some(ctx.report_with(
+                                    token_character(inv),
+                                    format!(
+                                        "Invalid character '{}' in Digest auth-param name",
+                                        inv
+                                    ),
+                                ));
+                            }
+                            // §3.4's two per-parameter quoting MUSTs, enforced in both
+                            // directions. The historical reason is the point: recipients
+                            // of these parameters were deployed against one spelling each,
+                            // so the wrong spelling is a credential some verifiers will
+                            // not read. The seven-name list is why the old `uri` branch —
+                            // which deliberately accepted an unquoted value — is gone: an
+                            // unquoted uri is exactly what the first sentence forbids.
+                            // `username*`, `userhash` and unknown extensions are in
+                            // neither list, and only their present spelling is judged.
+                            // cite(RFC 7616 § 3.4): "For historical reasons, a sender MUST only generate the quoted string syntax for the following parameters: username, realm, nonce, uri, response, cnonce, and opaque."
+                            // cite(RFC 7616 § 3.4): "For historical reasons, a sender MUST NOT generate the quoted string syntax for the following parameters: algorithm, qop, and nc."
+                            const MUST_QUOTE: &[&str] = &[
+                                "username", "realm", "nonce", "uri", "response", "cnonce", "opaque",
+                            ];
+                            const MUST_NOT_QUOTE: &[&str] = &["algorithm", "qop", "nc"];
+
+                            let quoted = v.starts_with('"');
+                            if MUST_QUOTE.contains(&k.as_str()) && !quoted {
+                                return Some(self.cited(&RFC_7616_3_4, ctx.severity, format!(
+                                        "Digest Authorization sends '{k}' unquoted, and RFC 7616 \u{a7}3.4 admits only the quoted string syntax for it (\"a sender MUST only generate the quoted string syntax for the following parameters: username, realm, nonce, uri, response, cnonce, and opaque\")"
+                                    )));
+                            }
+                            if MUST_NOT_QUOTE.contains(&k.as_str()) && quoted {
+                                return Some(self.violation(ctx.severity, format!(
+                                        "Digest Authorization sends '{k}' as a quoted string, and RFC 7616 \u{a7}3.4 forbids that spelling for it (\"a sender MUST NOT generate the quoted string syntax for the following parameters: algorithm, qop, and nc\")"
+                                    )));
+                            }
+
+                            // A value that opens with a quote is validated as a quoted-string
+                            // (grammar helper-owned, RFC 9110 §5.6.4).
+                            if quoted {
+                                if let Err(defect) =
+                                    crate::helpers::quoted_string::check_quoted_string(v)
+                                {
+                                    return Some(ctx.report_with(
+                                        quoted_string_defect(defect),
+                                        format!(
+                                            "Invalid quoted-string in Digest auth-param '{}': {}",
+                                            k,
+                                            defect.message(v)
+                                        ),
+                                    ));
+                                }
+                            } else {
+                                // Unquoted values are tokens. The `uri` carve-out that
+                                // stood here (allow anything without control characters)
+                                // is unreachable now: an unquoted `uri` returns above.
+                                if let Some(inv) = crate::helpers::token::find_invalid_token_char(v)
+                                {
+                                    return Some(ctx.report_with(token_character(inv), format!(
+                                            "Invalid character '{}' in Digest auth-param value for '{}'",
+                                            inv, k
+                                        )));
+                                }
                             }
                         }
                     }
-                    Err(_) => {
-                        return Some(self.violation(
-                            ctx.severity,
-                            "Authorization header contains non-UTF8 value".into(),
-                        ))
+                    // The reader is typed now, so three of its four
+                    // verdicts arrive with a name: an empty member is
+                    // the list's, an empty name and a bad character are
+                    // the `token`'s. The fourth — a member with no `=`
+                    // — is § 11.2's own sentence about `auth-param`,
+                    // and § 5.6.6's `parameter` does not answer for it.
+                    Err(defect) => {
+                        let message =
+                            format!("Invalid Digest auth parameters: {}", defect.message());
+                        return Some(match auth_param_member(defect) {
+                            Some(def) => ctx.report_with(def, message),
+                            None => self.violation(ctx.severity, message),
+                        });
                     }
                 }
             }

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1293,7 +1293,13 @@ severity = "warn"
         /// The rest are the per-rule reading that has not happened yet — the
         /// denominator is computed below, because merges and conversions both
         /// move it.
-        const FLOOR: usize = 147;
+        ///
+        /// It also falls when a finding *stops being made*: the
+        /// `Authorization` rules' "contains non-UTF8 value" arms went when
+        /// those fields began to be read as octets, and one of them was cited.
+        /// The sentence it named is still declared by the rule and carried by
+        /// the defs; what left is the site.
+        const FLOOR: usize = 146;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/rules/www_authenticate_challenge_syntax.rs
+++ b/lint-http-rules/src/rules/www_authenticate_challenge_syntax.rs
@@ -127,9 +127,19 @@ impl Rule for WwwAuthenticateChallengeSyntax {
         // Single-finding body behind an Option: `?` ends it early, and the
         // one finding (or none) becomes the vector.
         let finding = || -> Option<Violation> {
-            // Only check response headers; ignore non-UTF8 header values
+            // Read as octets and over the section. The reader this replaces
+            // skipped a field line it could not read as text, which made an
+            // octet outside visible US-ASCII invisible to the only rule that
+            // measures this field's grammar -- where it belongs to whichever
+            // production it landed in, and every one of them is declared here.
+            // `WWW-Authenticate = #challenge` is also why the lines are joined:
+            // they are one list.
             if let Some(resp) = &tx.response {
-                for s in crate::helpers::headers::field_lines(&resp.headers, "www-authenticate") {
+                if let Some(s) = crate::helpers::headers::combined_field_value_as_written(
+                    &resp.headers,
+                    "www-authenticate",
+                ) {
+                    let s = s.as_str();
                     // Group members into assembled challenges using the helper so we can
                     // test the grouping logic independently and exercise more branches.
                     // cite(RFC 9110 § 11.6.1): "The "WWW-Authenticate" response header field indicates the authentication scheme(s) and parameters applicable to the target resource."
@@ -272,28 +282,56 @@ mod tests {
         assert_eq!(v.severity, severity, "{}", v.message);
     }
 
+    /// This used to assert that a value the string reader refuses is
+    /// *ignored*, which was the reader's behaviour dressed as a reading: the
+    /// field's own grammar has a place for every octet — the scheme's `token`,
+    /// a `token68`, an `auth-param`'s two halves — and an octet outside
+    /// visible US-ASCII is outside all of them.
     #[test]
-    fn non_utf8_header_values_are_ignored() {
+    fn an_obs_text_octet_is_the_productions_defect() {
         let rule = WwwAuthenticateChallengeSyntax;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "www_authenticate_challenge_syntax",
         ]);
 
-        let mut tx = crate::test_helpers::make_test_transaction_with_response(401, &[]);
-        let mut hm = hyper::HeaderMap::new();
-        hm.insert(
-            "www-authenticate",
-            hyper::header::HeaderValue::from_bytes(b"\xff").unwrap(),
-        );
-        tx.response.as_mut().unwrap().headers = hm;
+        let judge = |value: &[u8]| {
+            let mut tx = crate::test_helpers::make_test_transaction_with_response(401, &[]);
+            let mut hm = hyper::HeaderMap::new();
+            hm.insert(
+                "www-authenticate",
+                hyper::header::HeaderValue::from_bytes(value).unwrap(),
+            );
+            tx.response.as_mut().unwrap().headers = hm;
+            crate::test_helpers::run_rule(
+                &rule,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &cfg,
+            )
+        };
 
-        let v = crate::test_helpers::run_rule(
-            &rule,
-            &tx,
-            &crate::transaction_history::TransactionHistory::empty(),
-            &cfg,
+        // Where the octet lands decides what is said about it. In the position
+        // a scheme would have started, the member is not a `token` and so
+        // begins no challenge — which is what the list says when a continuation
+        // arrives with nothing before it. In the `token68`, it is outside that
+        // production's alphabet. Inside a `quoted-string` it is `qdtext` and
+        // conforming, which the reader that refused the whole value could not
+        // say.
+        assert_eq!(
+            judge(b"B\xffasic realm=\"x\"")
+                .expect("a finding")
+                .violation,
+            "challenge_scheme_missing"
         );
-        assert!(v.is_none());
+        assert_eq!(
+            judge(b"\xff").expect("a finding").violation,
+            "challenge_scheme_missing"
+        );
+        assert_eq!(
+            judge(b"Basic ab\xffcd").expect("a finding").violation,
+            "challenge_token68_invalid"
+        );
+        assert!(judge(b"Basic realm=\"a\xffb\"").is_none());
     }
 
     #[test]

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1110,7 +1110,7 @@ sources:
     snippet: This MUST be specified if a qop directive is sent (see above), and MUST NOT be specified if the server did not send a qop directive in the WWW-Authenticate header field.
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
-      line: 218
+      line: 222
 - label: RFC 3230
   url: https://www.rfc-editor.org/rfc/rfc3230.html
   fragments:
@@ -3082,7 +3082,7 @@ sources:
     snippet: credentials = "Bearer" 1*SP b64token
     cited_by:
     - file: lint-http-rules/src/rules/bearer_token_syntax.rs
-      line: 117
+      line: 116
   - label: bearer b64token grammar
     section: § 2.1
     snippet: b64token    = 1*( ALPHA / DIGIT / "-" / "." / "_" / "~" / "+" / "/" ) *"="
@@ -3797,25 +3797,25 @@ sources:
     snippet: 'For historical reasons, a sender MUST NOT generate the quoted string syntax for the following parameters: algorithm, qop, and nc.'
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
-      line: 269
+      line: 271
   - label: digest_auth_valid (2)
     section: § 3.4
     snippet: 'For historical reasons, a sender MUST only generate the quoted string syntax for the following parameters: username, realm, nonce, uri, response, cnonce, and opaque.'
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
-      line: 268
+      line: 270
   - label: digest_auth_valid (3)
     section: § 3.4
     snippet: If a parameter or its value is improper, or required parameters are missing, the proper response is a 4xx error code.
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
-      line: 175
+      line: 179
   - label: cnonce
     section: § 3.4
     snippet: This parameter MUST be used by all implementations.
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
-      line: 217
+      line: 221
   - label: lint-http-rules/src/helpers/auth.rs
     section: § 3.5
     snippet: For historical reasons, the nc value MUST be exactly 8 hexadecimal digits.
@@ -3830,7 +3830,7 @@ sources:
     snippet: The value is computed based on user-id and password as defined below.
     cited_by:
     - file: lint-http-rules/src/rules/basic_auth_base64_valid.rs
-      line: 123
+      line: 127
   - label: lint-http-rules/src/helpers/auth.rs
     section: § 2
     snippet: The user-id and password MUST NOT contain any control characters
@@ -5275,13 +5275,13 @@ sources:
     snippet: New and existing authentication schemes are specified independently and ought to be registered
     cited_by:
     - file: lint-http-rules/src/rules/auth_scheme_registered.rs
-      line: 142
+      line: 173
   - label: auth_scheme_registered (2)
     section: § 16.4.1
     snippet: The "Hypertext Transfer Protocol (HTTP) Authentication Scheme Registry" defines the namespace for the authentication schemes in challenges and credentials.
     cited_by:
     - file: lint-http-rules/src/rules/auth_scheme_registered.rs
-      line: 143
+      line: 174
   - label: authentication_challenge_valid
     section: § 11.5
     snippet: Note that a response can have multiple challenges with the same auth-scheme but with different realms.
@@ -5319,7 +5319,7 @@ sources:
     snippet: Its value consists of credentials containing the authentication information of the user agent for the realm of the resource being requested
     cited_by:
     - file: lint-http-rules/src/rules/authorization_credentials_present.rs
-      line: 128
+      line: 132
     - file: lint-http-rules/src/violations/credentials.rs
       line: 67
   - label: cache_coherence
@@ -6545,13 +6545,13 @@ sources:
     - file: lint-http-rules/src/helpers/auth.rs
       line: 411
     - file: lint-http-rules/src/rules/auth_scheme_registered.rs
-      line: 129
+      line: 153
     - file: lint-http-rules/src/rules/basic_auth_base64_valid.rs
-      line: 104
+      line: 108
     - file: lint-http-rules/src/rules/bearer_token_syntax.rs
-      line: 110
+      line: 109
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
-      line: 150
+      line: 154
     - file: lint-http-rules/src/violations/auth_scheme.rs
       line: 42
   - label: lint-http-rules/src/helpers/auth.rs (2)
@@ -8899,7 +8899,7 @@ sources:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
       line: 175
     - file: lint-http-rules/src/rules/www_authenticate_challenge_syntax.rs
-      line: 135
+      line: 145
   - label: status_code_semantics (5)
     section: § 11.7.1
     snippet: A proxy MUST send at least one Proxy-Authenticate header field in each 407 (Proxy Authentication Required) response that it generates.


### PR DESCRIPTION
All six readers of `Authorization` and `WWW-Authenticate` went through the string reader. Four reported the refusal as *contains non-UTF8 value*, one reported it as the field's own cited finding, and the sixth skipped the line in silence — six rules, three different accounts of one octet, and none of them about the grammar.

The values are read as octets now, and each octet reaches the production that refuses it: the scheme's `token`, `b64token`'s alphabet, the Base64 credential, a `token68`, an `auth-param`'s two halves. A `realm="caf\xe9"` stops being reported at all, because `qdtext` admits it. The scheme's own character defect also takes the catalogue's id, which the challenge side has reported it under since the subject was written.

The citation floor falls by one for a site that was deleted rather than converted: the sentence it named is still declared by its rule and carried by its defs.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
