### PR TITLE
Three more fields read their own octets

### DIFF
--- a/lint-http-rules/src/rules/accept_ranges_values_valid.rs
+++ b/lint-http-rules/src/rules/accept_ranges_values_valid.rs
@@ -28,10 +28,9 @@ pub struct AcceptRangesValuesValid;
 /// combination — so it was always the finding here that least deserved to share
 /// a level with an octet no `token` admits.
 ///
-/// The non-UTF-8 line stays on the older API, with its own reasoning at the
-/// site: `to_str` refuses every octet outside visible US-ASCII, and what is
-/// wrong is that a range unit name is spelled from a subset of that — which is
-/// the octet-wise reading the rest of the tree owes this family.
+/// The value is read as octets, so an octet outside visible US-ASCII is one of
+/// these two ids rather than a sentence of its own: a range unit name is a
+/// `token`, and every character of one is inside that set.
 static DECLARED: &[&ViolationDef] = &[
     &LIST_MEMBER_MISSING,
     &LIST_MEMBER_EMPTY,
@@ -176,38 +175,23 @@ impl Rule for AcceptRangesValuesValid {
         // cite(RFC 9110 § 14): "Range requests are an OPTIONAL feature of HTTP, designed so that recipients not implementing this feature (or not supporting it for the target resource) can respond as if it is a normal GET request without impacting interoperability."
         let mut units: Vec<String> = Vec::new();
         for section in crate::helpers::accept_ranges::field_sections(resp) {
-            let mut lines: Vec<&str> = Vec::new();
-            // Set where this section cannot be read as a list at all. What
-            // follows is then skipped *for this section only* — the other
-            // section is a separate value and answers for itself, which is
-            // what returning at the first defect used to prevent: a header
-            // section holding an octet no range-unit admits hid a trailer
-            // section that was not `1#range-unit` either.
-            let mut unreadable = false;
+            // Read as octets. The whole of this field is built from `token`,
+            // so an octet outside visible US-ASCII is a character the
+            // production does not admit — which is what the member walk below
+            // reports it as, under the id every other reader of `token` uses.
+            // The refusal that stood here said the same thing in a sentence of
+            // its own, one step earlier and at the rule's severity; what it
+            // could not say is *which* octet, because the value it was
+            // refusing never became a value.
+            let mut lines: Vec<String> = Vec::new();
             for hv in section.get_all("accept-ranges").iter() {
-                // `to_str` refuses every octet outside visible US-ASCII, and the
-                // whole of this field is built from `token`, whose characters
-                // are a subset of that -- so the refusal is never a false alarm
-                // here and no other rule owns the field's syntax to report it.
-                // The line used to be handed to a reader that folds an absent
-                // field into an unreadable one, so the rule said nothing at all
-                // about a value no production admits.
-                //
-                // What makes it a finding is not that the value failed to be
-                // UTF-8: a `0xC3 0xA9` that decodes to a perfectly good `é` is
-                // refused as readily as a lone `0xFF`, and neither octet is one
-                // a range unit name is allowed to be built from.
-                //
-                // cite(RFC 9110 § 5.6.2): "Tokens are short textual identifiers that do not include whitespace or delimiters."
-                // cite(RFC 9110 § 5.6.2, label: tchar grammar): "tchar          = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA ; any VCHAR, except delimiters"
-                let Ok(value) = hv.to_str() else {
-                    out.push(self.cited(&RFC_9110_5_6_2, ctx.severity, "Accept-Ranges holds an octet no range-unit admits: a range unit name is a token, whose characters are all visible US-ASCII".into()));
-                    unreadable = true;
-                    break;
-                };
-                lines.push(value.trim());
+                lines.push(
+                    crate::helpers::headers::field_line_as_written(hv)
+                        .trim()
+                        .to_string(),
+                );
             }
-            if unreadable || lines.is_empty() {
+            if lines.is_empty() {
                 continue;
             }
 
@@ -556,18 +540,15 @@ mod tests {
 
     /// `0xFF` is not UTF-8 and `0xC3 0xA9` is -- the `é` a server might put in a
     /// field value by accident. Both are outside `token`, which is the whole of
-    /// what this field is built from, and the rule used to say nothing about
-    /// either: the reader it called folds an unreadable value into an absent one.
+    /// what this field is built from, so both report as the character the
+    /// production does not admit rather than as a verdict about the value's
+    /// encoding.
     #[rstest]
     #[case(&[0xff][..])]
     #[case("bytes, pag\u{e9}s".as_bytes())]
     fn an_octet_outside_the_grammar_is_reported(#[case] bad: &[u8]) {
-        let found = judge(&advertising(&[(Section::Header, bad)]));
-        let message = found.expect("expected a violation").message;
-        assert!(
-            message.contains("no range-unit admits"),
-            "reported for another reason: {message}"
-        );
+        let found = judge(&advertising(&[(Section::Header, bad)])).expect("a violation");
+        assert_eq!(found.violation, "token_character_forbidden", "{found:?}");
     }
 
     /// Nothing else runs a rule's published examples through it. These used to be
@@ -648,11 +629,7 @@ mod tests {
         ]);
         let all = judge_all(&tx);
         assert_eq!(all.len(), 2, "{all:?}");
-        assert!(
-            all[0].message.contains("no range-unit admits"),
-            "{}",
-            all[0].message
-        );
+        assert_eq!(all[0].violation, "token_character_forbidden", "{all:?}");
         assert!(all[1].message.contains("is empty"), "{}", all[1].message);
     }
 

--- a/lint-http-rules/src/rules/digest_header_syntax.rs
+++ b/lint-http-rules/src/rules/digest_header_syntax.rs
@@ -605,12 +605,14 @@ impl Rule for DigestHeaderSyntax {
                 };
 
                 for line in headers.get_all(field.name).iter() {
-                    let Ok(value) = line.to_str() else {
-                        return Some(self.violation(
-                            ctx.severity,
-                            format!("{} header value is not valid UTF-8", field.display),
-                        ));
-                    };
+                    // Read as octets. Two of these four fields are lists of
+                    // `token`s and two are Structured Fields; every one of the
+                    // productions stops inside visible US-ASCII, so an octet
+                    // outside it belongs to whichever of them was being read --
+                    // not to a verdict about the field's encoding, which is
+                    // what refusing the value outright reported.
+                    let value = crate::helpers::headers::field_line_as_written(line);
+                    let value = value.as_str();
 
                     if let Some(defect) = field.syntax.defect(value) {
                         let defect = defect.in_context(|message| {

--- a/lint-http-rules/src/rules/etag_syntax.rs
+++ b/lint-http-rules/src/rules/etag_syntax.rs
@@ -121,11 +121,14 @@ impl Rule for EtagSyntax {
             let mut count = 0usize;
             for hv in resp.headers.get_all("etag").iter() {
                 count += 1;
-                let Ok(s) = hv.to_str() else {
-                    return Some(
-                        self.violation(ctx.severity, "ETag header value is not valid UTF-8".into()),
-                    );
-                };
+                // Read as octets. `ETag = entity-tag` is one value rather than
+                // a list, so the field line is the value; and `etagc` stops at
+                // %x7E except for `obs-text`, so an octet outside visible
+                // US-ASCII is measured against the production like any other
+                // rather than folded into a verdict about the field's
+                // encoding. The two conditional fields that quote this value
+                // back have read it this way since their own conversion.
+                let s = crate::helpers::headers::field_line_as_written(hv);
 
                 let t = s.trim();
                 // The `*` kept its own branch, and the reason changed. It stood here
@@ -260,7 +263,11 @@ mod tests {
     }
 
     #[test]
-    fn non_utf8_is_violation() -> anyhow::Result<()> {
+    /// An octet outside visible US-ASCII is measured against `etagc`, which
+    /// admits `obs-text` and refuses the rest — not folded into a verdict
+    /// about the field's encoding, which is what the reader this replaces
+    /// reported.
+    fn an_obs_text_octet_is_measured_against_the_production() -> anyhow::Result<()> {
         use hyper::header::HeaderValue;
         use hyper::HeaderMap;
         let rule = EtagSyntax;
@@ -284,7 +291,8 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
-        assert!(v.is_some());
+        let v = v.expect("a finding");
+        assert_eq!(v.violation, "etag_delimiter_missing");
         Ok(())
     }
 

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1296,10 +1296,12 @@ severity = "warn"
         ///
         /// It also falls when a finding *stops being made*: the
         /// `Authorization` rules' "contains non-UTF8 value" arms went when
-        /// those fields began to be read as octets, and one of them was cited.
-        /// The sentence it named is still declared by the rule and carried by
-        /// the defs; what left is the site.
-        const FLOOR: usize = 146;
+        /// those fields began to be read as octets, and two of the family's
+        /// sites were cited — the other being `Accept-Ranges`, whose sentence
+        /// about `token` moved onto the id the member walk reports under. The
+        /// sentences are still declared by their rules and carried by the
+        /// defs; what left is the site.
+        const FLOOR: usize = 145;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -4894,8 +4894,6 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 240
-    - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 201
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
       line: 100
   - label: accept_header_media_type_syntax (7)
@@ -5031,7 +5029,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 182
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 176
+      line: 175
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 169
   - label: accept_ranges_and_206_consistent (2)
@@ -5057,7 +5055,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 191
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 259
+      line: 243
   - label: accept_ranges_and_206_consistent (5)
     section: § 14.3
     snippet: The "Accept-Ranges" field in a response indicates whether an upstream server supports range requests for the target resource.
@@ -5067,7 +5065,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 168
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 139
+      line: 138
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 48
   - label: accept_ranges_and_206_consistent (6)
@@ -5079,7 +5077,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 165
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 260
+      line: 244
   - label: accept_ranges_and_206_consistent (7)
     section: § 14.3
     snippet: to indicate that it supports byte range requests for that target resource, thereby encouraging its use by the client for future partial requests on the same request path.
@@ -5129,7 +5127,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 228
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 297
+      line: 281
   - label: accept_ranges_on_partial_content (5)
     section: § 15.3.7
     snippet: A client MUST inspect a 206 response's Content-Type and Content-Range field(s) to determine what parts are enclosed and whether additional requests are needed.
@@ -5149,25 +5147,19 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 37
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 372
+      line: 356
   - label: acceptable-ranges grammar
     section: § 14.3
     snippet: acceptable-ranges = 1#range-unit
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 222
+      line: 206
   - label: accept_ranges_values_valid
     section: § 16.5.1
     snippet: The "HTTP Range Unit Registry" defines the namespace for the range unit names and refers to their corresponding specifications.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 295
-  - label: tchar grammar
-    section: § 5.6.2
-    snippet: tchar          = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA ; any VCHAR, except delimiters
-    cited_by:
-    - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 202
+      line: 279
   - label: allow_header_method_tokens_valid
     section: § 10.2
     snippet: The response header fields below provide additional information about the response, beyond what is implied by the status code, including information about the server, about the target resource, or about related resources.
@@ -6465,9 +6457,9 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 47
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 294
+      line: 278
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 387
+      line: 371
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
       line: 85
     - file: lint-http-rules/src/rules/range_header_syntax.rs
@@ -6483,7 +6475,7 @@ sources:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 221
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 332
+      line: 316
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 294
   - label: Accept-Ranges grammar
@@ -6499,7 +6491,7 @@ sources:
     - file: lint-http-rules/src/helpers/accept_ranges.rs
       line: 61
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 296
+      line: 280
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 49
   - label: lint-http-rules/src/helpers/accept_ranges.rs (4)
@@ -6515,7 +6507,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 208
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 333
+      line: 317
     - file: lint-http-rules/src/rules/content_transfer_encoding_valid.rs
       line: 122
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
@@ -6535,7 +6527,7 @@ sources:
     - file: lint-http-rules/src/helpers/accept_ranges.rs
       line: 118
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 340
+      line: 324
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
       line: 212
   - label: lint-http-rules/src/helpers/auth.rs
@@ -6613,7 +6605,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
       line: 126
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 355
+      line: 339
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
       line: 329
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
@@ -6637,7 +6629,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
       line: 137
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 359
+      line: 343
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 104
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
@@ -6961,7 +6953,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 90
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 221
+      line: 205
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 210
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -6989,7 +6981,7 @@ sources:
     - file: lint-http-rules/src/rules/deprecation_header_syntax.rs
       line: 96
     - file: lint-http-rules/src/rules/etag_syntax.rs
-      line: 156
+      line: 159
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 369
     - file: lint-http-rules/src/rules/host_header.rs
@@ -7089,7 +7081,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 222
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 356
+      line: 340
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 147
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
@@ -7557,7 +7549,7 @@ sources:
     - file: lint-http-rules/src/helpers/validator.rs
       line: 133
     - file: lint-http-rules/src/rules/etag_syntax.rs
-      line: 138
+      line: 141
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
       line: 145
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs


### PR DESCRIPTION
`ETag`, the four digest fields and `Accept-Ranges` were the converted rules still reading through the string reader. Each is the only rule that measures its field's grammar, so the octet had nowhere else to be reported: an `etagc` question became a verdict about the field's encoding, and a `token` question became a sentence one step before the member walk that owns it.

`Accept-Ranges` is the one that had already said the right thing — its message named the octet no range-unit admits — and it said it at its own severity from a branch that ran before the value existed. Now the member walk reports it, under the id every other reader of the production uses, and the branch is gone. The citation floor falls with it: both sentences it cited are carried elsewhere in the tree, one of them by the def that now answers.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
