### PR TITLE
A Set-Cookie octet lands in an attribute

### DIFF
--- a/lint-http-rules/src/rules/cookie_attribute_consistent.rs
+++ b/lint-http-rules/src/rules/cookie_attribute_consistent.rs
@@ -336,12 +336,15 @@ impl Rule for CookieAttributeConsistent {
             resp.headers
                 .get_all("set-cookie")
                 .iter()
-                .find_map(|line| match line.to_str() {
-                    Err(_) => Some(self.violation(
-                        ctx.severity,
-                        "Set-Cookie header value is not valid UTF-8".into(),
-                    )),
-                    Ok(line) => self.set_cookie_defect(line, ctx),
+                // Read as octets, one field line at a time: `Set-Cookie` is
+                // not a list, and § 4.1.1's grammar stops at `CHAR`, so an
+                // octet above %x7F is the attribute reader's finding rather
+                // than a verdict about the field's encoding.
+                .find_map(|line| {
+                    self.set_cookie_defect(
+                        &crate::helpers::headers::field_line_as_written(line),
+                        ctx,
+                    )
                 })
         };
         Vec::from_iter(finding())
@@ -417,7 +420,7 @@ mod tests {
     }
 
     #[test]
-    fn non_utf8_set_cookie_is_reported() -> anyhow::Result<()> {
+    fn an_obs_text_octet_is_read_where_it_lands() -> anyhow::Result<()> {
         use crate::http_transaction::ResponseInfo;
         use crate::test_helpers::make_test_transaction;
         use hyper::header::HeaderValue;
@@ -432,7 +435,7 @@ mod tests {
             trailers: None,
         });
 
-        // Append a non-UTF8 header value
+        // A field line holding an octet above %x7F
         tx.response
             .as_mut()
             .unwrap()
@@ -446,9 +449,15 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
-        assert!(v.is_some());
-        let msg = v.unwrap().message;
-        assert!(msg.contains("not valid UTF-8"));
+        // The octet is in the cookie-name, and that is what the finding says
+        // now: § 4.1.1 writes the name as a `token`, so an octet above %x7F is
+        // a character it does not admit. The verdict this replaces named the
+        // field's encoding and stopped before the name was read.
+        let v = v.expect("a finding");
+        assert_eq!(
+            v.message,
+            "Set-Cookie cookie-name contains invalid character: '\u{ff}'"
+        );
         Ok(())
     }
 

--- a/lint-http-rules/src/rules/cookie_domain_valid.rs
+++ b/lint-http-rules/src/rules/cookie_domain_valid.rs
@@ -118,12 +118,14 @@ impl Rule for CookieDomainValid {
             let resp = tx.response.as_ref()?;
 
             for hv in resp.headers.get_all("set-cookie").iter() {
-                let Ok(s) = hv.to_str() else {
-                    return Some(self.violation(
-                        ctx.severity,
-                        "Set-Cookie header value is not valid UTF-8".into(),
-                    ));
-                };
+                // Read as octets, one field line at a time. `Set-Cookie` is
+                // not a list -- § 5.3's recombination does not apply to it, so
+                // the lines are never joined -- and § 4.1.1's grammar stops at
+                // `CHAR`, %x01-7F, so an octet above that is a character the
+                // production does not admit rather than a verdict about the
+                // field's encoding. The readers below have an entry for it.
+                let s = crate::helpers::headers::field_line_as_written(hv);
+                let s = s.as_str();
 
                 // Split into cookie-pair and attributes — § 5.2's own parsing
                 // algorithm, which is the reading this rule does before any
@@ -309,7 +311,7 @@ mod tests {
     }
 
     #[test]
-    fn non_utf8_set_cookie_is_reported() -> anyhow::Result<()> {
+    fn an_obs_text_octet_in_a_domain_is_the_names_defect() -> anyhow::Result<()> {
         use crate::http_transaction::ResponseInfo;
         use crate::test_helpers::make_test_transaction;
         use hyper::header::HeaderValue;
@@ -324,23 +326,25 @@ mod tests {
             trailers: None,
         });
 
-        // Append a non-UTF8 header value
-        tx.response
-            .as_mut()
-            .unwrap()
-            .headers
-            .append("set-cookie", HeaderValue::from_bytes(&[0xff])?);
+        tx.response.as_mut().unwrap().headers.append(
+            "set-cookie",
+            HeaderValue::from_bytes(b"SID=1; Domain=ex\xffample.com")?,
+        );
 
+        // Inside the attribute this rule reads, the octet is one the preferred
+        // name syntax does not admit, and it answers with the shared `domain`
+        // subject's id -- the same one a `From` address or a `Forwarded` node
+        // answers with. The verdict this replaces named the field's encoding
+        // and never reached the name.
         let rule = CookieDomainValid;
         let v = crate::test_helpers::run_rule(
             &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-        );
-        assert!(v.is_some());
-        let msg = v.unwrap().message;
-        assert!(msg.contains("not valid UTF-8"));
+        )
+        .expect("a finding");
+        assert_eq!(v.violation, "domain_label_character_forbidden");
         Ok(())
     }
 

--- a/lint-http-rules/src/rules/cookie_path_valid.rs
+++ b/lint-http-rules/src/rules/cookie_path_valid.rs
@@ -139,12 +139,14 @@ impl Rule for CookiePathValid {
             let resp = tx.response.as_ref()?;
 
             for hv in resp.headers.get_all("set-cookie").iter() {
-                let Ok(s) = hv.to_str() else {
-                    return Some(self.violation(
-                        ctx.severity,
-                        "Set-Cookie header value is not valid UTF-8".into(),
-                    ));
-                };
+                // Read as octets, one field line at a time. `Set-Cookie` is
+                // not a list -- § 5.3's recombination does not apply to it, so
+                // the lines are never joined -- and § 4.1.1's grammar stops at
+                // `CHAR`, %x01-7F, so an octet above that is a character the
+                // production does not admit rather than a verdict about the
+                // field's encoding. The readers below have an entry for it.
+                let s = crate::helpers::headers::field_line_as_written(hv);
+                let s = s.as_str();
 
                 // Split into cookie-pair and attribute segments. The `;` and
                 // the trim are § 5.2's own parsing algorithm, which is what
@@ -372,32 +374,39 @@ mod tests {
     }
 
     #[test]
-    fn non_utf8_set_cookie_value_reports() -> anyhow::Result<()> {
+    fn an_obs_text_octet_in_a_path_is_the_paths_defect() -> anyhow::Result<()> {
         use hyper::header::HeaderValue;
         use hyper::HeaderMap;
-        let mut tx = crate::test_helpers::make_test_transaction();
-        let mut hm = HeaderMap::new();
-        let bad = HeaderValue::from_bytes(&[0xff]).expect("should construct non-utf8 header");
-        hm.insert("set-cookie", bad);
-        tx.response = Some(crate::http_transaction::ResponseInfo {
-            status: 200,
-            version: "HTTP/1.1".into(),
-            headers: hm,
+        let judge = |value: &[u8]| {
+            let mut tx = crate::test_helpers::make_test_transaction();
+            let mut hm = HeaderMap::new();
+            hm.insert(
+                "set-cookie",
+                HeaderValue::from_bytes(value).expect("a header value"),
+            );
+            tx.response = Some(crate::http_transaction::ResponseInfo {
+                status: 200,
+                version: "HTTP/1.1".into(),
+                headers: hm,
+                body_length: None,
+                trailers: None,
+            });
+            crate::test_helpers::run_rule(
+                &CookiePathValid,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_path_valid"]),
+            )
+        };
 
-            body_length: None,
-            trailers: None,
-        });
-
-        let rule = CookiePathValid;
-        let v = crate::test_helpers::run_rule(
-            &rule,
-            &tx,
-            &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-        );
-        assert!(v.is_some());
-        let msg = v.unwrap().message;
-        assert!(msg.contains("not valid UTF-8"));
+        // Inside the attribute this rule reads, the octet is one `path-value`
+        // does not admit -- `CHAR` stops at %x7F. Outside it, this rule has
+        // nothing to say: a cookie-name's octet is the attribute walk's
+        // finding next door, and the verdict this replaces reported the field
+        // for an encoding from either position.
+        let v = judge(b"SID=1; Path=/a\xffb").expect("a finding");
+        assert_eq!(v.violation, "cookie_path_non_ascii_character_forbidden");
+        assert!(judge(b"\xff").is_none());
         Ok(())
     }
 

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -2207,15 +2207,15 @@ sources:
     snippet: Consume the characters of the unparsed-attributes up to, but not including, the first %x3B (";") character.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_domain_valid.rs
-      line: 132
+      line: 134
     - file: lint-http-rules/src/rules/cookie_path_valid.rs
-      line: 154
+      line: 156
   - label: cookie_domain_valid (2)
     section: § 5.2.3
     snippet: If the attribute-name case-insensitively matches the string "Domain", the user agent MUST process the cookie-av as follows.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_domain_valid.rs
-      line: 141
+      line: 143
   - label: cookie_lifecycle
     section: § 4.1.2.5
     snippet: The Secure attribute limits the scope of the cookie to "secure" channels
@@ -2245,7 +2245,7 @@ sources:
     snippet: If the attribute-name case-insensitively matches the string "Path", the user agent MUST process the cookie-av as follows.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_path_valid.rs
-      line: 169
+      line: 171
   - label: lint-http-rules/src/helpers/cookie.rs
     section: § 4.1.1
     snippet: 'Servers SHOULD NOT send Set-Cookie headers that fail to conform to the following grammar:'


### PR DESCRIPTION
The three rules that read `Set-Cookie` attributes refused any field line the string reader could not decode and reported it as a value that is not UTF-8. RFC 6265 § 4.1.1 writes the whole field from `CHAR`, %x01-7F, so an octet above that is a character the grammar does not admit — and each of the three already had an entry for it: a path holding one, a domain label holding one, a cookie-name holding one.

The lines are read one at a time and never joined, because this field is the one that does not recombine. Where the octet is outside the attribute a rule reads, that rule now says nothing and the neighbour that reads the name reports it, which is the same division of labour these three already keep for every other defect.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
