### PR TITLE
A declared length is digits, not an encoding

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1131,9 +1131,25 @@ severity = "warn"
 # Comment is never closed
 severity = "warn"
 
+[violations.content_length_character_forbidden]
+# Content-Length value holds an octet DIGIT does not admit
+severity = "error"
+
 [violations.content_length_conflicting]
 # Content-Length disagrees with the octets received
 severity = "error"
+
+[violations.content_length_empty]
+# Content-Length declares no length
+severity = "error"
+
+[violations.content_length_members_conflicting]
+# Content-Length is declared twice with different numbers
+severity = "error"
+
+[violations.content_length_numeral_invalid]
+# Content-Length numeral is too large to represent
+severity = "warn"
 
 [violations.content_range_complete_length_conflicting]
 # Content-Range complete-length does not exceed its last-pos

--- a/docs/rules/content_length_valid.md
+++ b/docs/rules/content_length_valid.md
@@ -14,6 +14,8 @@ This rule validates `Content-Length` header values for syntax and consistency:
 - A `Content-Length` header with an empty value or containing non-digit characters is invalid.
 - When multiple `Content-Length` header fields are present, their trimmed numeric values MUST be identical.
 
+The field lines are read as the octets the sender wrote, so an octet outside US-ASCII is reported as the character `DIGIT` does not admit rather than as a verdict about the value's encoding — the whole production is ten visible US-ASCII characters, so there was never anything for the encoding to say first.
+
 Improper `Content-Length` values can lead to message framing errors or truncated bodies; the rule flags invalid or inconsistent values.
 
 ## Specifications

--- a/lint-http-rules/src/helpers/content_length.rs
+++ b/lint-http-rules/src/helpers/content_length.rs
@@ -13,25 +13,39 @@
 //! field and a body may be framed by connection close.
 //!
 //! [`ContentLengthError`] is one of the typed defect enums in this tree: the
-//! three ways the field fails are three different findings, and a caller that
+//! four ways the field fails are four different findings, and a caller that
 //! got a `String` could not tell them apart to word them differently.
+//!
+//! **The field lines are read as octets, and there is no encoding verdict among
+//! those four.** `Content-Length = 1*DIGIT` is ten characters of visible
+//! US-ASCII, so every octet a `HeaderValue::to_str` would refuse is an octet the
+//! production refuses first — the string reader was not a gate here but a
+//! second, worse copy of the alphabet check, answering "this value is not valid
+//! UTF-8" where the value holds a `-`, a `.` or a %xFF that `DIGIT` does not
+//! admit. Reading the line one `char` per octet collapses the two, which is why
+//! the enum below has an alphabet variant and no encoding one.
 
+use crate::helpers::headers::field_line_as_written;
 use crate::helpers::list::list_members;
 use hyper::HeaderMap;
 
 /// Errors returned by `validate_content_length`.
 #[derive(Debug, PartialEq, Eq)]
 pub enum ContentLengthError {
-    InvalidCharacter(String),
+    /// A field line carrying no numeral at all: an empty value, or one written
+    /// as nothing but the commas of a list. `1*DIGIT` has a floor of one.
+    Empty,
+    /// The first octet of a member that `DIGIT` does not admit, and the field
+    /// line it sat in.
+    InvalidCharacter(char, String),
     TooLarge(String),
     MultipleValuesDiffer(String, String),
-    NonUtf8,
 }
 
 /// Validate `Content-Length` headers in a `HeaderMap`.
 ///
 /// Checks:
-/// 1. Values must be valid UTF-8 digits.
+/// 1. Values must be digits, read as the octets the sender wrote.
 /// 2. Values must be parseable as u128.
 /// 3. If multiple values are present, they must be identical.
 ///
@@ -51,7 +65,11 @@ pub fn validate_content_length(headers: &HeaderMap) -> Result<Option<u128>, Cont
     let mut first_raw: String = String::new();
 
     for hv in entries.iter() {
-        let s = hv.to_str().map_err(|_| ContentLengthError::NonUtf8)?;
+        // One `char` per octet: the production admits ten characters and this
+        // walk names whichever one the sender wrote instead, so nothing is
+        // gained by asking first whether the whole line is text.
+        let s = field_line_as_written(hv);
+        let s = s.as_str();
 
         // A single field line may itself carry a comma-separated list, and that is
         // not automatically a violation. The sentence below makes `5, 5` valid and
@@ -66,8 +84,8 @@ pub fn validate_content_length(headers: &HeaderMap) -> Result<Option<u128>, Cont
             saw_value = true;
 
             // cite(RFC 9110 § 8.6, label: Content-Length grammar): "Content-Length = 1*DIGIT"
-            if !t.chars().all(|c| c.is_ascii_digit()) {
-                return Err(ContentLengthError::InvalidCharacter(s.to_string()));
+            if let Some(c) = t.chars().find(|c| !c.is_ascii_digit()) {
+                return Err(ContentLengthError::InvalidCharacter(c, s.to_string()));
             }
 
             // A digit run too long for `u128` is still valid `1*DIGIT` — the grammar
@@ -99,7 +117,7 @@ pub fn validate_content_length(headers: &HeaderMap) -> Result<Option<u128>, Cont
         // An empty field line has no values to be "all the same", and one is not a
         // list of none: `Content-Length:` is simply not `1*DIGIT`.
         if !saw_value {
-            return Err(ContentLengthError::InvalidCharacter(s.to_string()));
+            return Err(ContentLengthError::Empty);
         }
     }
 
@@ -201,8 +219,44 @@ mod tests {
         ));
 
         // Still not a list of digits.
-        assert!(one("").is_err());
+        assert_eq!(one(""), Err(ContentLengthError::Empty));
         assert!(one("5, x").is_err());
         assert!(one("abc").is_err());
+    }
+
+    /// The alphabet answers the octet, and it always could have. A line holding
+    /// %xFF came back as an encoding verdict about the whole value; `DIGIT` is
+    /// ten characters of visible US-ASCII, so the production had already refused
+    /// that octet and the only question left is which one it was.
+    #[test]
+    fn an_octet_outside_us_ascii_is_the_alphabets_defect_and_not_an_encodings() {
+        let mut h = HeaderMap::new();
+        h.append(
+            "content-length",
+            hyper::header::HeaderValue::from_bytes(&[b'1', 0xFF]).expect("a field line"),
+        );
+        assert_eq!(
+            validate_content_length(&h),
+            Err(ContentLengthError::InvalidCharacter(
+                '\u{FF}',
+                "1\u{FF}".into()
+            )),
+        );
+    }
+
+    /// A value of nothing but commas declares no length either, and it is the
+    /// same defect as an empty line rather than a member-level one: the
+    /// recipient's walk drops the empty members, so what is left is a field
+    /// line with no numeral in it.
+    #[test]
+    fn a_line_of_commas_declares_no_length() {
+        let mut h = HeaderMap::new();
+        h.append(
+            "content-length",
+            ", ,"
+                .parse::<hyper::header::HeaderValue>()
+                .expect("a field line"),
+        );
+        assert_eq!(validate_content_length(&h), Err(ContentLengthError::Empty));
     }
 }

--- a/lint-http-rules/src/rules/content_length_valid.rs
+++ b/lint-http-rules/src/rules/content_length_valid.rs
@@ -4,24 +4,29 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::content_length::{
+    content_length_defect, CONTENT_LENGTH_CHARACTER_FORBIDDEN, CONTENT_LENGTH_EMPTY,
+    CONTENT_LENGTH_MEMBERS_CONFLICTING, CONTENT_LENGTH_NUMERAL_INVALID, RFC_9110_8_6, RFC_9112_6_3,
+};
+use crate::violations::ViolationDef;
 
 pub struct ContentLengthValid;
 
-/// The specification references this rule declares, each named so a finding
-/// site can cite the one it enforces. `specifications()` below is built from
-/// exactly these, so the docs and the citations cannot name different text.
-const RFC_9110_8_6: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("8.6"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6",
-    note: "Where `Content-Length = 1*DIGIT` is defined — the grammar every value here is checked against",
-};
-const RFC_9112_6_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9112",
-    section: Some("6.3"),
-    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.3",
-    note: "Why differing values are an error and why a single field line may carry a comma-separated list, provided every member is valid and identical",
-};
+/// Everything this rule reports, and all of it belongs to the field rather than
+/// to this reading of it.
+///
+/// The messages come from `validate_content_length`, which four other rules
+/// call as a gate — so the defects are the *helper's* and the subject is the
+/// field's, not this rule's. What is left here is the claim that a malformed or
+/// self-contradictory `Content-Length` is worth reporting wherever it appears,
+/// which is why the rule reads both directions and cites the sentence saying
+/// the field describes a representation rather than a direction.
+static DECLARED: &[&ViolationDef] = &[
+    &CONTENT_LENGTH_EMPTY,
+    &CONTENT_LENGTH_CHARACTER_FORBIDDEN,
+    &CONTENT_LENGTH_NUMERAL_INVALID,
+    &CONTENT_LENGTH_MEMBERS_CONFLICTING,
+];
 
 impl RuleMeta for ContentLengthValid {
     fn id(&self) -> &'static str {
@@ -39,11 +44,15 @@ severity = "warn"
     }
 
     fn description(&self) -> &'static str {
-        "This rule validates `Content-Length` header values for syntax and consistency:\n\n- Each `Content-Length` header value must be a non-negative decimal integer (no signs, no decimals).\n- A `Content-Length` header with an empty value or containing non-digit characters is invalid.\n- When multiple `Content-Length` header fields are present, their trimmed numeric values MUST be identical.\n\nImproper `Content-Length` values can lead to message framing errors or truncated bodies; the rule flags invalid or inconsistent values."
+        "This rule validates `Content-Length` header values for syntax and consistency:\n\n- Each `Content-Length` header value must be a non-negative decimal integer (no signs, no decimals).\n- A `Content-Length` header with an empty value or containing non-digit characters is invalid.\n- When multiple `Content-Length` header fields are present, their trimmed numeric values MUST be identical.\n\nThe field lines are read as the octets the sender wrote, so an octet outside US-ASCII is reported as the character `DIGIT` does not admit rather than as a verdict about the value's encoding — the whole production is ten visible US-ASCII characters, so there was never anything for the encoding to say first.\n\nImproper `Content-Length` values can lead to message framing errors or truncated bodies; the rule flags invalid or inconsistent values."
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[RFC_9110_8_6, RFC_9112_6_3]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -88,12 +97,19 @@ impl Rule for ContentLengthValid {
                 match crate::helpers::content_length::validate_content_length(headers) {
                     Ok(_) => None,
                     Err(e) => {
-                        let message = match e {
-                            crate::helpers::content_length::ContentLengthError::NonUtf8 => {
-                                "Invalid Content-Length value (non-UTF8)".into()
+                        // The format strings stay where their arguments are; the
+                        // id comes from the helper's subject, because the helper
+                        // is what four other rules read this field through.
+                        let message = match &e {
+                            crate::helpers::content_length::ContentLengthError::Empty => {
+                                "Content-Length carries no digits".into()
                             }
-                            crate::helpers::content_length::ContentLengthError::InvalidCharacter(s) => {
-                                format!("Invalid Content-Length value: '{}'", s)
+                            crate::helpers::content_length::ContentLengthError::InvalidCharacter(c, s) => {
+                                format!(
+                                    "Invalid Content-Length value '{}': contains {}",
+                                    crate::helpers::shown::shown_in_finding(s),
+                                    crate::helpers::shown::describe_char(*c),
+                                )
                             }
                             crate::helpers::content_length::ContentLengthError::TooLarge(s) => {
                                 format!("Content-Length value too large: '{}'", s)
@@ -109,7 +125,7 @@ impl Rule for ContentLengthValid {
                             }
                         };
 
-                        Some(self.violation(ctx.severity, message))
+                        Some(ctx.report_with(content_length_defect(&e), message))
                     }
                 }
             };
@@ -284,12 +300,15 @@ mod tests {
         Ok(())
     }
 
+    /// The octet is the alphabet's defect and the finding names it. It used to
+    /// be reported as a verdict about the value's encoding, which said nothing
+    /// about which octet arrived — and `DIGIT` had already refused it, because
+    /// the whole production is visible US-ASCII.
     #[test]
-    fn check_non_utf8() -> anyhow::Result<()> {
+    fn an_octet_outside_us_ascii_is_named_rather_than_called_an_encoding() -> anyhow::Result<()> {
         let rule = ContentLengthValid;
         let mut tx = crate::test_helpers::make_test_transaction();
         let mut hm = hyper::HeaderMap::new();
-        // 0xFF is not a valid UTF-8 character
         let bad_value = HeaderValue::from_bytes(&[0xFF])?;
         hm.insert(hyper::header::CONTENT_LENGTH, bad_value);
         tx.request.headers = hm;
@@ -299,10 +318,56 @@ mod tests {
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .expect("a finding");
+        assert_eq!(v.violation, "content_length_character_forbidden");
+        assert_eq!(
+            v.message, "Invalid Content-Length value 'ÿ': contains 0xFF",
+            "the octet is named, and the value is shown as it was written",
         );
-        assert!(v.is_some());
-        assert!(v.unwrap().message.contains("non-UTF8"));
         Ok(())
+    }
+
+    /// Four ways to get the framing wrong, four ids, and three of them outrank
+    /// the fourth: the overlong numeral is the one no sentence refuses, so it
+    /// stays `warn` while the rest are `error`. One rule severity said all four
+    /// at once.
+    #[test]
+    fn each_defect_is_the_fields_and_carries_its_own_rank() {
+        for (value, id, severity) in [
+            ("", "content_length_empty", crate::lint::Severity::Error),
+            (
+                "1.5",
+                "content_length_character_forbidden",
+                crate::lint::Severity::Error,
+            ),
+            (
+                "340282366920938463463374607431768211456",
+                "content_length_numeral_invalid",
+                crate::lint::Severity::Warn,
+            ),
+            (
+                "10, 20",
+                "content_length_members_conflicting",
+                crate::lint::Severity::Error,
+            ),
+        ] {
+            let tx = crate::test_helpers::make_test_transaction_with_headers(&[(
+                "content-length",
+                value,
+            )]);
+            let found = crate::test_helpers::run_rule(
+                &ContentLengthValid,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "content_length_valid",
+                ]),
+            )
+            .unwrap_or_else(|| panic!("{value:?}"));
+            assert_eq!(found.violation, id, "{value:?}");
+            assert_eq!(found.severity, severity, "{value:?}");
+        }
     }
 
     #[test]

--- a/lint-http-rules/src/violations/content_length.rs
+++ b/lint-http-rules/src/violations/content_length.rs
@@ -2,25 +2,36 @@
 //
 // SPDX-License-Identifier: ISC
 
-//! `Content-Length` defects — the declared length against the octets that came.
+//! `Content-Length` defects — the declared length against the octets that came,
+//! and against the grammar that spells it.
 //!
 //! The field is framing before it is metadata: RFC 9112 § 6.2 makes its value
 //! the information a recipient uses to decide where the message ends, so a
 //! value that disagrees with the body is not a description that happens to be
 //! stale — it is a recipient reading the next message from the wrong offset.
-//! That is why the entry here defaults to `error` while most grammar defects in
+//! That is why the entries here default to `error` while most grammar defects in
 //! this catalogue default to `warn`, and it is not this catalogue's judgment
-//! alone: the two rules that report it had each chosen `error` in their own
-//! configuration example, separately, before there was one place to say it.
+//! alone: the two rules that report the mismatch had each chosen `error` in
+//! their own configuration example, separately, before there was one place to
+//! say it.
+//!
+//! **The grammar entries inherit that reasoning rather than the catalogue's
+//! usual ranking**, because RFC 9112 § 6.3 says so in as many words: a message
+//! with an invalid `Content-Length` and no `Transfer-Encoding` is a framing
+//! error a recipient must treat as unrecoverable. A value that is not `1*DIGIT`
+//! and a value the sender wrote twice with two different numbers land in the
+//! same place as a value that is simply wrong, so they are ranked the same.
+//! The one entry below that is *not* `error` is the one no sentence asks for.
 //!
 //! One id for both directions. A request whose declared length is wrong and a
 //! response whose declared length is wrong are the same defect at opposite ends
 //! of the same exchange, and the mirror rules that report them differ in which
 //! message they read and in nothing else.
 
+use crate::helpers::content_length::ContentLengthError;
 use crate::lint::Severity;
 use crate::rules::SpecRef;
-use crate::violations::defects;
+use crate::violations::{defects, ViolationDef};
 
 /// Why a mismatch matters rather than merely differing: the value is what a
 /// recipient frames the message with.
@@ -29,6 +40,25 @@ pub const RFC_9112_6_2: SpecRef = SpecRef {
     section: Some("6.2"),
     url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.2",
     note: "Content-Length as framing — the declared length is how a recipient determines where the data and the message end",
+};
+
+/// Where `Content-Length = 1*DIGIT` is defined — the grammar every value is
+/// measured against, and the floor of one digit a value has to reach.
+pub const RFC_9110_8_6: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.6"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6",
+    note: "Where `Content-Length = 1*DIGIT` is defined — the grammar every value here is checked against",
+};
+
+/// Why an invalid or self-contradictory value is a framing error rather than a
+/// description that is merely wrong, and why one field line may carry a
+/// comma-separated list provided every member is valid and identical.
+pub const RFC_9112_6_3: SpecRef = SpecRef {
+    spec: "RFC 9112",
+    section: Some("6.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.3",
+    note: "Why differing values are an error and why a single field line may carry a comma-separated list, provided every member is valid and identical",
 };
 
 defects! {
@@ -49,16 +79,134 @@ defects! {
         default_severity: Severity::Error,
         spec: Some(RFC_9112_6_2),
     }
+
+    /// A field line carrying no digit at all: an empty value, or one written as
+    /// nothing but the commas of a list. `1*DIGIT` has a floor of one, so such
+    /// a line declares no length — which is not the same as declaring zero, and
+    /// a recipient that reads it as zero frames the message short.
+    ///
+    // cite(RFC 9110 § 8.6, label: Content-Length grammar): "Content-Length = 1*DIGIT"
+    CONTENT_LENGTH_EMPTY = {
+        id: "content_length_empty",
+        title: "Content-Length declares no length",
+        message: "",
+        default_severity: Severity::Error,
+        spec: Some(RFC_9110_8_6),
+    }
+
+    /// An octet in the value that `DIGIT` does not admit — the sign of `-1`,
+    /// the point of `1.5`, a letter, or an octet outside US-ASCII entirely.
+    ///
+    /// The whole production is `DIGIT`, which is ten characters of visible
+    /// US-ASCII, so every octet a string reader would have refused is already
+    /// an octet this entry answers for: there is nothing for the field to say
+    /// about its own encoding that the grammar has not said first.
+    ///
+    // cite(RFC 9110 § 8.6, label: Content-Length grammar): "Content-Length = 1*DIGIT"
+    CONTENT_LENGTH_CHARACTER_FORBIDDEN = {
+        id: "content_length_character_forbidden",
+        title: "Content-Length value holds an octet DIGIT does not admit",
+        message: "",
+        default_severity: Severity::Error,
+        spec: Some(RFC_9110_8_6),
+    }
+
+    /// A numeral that *is* `1*DIGIT` and is larger than a reader can hold. It
+    /// derives from the grammar — no sentence caps the digits, unlike
+    /// `delta-seconds`, and none tells a recipient to clamp — so this is a
+    /// tolerance of this crate rather than a requirement it quotes, which is
+    /// why it carries no citation and is the one entry in the subject that is
+    /// not `error`. It takes a 39-digit value to reach.
+    CONTENT_LENGTH_NUMERAL_INVALID = {
+        id: "content_length_numeral_invalid",
+        title: "Content-Length numeral is too large to represent",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: None,
+    }
+
+    /// Two lengths declared in one message that are not the same number.
+    /// § 5.3 makes the field lines of one section a single list, so a value
+    /// repeated across lines and a value written `5, 6` on one line are the
+    /// same message and the same defect — a recipient has two offsets to end
+    /// the message at and no sentence choosing between them.
+    ///
+    // cite(RFC 9112 § 6.3): "If a message is received without Transfer-Encoding and with an invalid Content-Length header field, then the message framing is invalid and the recipient MUST treat it as an unrecoverable error, unless the field value can be successfully parsed as a comma-separated list (Section 5.6.1 of [HTTP]), all values in the list are valid, and all values in the list are the same (in which case, the message is processed with that single value used as the Content-Length field value)."
+    CONTENT_LENGTH_MEMBERS_CONFLICTING = {
+        id: "content_length_members_conflicting",
+        title: "Content-Length is declared twice with different numbers",
+        message: "",
+        default_severity: Severity::Error,
+        spec: Some(RFC_9112_6_3),
+    }
+}
+
+/// The defect a [`ContentLengthError`] reports as.
+///
+/// Exhaustive, so a new way for the field to fail does not compile until the
+/// catalogue names it.
+pub fn content_length_defect(defect: &ContentLengthError) -> &'static ViolationDef {
+    match defect {
+        ContentLengthError::Empty => &CONTENT_LENGTH_EMPTY,
+        ContentLengthError::InvalidCharacter(..) => &CONTENT_LENGTH_CHARACTER_FORBIDDEN,
+        ContentLengthError::TooLarge(_) => &CONTENT_LENGTH_NUMERAL_INVALID,
+        ContentLengthError::MultipleValuesDiffer(..) => &CONTENT_LENGTH_MEMBERS_CONFLICTING,
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// The default is the one thing worth pinning about a single-entry subject,
-    /// because it is the reason the entry is not `warn` like its neighbours.
+    /// Every way of getting the framing wrong ranks the same, which is the
+    /// subject's whole argument: the field is what a recipient ends the message
+    /// with, so a value that is not a numeral is no better than one that
+    /// contradicts the octets.
     #[test]
-    fn a_framing_disagreement_defaults_above_a_grammar_defect() {
-        assert_eq!(CONTENT_LENGTH_CONFLICTING.default_severity, Severity::Error);
+    fn every_framing_defect_defaults_above_a_grammar_defect() {
+        for def in [
+            &CONTENT_LENGTH_CONFLICTING,
+            &CONTENT_LENGTH_EMPTY,
+            &CONTENT_LENGTH_CHARACTER_FORBIDDEN,
+            &CONTENT_LENGTH_MEMBERS_CONFLICTING,
+        ] {
+            assert_eq!(def.default_severity, Severity::Error, "{}", def.id);
+        }
+    }
+
+    /// The exception, and the two halves of it are one fact: an overlong
+    /// numeral is refused by this crate and by no sentence, so it carries no
+    /// citation and does not rank with the defects a document asks for.
+    #[test]
+    fn the_entry_no_sentence_asks_for_is_the_one_that_is_not_an_error() {
+        assert_eq!(
+            CONTENT_LENGTH_NUMERAL_INVALID.default_severity,
+            Severity::Warn
+        );
+        assert!(CONTENT_LENGTH_NUMERAL_INVALID.spec.is_none());
+    }
+
+    /// Four ways the field fails, four ids — the mapping is the catalogue's
+    /// half of the helper's enum, and it is spelled out so a collapse would be
+    /// a decision on the page rather than a `match` arm nobody re-read.
+    #[test]
+    fn each_content_length_error_maps_to_its_own_id() {
+        for (defect, id) in [
+            (ContentLengthError::Empty, "content_length_empty"),
+            (
+                ContentLengthError::InvalidCharacter('x', "x".into()),
+                "content_length_character_forbidden",
+            ),
+            (
+                ContentLengthError::TooLarge("1".into()),
+                "content_length_numeral_invalid",
+            ),
+            (
+                ContentLengthError::MultipleValuesDiffer("1".into(), "2".into()),
+                "content_length_members_conflicting",
+            ),
+        ] {
+            assert_eq!(content_length_defect(&defect).id, id);
+        }
     }
 }

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -355,10 +355,14 @@ mod tests {
     /// equality. `cookie_path_whitespace_invalid` is the first proof: no
     /// specification asks for it, this crate refuses the character anyway, and
     /// carrying a citation there would be a guess dressed as a reference.
+    /// `content_length_numeral_invalid` is the second, and its reason is a
+    /// different one worth having beside the first: that value *derives* from
+    /// its production — `1*DIGIT` sets no ceiling — and what refuses it is this
+    /// crate's inability to represent it, which no document asked for either.
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 115;
+        const FLOOR: usize = 118;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -5589,7 +5589,7 @@ sources:
     snippet: The "Content-Length" header field indicates the associated representation's data length as a decimal non-negative integer number of octets.
     cited_by:
     - file: lint-http-rules/src/rules/content_length_valid.rs
-      line: 86
+      line: 95
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
       line: 256
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
@@ -6737,13 +6737,13 @@ sources:
     snippet: For example, an HTTP/1.1 message body (Section 6 of [HTTP/1.1]) might consist of a stream of data encoded with the chunked transfer coding -- a sequence of data chunks, one zero-length chunk, and a trailer section -- whereas the content of that same message includes only the data stream after the transfer coding has been decoded; it does not include the chunk lengths, chunked framing syntax, nor the trailer fields (Section 6.5).
     cited_by:
     - file: lint-http-rules/src/helpers/content_length.rs
-      line: 135
+      line: 153
   - label: lint-http-rules/src/helpers/content_length.rs (2)
     section: § 6.4
     snippet: 'HTTP messages often transfer a complete or partial representation as the message "content": a stream of octets sent after the header section, as delineated by the message framing.'
     cited_by:
     - file: lint-http-rules/src/helpers/content_length.rs
-      line: 134
+      line: 152
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
       line: 86
   - label: Content-Length grammar
@@ -6751,13 +6751,17 @@ sources:
     snippet: Content-Length = 1*DIGIT
     cited_by:
     - file: lint-http-rules/src/helpers/content_length.rs
-      line: 68
+      line: 86
+    - file: lint-http-rules/src/violations/content_length.rs
+      line: 88
+    - file: lint-http-rules/src/violations/content_length.rs
+      line: 105
   - label: lint-http-rules/src/helpers/content_length.rs (3)
     section: § 8.6
     snippet: When transferring a representation as content, Content-Length refers specifically to the amount of data enclosed so that it can be used to delimit framing
     cited_by:
     - file: lint-http-rules/src/helpers/content_length.rs
-      line: 155
+      line: 173
   - label: lint-http-rules/src/helpers/content_range.rs
     section: § 14.1
     snippet: This general notion of a "range unit" is used in the Accept-Ranges (Section 14.3) response header field to advertise support for range requests, the Range (Section 14.2) request header field to delineate the parts of a representation that are requested, and the Content-Range (Section 14.4) header field to describe which part of a representation is being transferred.
@@ -9931,9 +9935,11 @@ sources:
     snippet: If a message is received without Transfer-Encoding and with an invalid Content-Length header field, then the message framing is invalid and the recipient MUST treat it as an unrecoverable error, unless the field value can be successfully parsed as a comma-separated list (Section 5.6.1 of [HTTP]), all values in the list are valid, and all values in the list are the same (in which case, the message is processed with that single value used as the Content-Length field value).
     cited_by:
     - file: lint-http-rules/src/helpers/content_length.rs
-      line: 63
+      line: 81
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
       line: 123
+    - file: lint-http-rules/src/violations/content_length.rs
+      line: 134
   - label: lint-http-rules/src/helpers/uri.rs
     section: § 3.2
     snippet: A server MUST respond with a 400 (Bad Request) status code to any HTTP/1.1 request message that lacks a Host header field and to any request message that contains more than one Host header field line or a Host header field with an invalid field value.
@@ -10027,7 +10033,7 @@ sources:
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
       line: 226
     - file: lint-http-rules/src/violations/content_length.rs
-      line: 44
+      line: 74
   - label: request_body_length_accuracy (2)
     section: § 6.2
     snippet: When a message does not have a Transfer-Encoding header field, a Content-Length header field (Section 8.6 of [HTTP]) can provide the anticipated size, as a decimal number of octets, for potential content.


### PR DESCRIPTION
`Content-Length = 1*DIGIT` is ten characters of visible US-ASCII, so the string reader in front of it was never a gate: every octet it refused is an octet the production refuses first, and it answered "not valid UTF-8" where the value holds a `-`, a `.` or a %xFF. The field lines are read one `char` per octet now, the encoding variant is gone from the helper's enum, and the octet is named by the character class that owns it.

Four defects where there was one rule severity: a line with no digit, an octet `DIGIT` does not admit, a numeral too large to represent, and two lengths declared that are not the same number. Three rank `error` on § 6.3's own words — an invalid Content-Length with no Transfer-Encoding is an unrecoverable framing error — and the fourth stays `warn` and carries no citation, because a 39-digit value still derives from the grammar and only this crate refuses it.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
