### PR TITLE
A skipped line hid the directives beside it

### DIFF
--- a/lint-http-rules/src/helpers/cache_control.rs
+++ b/lint-http-rules/src/helpers/cache_control.rs
@@ -86,14 +86,34 @@ impl<'a> Directive<'a> {
     }
 }
 
-/// Every list member in the section's `Cache-Control` field lines, in order and
-/// as written — **including the empty ones**.
+/// The section's `Cache-Control` field lines, each read as the octets the sender
+/// wrote.
 ///
-/// [`directives`] drops an empty member because a caller asking what the sender
-/// requested has nothing to read in one. A caller reporting on the sender's
-/// syntax has the opposite need: an empty element is precisely its finding, and
-/// before this existed those callers reached past the reader and re-split the
-/// field themselves to see it.
+/// **The line boundary is kept and the string reader is not.** § 5.3's combining
+/// is a *recipient's* option, so an empty `Cache-Control:` line is a
+/// zero-element list the sender wrote and not an empty element it generated —
+/// which is a finding one of the callers here makes, and joining first would
+/// invent it. What does go is `to_str`: a directive name holding an octet
+/// outside visible US-ASCII is a `token` defect the two syntax rules report, and
+/// a reader that refused the whole *line* for it hid every directive written
+/// beside it, so `Cache-Control: no-store, \xff` answered "no directives here"
+/// to every rule that asked.
+///
+/// The caller holds the vector for the length of its walk: a member borrows the
+/// line it was cut from. The field name lives here once so no caller spells it.
+// cite(RFC 9110 § 5.2): "When a field name is repeated within a section, its combined field value consists of the list of corresponding field line values within that section, concatenated in order, with each field line value separated by a comma."
+pub fn field_lines(headers: &HeaderMap) -> Vec<String> {
+    crate::helpers::headers::field_lines_as_written(headers, "cache-control")
+}
+
+/// Every list member across those field lines, in order and as written —
+/// **including the empty ones**.
+///
+/// [`directives_in`] drops an empty member because a caller asking what the
+/// sender requested has nothing to read in one. A caller reporting on the
+/// sender's syntax has the opposite need: an empty element is precisely its
+/// finding, and before this existed those callers reached past the reader and
+/// re-split the field themselves to see it.
 ///
 /// **A field line that is empty contributes no members at all**, and that is
 /// the one exemption every caller of this needs: an entirely empty
@@ -102,16 +122,10 @@ impl<'a> Directive<'a> {
 /// distinction out separately — skipping the empty value at the call site and
 /// reporting the empty member in a function two levels down — which is two
 /// places to get one sentence right.
-///
-/// Field lines that are not readable as text are skipped by both readers.
-/// Naming *that* defect belongs to the rule that owns the field and needs the
-/// field line rather than the member, so it asks
-/// [`crate::helpers::headers::has_unreadable_line`].
-// cite(RFC 9110 § 5.2): "When a field name is repeated within a section, its combined field value consists of the list of corresponding field line values within that section, concatenated in order, with each field line value separated by a comma."
 // cite(RFC 9110 § 5.6.1.1): "In any production that uses the list construct, a sender MUST NOT generate empty list elements."
 // cite(RFC 9110 § 5.6.1): "#element => [ element ] *( OWS "," OWS [ element ] )"
-pub fn members(headers: &HeaderMap) -> impl Iterator<Item = &str> {
-    crate::helpers::headers::field_lines(headers, "cache-control").flat_map(members_of)
+pub fn members(lines: &[String]) -> impl Iterator<Item = &str> {
+    lines.iter().flat_map(|line| members_of(line))
 }
 
 /// The list members of one `Cache-Control` field line, as written.
@@ -130,16 +144,26 @@ pub fn members_of(line: &str) -> Vec<&str> {
     split_top_level(line, b",;")
 }
 
-/// Every directive in the section's `Cache-Control` field lines, in order.
+/// Every directive across those field lines, in order.
 ///
 /// Empty members are dropped: every caller here is asking what the sender
 /// *asked for*, not whether they wrote it correctly. Use [`members`] to see
 /// them.
-pub fn directives(headers: &HeaderMap) -> impl Iterator<Item = Directive<'_>> {
-    members(headers)
+///
+/// The lines come from [`field_lines`] and the caller holds them: a directive
+/// borrows the member it was parsed from, and the member borrows the decoded
+/// line. That is the whole cost of reading the field as the sender wrote it
+/// rather than through a `&str` the header map already owned.
+pub fn directives_in(lines: &[String]) -> impl Iterator<Item = Directive<'_>> {
+    members(lines)
         .filter(|member| !member.is_empty())
         .map(Directive::parse)
 }
+
+// The four questions below each answer with a `bool` or a number, so each can
+// hold the decoded lines for the length of its own walk. A caller that wants the
+// directives themselves cannot: a `Directive` borrows the member it was parsed
+// from, so the lines have to outlive the loop and the rule holds them.
 
 /// Read one list member strictly, as a rule reporting on this field's syntax
 /// must: a defect comes back as the sentence that names it.
@@ -206,12 +230,12 @@ impl MemberDefect<'_> {
 
 /// Whether the section carries the named directive at all.
 pub fn has(headers: &HeaderMap, name: &str) -> bool {
-    directives(headers).any(|d| d.is(name))
+    directives_in(&field_lines(headers)).any(|d| d.is(name))
 }
 
 /// Whether the section carries the named directive in its bare form.
 pub fn has_unqualified(headers: &HeaderMap, name: &str) -> bool {
-    directives(headers).any(|d| d.is_unqualified(name))
+    directives_in(&field_lines(headers)).any(|d| d.is_unqualified(name))
 }
 
 /// The first non-negative `delta-seconds` given for the named directive.
@@ -221,7 +245,7 @@ pub fn has_unqualified(headers: &HeaderMap, name: &str) -> bool {
 /// carries none is not the answer to "what lifetime was advertised" and the
 /// next member still might be.
 pub fn delta_seconds(headers: &HeaderMap, name: &str) -> Option<i64> {
-    directives(headers)
+    directives_in(&field_lines(headers))
         .filter(|d| d.is(name))
         .filter_map(|d| d.delta_seconds())
         .find(|seconds| *seconds >= 0)
@@ -246,7 +270,8 @@ pub fn delta_seconds(headers: &HeaderMap, name: &str) -> Option<i64> {
 // cite(RFC 9111 § 5.2.2.4): "The no-cache response directive, in its unqualified form (without an argument), indicates that the response MUST NOT be used to satisfy any other request without forwarding it for validation and receiving a successful response"
 // cite(RFC 9111 § 5.2.2.4): "The qualified form of the no-cache response directive, with an argument that lists one or more field names, indicates that a cache MAY use the response to satisfy a subsequent request"
 pub fn forbids_storage_or_reuse(headers: &HeaderMap) -> bool {
-    directives(headers).any(|d| d.is_unqualified("no-store") || d.is_unqualified("no-cache"))
+    directives_in(&field_lines(headers))
+        .any(|d| d.is_unqualified("no-store") || d.is_unqualified("no-cache"))
 }
 
 // ── Freshness, computed from the directives above ────────────────────
@@ -398,14 +423,16 @@ mod tests {
     #[test]
     fn directives_come_off_every_field_line_in_order() {
         let hm = headers(&["max-age=60, private", "no-store"]);
-        let names: Vec<&str> = directives(&hm).map(|d| d.name).collect();
+        let lines = field_lines(&hm);
+        let names: Vec<&str> = directives_in(&lines).map(|d| d.name).collect();
         assert_eq!(names, ["max-age", "private", "no-store"]);
     }
 
     #[test]
     fn a_member_is_parsed_into_name_and_argument() {
         let hm = headers(&["no-cache=\"set-cookie\""]);
-        let d = directives(&hm).next().unwrap();
+        let lines = field_lines(&hm);
+        let d = directives_in(&lines).next().unwrap();
         assert_eq!(d.name, "no-cache");
         assert_eq!(d.argument, Some("\"set-cookie\""));
         assert!(d.is("no-cache"));
@@ -434,7 +461,7 @@ mod tests {
     fn a_quoted_argument_hides_neither_separator_nor_directive_name() {
         let hm = headers(&["private=\"no-store,x-secret\""]);
         assert!(!forbids_storage_or_reuse(&hm));
-        assert_eq!(directives(&hm).count(), 1);
+        assert_eq!(directives_in(&field_lines(&hm)).count(), 1);
     }
 
     /// **The qualified form licenses what the bare form forbids**, so a
@@ -454,10 +481,25 @@ mod tests {
     }
 
     #[test]
-    fn a_field_line_that_is_not_text_is_skipped_not_reported() {
+    /// A field line holding an octet outside US-ASCII is read like any other,
+    /// and the directives written beside it are still there. The reader used to
+    /// drop the whole line: `no-store, \xff` answered "no directives here", and
+    /// two rules carried a compensating finding that named the encoding instead
+    /// of the octet.
+    fn a_field_line_that_is_not_text_is_read_like_any_other() {
         let mut hm = headers(&["max-age=60"]);
         hm.append("cache-control", HeaderValue::from_bytes(&[0xff]).unwrap());
         assert_eq!(delta_seconds(&hm, "max-age"), Some(60));
+
+        let mut hm = HeaderMap::new();
+        hm.append(
+            "cache-control",
+            HeaderValue::from_bytes(b"no-store, \xff").unwrap(),
+        );
+        assert!(forbids_storage_or_reuse(&hm), "the readable half survives");
+        let lines = field_lines(&hm);
+        let names: Vec<&str> = directives_in(&lines).map(|d| d.name).collect();
+        assert_eq!(names, ["no-store", "\u{ff}"]);
     }
 
     #[test]
@@ -472,7 +514,8 @@ mod tests {
     #[test]
     fn a_directive_reports_its_argument_as_written() {
         let hm = headers(&["max-age=-1"]);
-        let d = directives(&hm).next().unwrap();
+        let lines = field_lines(&hm);
+        let d = directives_in(&lines).next().unwrap();
         assert_eq!(d.delta_seconds(), Some(-1));
         assert_eq!(delta_seconds(&hm, "max-age"), None);
     }
@@ -481,22 +524,29 @@ mod tests {
     #[test]
     fn members_keeps_the_empty_elements_directives_drops() {
         let hm = headers(&["max-age=1, ,public"]);
+        let lines = field_lines(&hm);
         assert_eq!(
-            members(&hm).collect::<Vec<_>>(),
+            members(&lines).collect::<Vec<_>>(),
             ["max-age=1", "", "public"]
         );
-        assert_eq!(directives(&hm).count(), 2);
+        assert_eq!(directives_in(&lines).count(), 2);
     }
 
     /// An empty *value* is a zero-element list and contributes no member; an
     /// empty *element* inside a list is a member, and a defect.
     #[test]
     fn an_empty_field_value_is_a_zero_element_list() {
-        assert_eq!(members(&headers(&[""])).count(), 0);
-        assert_eq!(members(&headers(&["   "])).count(), 0);
-        assert_eq!(members(&headers(&[","])).collect::<Vec<_>>(), ["", ""]);
+        assert_eq!(members(&field_lines(&headers(&[""]))).count(), 0);
+        assert_eq!(members(&field_lines(&headers(&["   "]))).count(), 0);
         assert_eq!(
-            members(&headers(&["", "max-age=1"])).collect::<Vec<_>>(),
+            members(&field_lines(&headers(&[","]))).collect::<Vec<_>>(),
+            ["", ""]
+        );
+        // § 5.3's combining is a recipient's option, so an empty field line is
+        // a zero-element list the sender wrote and not an empty element it
+        // generated. Joining the lines before counting would invent one.
+        assert_eq!(
+            members(&field_lines(&headers(&["", "max-age=1"]))).collect::<Vec<_>>(),
             ["max-age=1"]
         );
     }
@@ -535,7 +585,7 @@ mod tests {
     #[test]
     fn empty_members_are_not_directives() {
         let hm = headers(&[", ,max-age=1,"]);
-        assert_eq!(directives(&hm).count(), 1);
+        assert_eq!(directives_in(&field_lines(&hm)).count(), 1);
     }
 
     #[test]

--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -47,6 +47,15 @@ pub fn get_header_str<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str>
 /// that must measure what a sender actually wrote — including the octets
 /// `to_str` refuses — want [`combined_field_value_octets`] instead, and the
 /// distinction is the same one drawn at [`get_all_header_values`].
+///
+/// **The skip is silent, and a rule that compensates for it is reading the
+/// wrong function.** There used to be a `has_unreadable_line` beside this one
+/// so a rule could ask whether anything had been skipped and report it; two
+/// rules did, and both reported the skip as a verdict about the field's
+/// encoding while the octet that caused it went unnamed — and every other
+/// directive on that line went unread. The answer is not a companion question
+/// but [`field_lines_as_written`] beside it: where a field's own grammar is
+/// inside visible US-ASCII, that reader refuses nothing the grammar does not.
 pub fn field_lines<'a>(headers: &'a HeaderMap, name: &str) -> impl Iterator<Item = &'a str> {
     headers
         .get_all(name)
@@ -54,15 +63,29 @@ pub fn field_lines<'a>(headers: &'a HeaderMap, name: &str) -> impl Iterator<Item
         .filter_map(|hv| hv.to_str().ok())
 }
 
-/// Whether any field line for `name` carries octets that are not text.
+/// The field lines for `name`, in order, each one `char` per octet — **all of
+/// them**.
 ///
-/// The companion to [`field_lines`], and the reason that one can be silent: it
-/// skips such a line, so a rule whose *finding* is that the sender wrote one
-/// has to ask separately. Keeping the two beside each other is what stops the
-/// silent skip from quietly deleting a rule's finding when it adopts the
-/// reader.
-pub fn has_unreadable_line(headers: &HeaderMap, name: &str) -> bool {
-    headers.get_all(name).iter().any(|hv| hv.to_str().is_err())
+/// [`field_lines`]'s octet twin, and the difference is the whole of why it
+/// exists: that one drops a line it cannot read as text, so a single octet
+/// outside US-ASCII takes every value written beside it out of reach, and this
+/// one drops nothing. Where the field's own grammar is inside visible US-ASCII,
+/// the octet is a defect of whatever production it landed in and the rule that
+/// measures that production names it.
+///
+/// A `Vec<String>` rather than an iterator of `&str`, because the decode
+/// allocates: a caller that walks the members of these lines holds the vector
+/// for the length of the walk, since each member borrows the line it was cut
+/// from. [`combined_field_value_as_written`] is the sibling for a field whose
+/// grammar is a list over the whole section; this one is for a caller that must
+/// keep the line boundary, because § 5.3's combining is a *recipient's* option
+/// and some findings are about what the sender wrote on one line.
+pub fn field_lines_as_written(headers: &HeaderMap, name: &str) -> Vec<String> {
+    headers
+        .get_all(name)
+        .iter()
+        .map(field_line_as_written)
+        .collect()
 }
 
 /// Collect all header values for the given name and concatenate them using

--- a/lint-http-rules/src/rules/caching_directive_interaction.rs
+++ b/lint-http-rules/src/rules/caching_directive_interaction.rs
@@ -88,22 +88,20 @@ impl Rule for CachingDirectiveInteraction {
         let finding = || -> Option<Violation> {
             // Helper to check a single HeaderMap for contradictions
             let check_headers = |hdrs: &hyper::HeaderMap| -> Option<Violation> {
-                // The shared reader skips a field line it cannot read as text;
-                // reporting that is this rule's, so it is asked for separately.
-                if crate::helpers::headers::has_unreadable_line(hdrs, "cache-control") {
-                    return Some(self.violation(
-                        ctx.severity,
-                        "Cache-Control header contains non-UTF8 value".into(),
-                    ));
-                }
+                // The value is read as the octets the sender wrote, so there is
+                // no line for a reader to skip and nothing for this rule to say
+                // about the field's encoding. An octet no `tchar` admits is a
+                // directive name's defect, which the two syntax rules next door
+                // report with the id that names it.
+                let lines = crate::helpers::cache_control::field_lines(hdrs);
 
                 // An empty *element* within the list is forbidden — as distinct
                 // from an entirely empty field value, which is a legal
                 // zero-element list and which `members` already exempts.
-                // `directives` would have dropped the empty member; this is
+                // `directives_of` would have dropped the empty member; this is
                 // what the raw reader is for.
                 // cite(RFC 9110 § 5.6.1.1): "In any production that uses the list construct, a sender MUST NOT generate empty list elements."
-                if crate::helpers::cache_control::members(hdrs).any(str::is_empty) {
+                if crate::helpers::cache_control::members(&lines).any(str::is_empty) {
                     return Some(self.violation(
                         ctx.severity,
                         "Cache-Control header contains empty member".into(),
@@ -114,7 +112,7 @@ impl Rule for CachingDirectiveInteraction {
                 // keyed by the folded name; the argument is kept as written.
                 use std::collections::HashMap;
                 let mut seen: HashMap<String, Vec<Option<String>>> = HashMap::new();
-                for directive in crate::helpers::cache_control::directives(hdrs) {
+                for directive in crate::helpers::cache_control::directives_in(&lines) {
                     seen.entry(directive.name.to_ascii_lowercase())
                         .or_default()
                         .push(directive.argument.map(str::to_string));
@@ -284,25 +282,42 @@ mod tests {
         }
     }
 
+    /// The octet is not this rule's finding, and the directives written beside
+    /// it are. The reader used to drop the whole field line, so the
+    /// contradiction below was invisible and what this rule reported instead
+    /// was a verdict about the field's encoding — a claim `cache_control_token_valid`
+    /// and `cache_control_directive_valid` answer properly, with the id that
+    /// names the octet.
     #[test]
-    fn non_utf8_header_is_violation() {
+    fn an_octet_hides_neither_the_contradiction_nor_this_rules_silence() {
         use hyper::header::HeaderValue;
-        let mut tx = crate::test_helpers::make_test_transaction();
-        let bad = HeaderValue::from_bytes(&[0xff]).expect("should construct non-utf8 header");
-        let mut hm = hyper::HeaderMap::new();
-        hm.insert("cache-control", bad);
-        tx.request.headers = hm;
         let rule = CachingDirectiveInteraction;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "caching_directive_interaction",
         ]);
-        let v = crate::test_helpers::run_rule(
-            &rule,
-            &tx,
-            &crate::transaction_history::TransactionHistory::empty(),
-            &cfg,
+        let run = |bytes: &[u8]| {
+            let mut tx = crate::test_helpers::make_test_transaction();
+            let mut hm = hyper::HeaderMap::new();
+            hm.insert(
+                "cache-control",
+                HeaderValue::from_bytes(bytes).expect("a line"),
+            );
+            tx.request.headers = hm;
+            crate::test_helpers::run_rule(
+                &rule,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &cfg,
+            )
+        };
+
+        assert!(run(&[0xff]).is_none(), "the octet alone is not this rule's");
+        let found = run(b"public, private, \xff").expect("the contradiction");
+        assert!(
+            found.message.contains("contradictory visibility"),
+            "{}",
+            found.message
         );
-        assert!(v.is_some());
     }
 
     #[test]

--- a/lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
+++ b/lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
@@ -106,7 +106,11 @@ impl Rule for ExpiresAndCacheControlConsistent {
             let mut cc_no_cache = false;
             let mut cc_no_store = false;
             let mut cc_max_age: Option<i64> = None;
-            for directive in crate::helpers::cache_control::directives(&resp.headers) {
+            // The joined value is held here because a directive borrows the
+            // member it was parsed from, and it is read as octets so a bad
+            // one no longer hides the directives written beside it.
+            let lines = crate::helpers::cache_control::field_lines(&resp.headers);
+            for directive in crate::helpers::cache_control::directives_in(&lines) {
                 cc_present = true;
                 if directive.is("no-cache") {
                     cc_no_cache = true;

--- a/lint-http-rules/src/rules/immutable_requires_freshness.rs
+++ b/lint-http-rules/src/rules/immutable_requires_freshness.rs
@@ -111,16 +111,14 @@ impl Rule for ImmutableRequiresFreshness {
             let mut found_immutable = false;
             let mut conflicting: Option<String> = None;
 
-            // The shared reader skips a field line it cannot read as text;
-            // reporting that is this rule's, so it is asked for separately.
-            if crate::helpers::headers::has_unreadable_line(&resp.headers, "cache-control") {
-                return Some(self.violation(
-                    ctx.severity,
-                    "Cache-Control header contains non-UTF8 value".into(),
-                ));
-            }
+            // The value is read as the octets the sender wrote, so there is no
+            // line for a reader to skip and nothing for this rule to say about
+            // the field's encoding: an octet no `tchar` admits is a directive
+            // name's defect, and the two rules that read this field's syntax
+            // report it under the id that names it.
+            let lines = crate::helpers::cache_control::field_lines(&resp.headers);
 
-            for directive in crate::helpers::cache_control::directives(&resp.headers) {
+            for directive in crate::helpers::cache_control::directives_in(&lines) {
                 let lname = directive.name.to_ascii_lowercase();
                 let value = directive.argument;
 
@@ -267,38 +265,41 @@ mod tests {
         assert!(v.is_some());
     }
 
+    /// The octet is not this rule's finding, and `immutable` beside a directive
+    /// that leaves no freshness lifetime still is. The reader used to drop the
+    /// whole field line, so the pairing below went unreported and what came out
+    /// instead was a verdict about the field's encoding.
     #[test]
-    fn non_utf8_header_value_is_violation() -> anyhow::Result<()> {
+    fn an_octet_hides_neither_the_pairing_nor_this_rules_silence() -> anyhow::Result<()> {
         use hyper::header::HeaderValue;
         use hyper::HeaderMap;
+        let run = |bytes: &[u8]| -> Option<Violation> {
+            let mut tx = crate::test_helpers::make_test_transaction();
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                "cache-control",
+                HeaderValue::from_bytes(bytes).expect("a line"),
+            );
+            tx.response = Some(crate::http_transaction::ResponseInfo {
+                status: 200,
+                version: "HTTP/1.1".into(),
+                headers,
+                body_length: None,
+                trailers: None,
+            });
+            crate::test_helpers::run_rule(
+                &ImmutableRequiresFreshness,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "immutable_requires_freshness",
+                ]),
+            )
+        };
 
-        let mut tx = crate::test_helpers::make_test_transaction();
-        tx.response = Some(crate::http_transaction::ResponseInfo {
-            status: 200,
-            version: "HTTP/1.1".into(),
-            headers: HeaderMap::new(),
-
-            body_length: None,
-            trailers: None,
-        });
-
-        let bad = HeaderValue::from_bytes(&[0xff]).expect("should construct non-utf8 header");
-        tx.response
-            .as_mut()
-            .unwrap()
-            .headers
-            .insert("cache-control", bad);
-
-        let rule = ImmutableRequiresFreshness;
-        let v = crate::test_helpers::run_rule(
-            &rule,
-            &tx,
-            &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-        );
-        assert!(v.is_some());
-        let msg = v.unwrap().message;
-        assert!(msg.contains("non-UTF8"));
+        assert!(run(&[0xff]).is_none(), "the octet alone is not this rule's");
+        let found = run(b"immutable, max-age=0, \xff").expect("the pairing");
+        assert!(found.message.contains("immutable"), "{}", found.message);
         Ok(())
     }
 

--- a/lint-http-rules/src/rules/vary_and_cache_consistent.rs
+++ b/lint-http-rules/src/rules/vary_and_cache_consistent.rs
@@ -108,7 +108,11 @@ impl Rule for VaryAndCacheConsistent {
             // deliberately excluded: it promises no reuse benefit (it requires
             // revalidation), so pairing it with Vary: * is not a misconfiguration signal.
             const ADVERTISES_REUSE: [&str; 3] = ["max-age", "s-maxage", "public"];
-            for directive in crate::helpers::cache_control::directives(&resp.headers) {
+            // The joined value is held here because a directive borrows the
+            // member it was parsed from, and it is read as octets so a bad
+            // one no longer hides the directives written beside it.
+            let lines = crate::helpers::cache_control::field_lines(&resp.headers);
+            for directive in crate::helpers::cache_control::directives_in(&lines) {
                 if ADVERTISES_REUSE.iter().any(|name| directive.is(name)) {
                     let name = directive.name.to_ascii_lowercase();
                     return Some(self.violation(ctx.severity, format!(

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -4119,7 +4119,7 @@ sources:
     - file: lint-http-rules/src/rules/immutable_cache_never_stale.rs
       line: 138
     - file: lint-http-rules/src/rules/immutable_requires_freshness.rs
-      line: 159
+      line: 157
   - label: immutable_cache_never_stale (2)
     section: § 2
     snippet: The immutable extension only applies during the freshness lifetime of the stored response.
@@ -4127,7 +4127,7 @@ sources:
     - file: lint-http-rules/src/rules/immutable_cache_never_stale.rs
       line: 139
     - file: lint-http-rules/src/rules/immutable_requires_freshness.rs
-      line: 158
+      line: 156
 - label: RFC 8259
   url: https://www.rfc-editor.org/rfc/rfc8259.html
   fragments:
@@ -6619,9 +6619,9 @@ sources:
     - file: lint-http-rules/src/helpers/auth.rs
       line: 676
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 111
+      line: 125
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 152
+      line: 176
     - file: lint-http-rules/src/helpers/list.rs
       line: 87
     - file: lint-http-rules/src/helpers/list.rs
@@ -6635,7 +6635,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 752
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
-      line: 105
+      line: 103
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
       line: 89
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
@@ -6673,11 +6673,11 @@ sources:
     snippet: When a field name is repeated within a section, its combined field value consists of the list of corresponding field line values within that section, concatenated in order, with each field line value separated by a comma.
     cited_by:
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 110
+      line: 104
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 121
+      line: 144
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 389
+      line: 412
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
       line: 127
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
@@ -6699,7 +6699,7 @@ sources:
     snippet: '#element => [ element ] *( OWS "," OWS [ element ] )'
     cited_by:
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 112
+      line: 126
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
       line: 347
   - label: lint-http-rules/src/helpers/comment.rs
@@ -6945,7 +6945,7 @@ sources:
     snippet: Fields are sent and received within the header and trailer sections of messages
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 252
+      line: 275
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
       line: 135
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
@@ -6955,7 +6955,7 @@ sources:
     snippet: A recipient MAY combine multiple field lines within a field section that have the same field name into one field line, without changing the semantics of the message, by appending each subsequent field line value to the initial field line value in order, separated by a comma (",") and optional whitespace (OWS, defined in Section 5.6.3).  For consistency, use comma SP.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 90
+      line: 113
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 205
     - file: lint-http-rules/src/rules/range_header_syntax.rs
@@ -6967,13 +6967,13 @@ sources:
     snippet: Since it cannot be combined into a single field value, recipients ought to handle "Set-Cookie" as a special case while processing fields.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 91
+      line: 114
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 5.3
     snippet: a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 390
+      line: 413
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 28
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
@@ -7013,9 +7013,9 @@ sources:
     snippet: A recipient SHOULD treat other allowed octets in field content (i.e., obs-text) as opaque data.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 122
+      line: 145
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 157
+      line: 180
     - file: lint-http-rules/src/helpers/shown.rs
       line: 43
     - file: lint-http-rules/src/rules/charset_registered.rs
@@ -7043,7 +7043,7 @@ sources:
     snippet: Fields that only anticipate a single member as the field value are referred to as "singleton fields".
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 387
+      line: 410
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
       line: 256
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
@@ -7053,7 +7053,7 @@ sources:
     snippet: This is true for both list-based and singleton fields, since a singleton field might be erroneously sent with multiple members and detecting such errors improves interoperability.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 388
+      line: 411
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 264
   - label: lint-http-rules/src/helpers/headers.rs (8)
@@ -7061,13 +7061,13 @@ sources:
     snippet: field-content  = field-vchar [ 1*( SP / HTAB / field-vchar ) field-vchar ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 158
+      line: 181
   - label: OWS grammar
     section: § 5.6.3
     snippet: OWS            = *( SP / HTAB )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 311
+      line: 334
     - file: lint-http-rules/src/helpers/list.rs
       line: 36
     - file: lint-http-rules/src/helpers/list.rs
@@ -7115,15 +7115,15 @@ sources:
     snippet: The OWS rule is used where zero or more linear whitespace octets might appear.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 310
+      line: 333
   - label: lint-http-rules/src/helpers/headers.rs (10)
     section: § 6.5
     snippet: Fields (Section 5) that are located within a "trailer section" are referred to as "trailer fields"
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 203
+      line: 226
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 253
+      line: 276
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
       line: 154
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
@@ -9422,13 +9422,13 @@ sources:
     snippet: 'When there is more than one value present for a given directive (e.g., two Expires header field lines or multiple Cache-Control: max-age directives), either the first occurrence should be used or the response should be considered stale.'
     cited_by:
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
-      line: 160
+      line: 158
   - label: caching_directive_interaction (2)
     section: § 5.2.2.7
     snippet: The unqualified private response directive indicates that a shared cache MUST NOT store the response (i.e., the response is intended for a single user).
     cited_by:
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
-      line: 135
+      line: 133
     - file: lint-http-rules/src/rules/private_cache_visibility.rs
       line: 129
     - file: lint-http-rules/src/rules/private_cache_visibility.rs
@@ -9438,27 +9438,27 @@ sources:
     snippet: The public response directive indicates that a cache MAY store the response even if it would otherwise be prohibited, subject to the constraints defined in Section 3.
     cited_by:
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
-      line: 134
+      line: 132
   - label: expires_and_cache_control_consistent
     section: § 4.2.1
     snippet: If the max-age response directive (Section 5.2.2.1) is present, use its value, or If the Expires response header field (Section 5.3) is present, use its value minus the value of the Date response header field
     cited_by:
     - file: lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
-      line: 159
+      line: 163
   - label: expires_and_cache_control_consistent (2)
     section: § 5.3
     snippet: A cache recipient MUST interpret invalid date formats, especially the value "0", as representing a time in the past (i.e., "already expired").
     cited_by:
     - file: lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
-      line: 135
+      line: 139
   - label: expires_and_cache_control_consistent (3)
     section: § 5.3
     snippet: If a response includes a Cache-Control header field with the max-age directive (Section 5.2.2.1), a recipient MUST ignore the Expires header field.
     cited_by:
     - file: lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
-      line: 158
+      line: 162
     - file: lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
-      line: 172
+      line: 176
   - label: expires_and_cache_control_consistent (4)
     section: § 5.3
     snippet: The Expires field value is an HTTP-date timestamp, as defined in Section 5.6.7 of [HTTP].
@@ -9498,25 +9498,25 @@ sources:
     snippet: If the max-age response directive (Section 5.2.2.1) is present, use its value, or If the Expires response header field (Section 5.3) is present, use its value minus the value of the Date response header field (using the time the message was received if it is not present, as per Section 6.6.1 of [HTTP]), or
     cited_by:
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 359
+      line: 384
   - label: lint-http-rules/src/helpers/cache_control.rs (2)
     section: § 4.2.1
     snippet: Note that this calculation is intended to reduce clock skew by using the clock information provided by the origin server whenever possible.
     cited_by:
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 369
+      line: 394
   - label: lint-http-rules/src/helpers/cache_control.rs (3)
     section: § 4.2.3
     snippet: corrected_initial_age = max(apparent_age, corrected_age_value)
     cited_by:
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 324
+      line: 349
   - label: lint-http-rules/src/helpers/cache_control.rs (4)
     section: § 5.1
     snippet: The "Age" response header field conveys the sender's estimate of the time since the response was generated or successfully validated at the origin server
     cited_by:
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 323
+      line: 348
     - file: lint-http-rules/src/rules/age_header_numeric.rs
       line: 86
     - file: lint-http-rules/src/rules/max_age_directive_valid.rs
@@ -9540,7 +9540,7 @@ sources:
     snippet: cache-directive = token [ "=" ( token / quoted-string ) ]
     cited_by:
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 151
+      line: 175
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
       line: 211
     - file: lint-http-rules/src/rules/cache_control_token_valid.rs
@@ -9550,7 +9550,7 @@ sources:
     snippet: The no-cache response directive, in its unqualified form (without an argument), indicates that the response MUST NOT be used to satisfy any other request without forwarding it for validation and receiving a successful response
     cited_by:
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 246
+      line: 270
     - file: lint-http-rules/src/rules/no_cache_revalidation.rs
       line: 134
   - label: lint-http-rules/src/helpers/cache_control.rs (9)
@@ -9560,7 +9560,7 @@ sources:
     - file: lint-http-rules/src/helpers/cache_control.rs
       line: 72
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 247
+      line: 271
     - file: lint-http-rules/src/rules/no_cache_revalidation.rs
       line: 150
   - label: lint-http-rules/src/helpers/cache_control.rs (10)
@@ -9568,9 +9568,9 @@ sources:
     snippet: The no-store response directive indicates that a cache MUST NOT store any part of either the immediate request or the response and MUST NOT use the response to satisfy any other request.
     cited_by:
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 245
+      line: 269
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
-      line: 150
+      line: 148
     - file: lint-http-rules/src/rules/no_store_enforced.rs
       line: 169
     - file: lint-http-rules/src/rules/no_store_enforced.rs


### PR DESCRIPTION
Two rules carried a finding that said the Cache-Control value was not valid UTF-8. Neither was reading the field for that: the shared reader drops a field line it cannot read as text, and the compensation existed so the drop would not be silent. It reported the wrong thing twice over — an encoding where the defect is an octet no `tchar` admits, and nothing at all about the directives written on the same line, which went unread.

So the reader reads octets, per line, and both compensations go with the claim. `no-store, \xff` now answers `no-store`, and `immutable, max-age=0, \xff` reports the pairing it always had. The octet is the two syntax rules' finding and has been since they converted.

The line boundary is kept rather than joined: § 5.3's combining is a recipient's option, so an empty field line is a zero-element list the sender wrote, not an empty element it generated.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
