### PR TITLE
An origin octet fails all three alternatives

### DIFF
--- a/lint-http-rules/src/rules/access_control_allow_origin_valid.rs
+++ b/lint-http-rules/src/rules/access_control_allow_origin_valid.rs
@@ -144,11 +144,15 @@ impl Rule for AccessControlAllowOriginValid {
                 .iter()
                 .next()
                 .unwrap();
-            let s = match hv.to_str() {
-                Ok(v) => v.trim(),
-                Err(_) => return Some(self.violation(ctx.severity, "Access-Control-Allow-Origin header contains non-ASCII or control characters"
-                            .into())),
-            };
+            // Read as the octets the sender wrote. The value derives from one of
+            // three alternatives — `*`, the case-sensitive `null`, or a
+            // serialized origin — and every one of them is inside visible
+            // US-ASCII, so an octet above it is a value deriving from none of
+            // them and the finding below says exactly that. Naming the octet
+            // class instead was a fourth verdict for a value that had already
+            // failed all three.
+            let line = crate::helpers::headers::field_line_as_written(hv);
+            let s = crate::helpers::headers::trim_ows(&line);
 
             // Must be a single value (not a comma-separated list)
             let members: Vec<String> = crate::helpers::list::list_members(s)
@@ -168,7 +172,7 @@ impl Rule for AccessControlAllowOriginValid {
                     ctx.severity,
                     format!(
                         "Access-Control-Allow-Origin contains invalid origin: '{}'",
-                        member
+                        crate::helpers::shown::shown_in_finding(&member)
                     ),
                 ));
             }
@@ -363,8 +367,12 @@ mod tests {
         assert!(v.unwrap().message.contains("invalid origin"));
     }
 
+    /// The octet is a value deriving from none of the three alternatives, and
+    /// that is what the finding says. It used to be a fourth verdict — the octet
+    /// class, named before the value had been measured against `*`, `null` or an
+    /// origin — and the three-way alternation had already refused it.
     #[test]
-    fn non_utf8_header_is_violation() {
+    fn an_octet_is_a_value_deriving_from_none_of_the_alternatives() {
         use crate::test_helpers::make_headers_from_pairs;
         use hyper::header::HeaderValue;
 
@@ -390,8 +398,8 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
-        assert!(v.is_some());
-        assert!(v.unwrap().message.contains("non-ASCII"));
+        let v = v.expect("a finding");
+        assert!(v.message.contains("invalid origin"), "{}", v.message);
     }
 
     #[test]

--- a/lint-http-rules/src/rules/timing_allow_origin_valid.rs
+++ b/lint-http-rules/src/rules/timing_allow_origin_valid.rs
@@ -153,22 +153,18 @@ impl Rule for TimingAllowOriginValid {
             // cite(Resource Timing § 3.5.2): "The sender MAY generate multiple Timing-Allow-Origin header fields."
             // cite(Resource Timing § 3.5.2): "The recipient MAY combine multiple Timing-Allow-Origin header fields by appending each subsequent field value to the combined field value in order, separated by a comma."
             for hv in headers.get_all("timing-allow-origin").iter() {
-                // cite(RFC 9110 § 5.5): "newly defined fields SHOULD limit their values to visible US-ASCII octets (VCHAR), SP, and HTAB"
-                let s = match hv.to_str() {
-                    Ok(v) => v,
-                    Err(_) => return Some(
-                        self.violation(
-                            ctx.severity,
-                            "Timing-Allow-Origin header contains non-ASCII or control characters"
-                                .into(),
-                        ),
-                    ),
-                };
+                // Read as the octets the sender wrote: every member derives from
+                // `*`, the case-sensitive `null` or a serialized origin, and all
+                // three are inside visible US-ASCII — so an octet above it is a
+                // member deriving from none of them, which the origin finding
+                // below already says.
+                let line = crate::helpers::headers::field_line_as_written(hv);
+                let s = line.as_str();
 
                 // Empty header value (only whitespace) is invalid: `1#` requires at least
                 // one member.
                 // cite(Resource Timing): "Timing-Allow-Origin = 1#( origin-or-null / wildcard )"
-                if s.trim().is_empty() {
+                if crate::helpers::headers::trim_ows(s).is_empty() {
                     return Some(ctx.report_with(
                         &LIST_MEMBER_MISSING,
                         "Timing-Allow-Origin header value is empty".into(),
@@ -181,11 +177,15 @@ impl Rule for TimingAllowOriginValid {
                 // cite(Resource Timing § 3.5.2): "The header’s value is represented by the following ABNF [RFC5234] (using List Extension, [RFC9110]):"
                 let parts: Vec<&str> = s.split(',').collect();
                 for (i, raw_member) in parts.iter().enumerate() {
-                    if raw_member.trim().is_empty() {
+                    if crate::helpers::headers::trim_ows(raw_member).is_empty() {
                         // An internal/leading empty member means the sender generated an
                         // empty list element.
                         // cite(RFC 9110 § 5.6.1.1): "In any production that uses the list construct, a sender MUST NOT generate empty list elements."
-                        if parts.iter().skip(i + 1).any(|p| !p.trim().is_empty()) {
+                        if parts
+                            .iter()
+                            .skip(i + 1)
+                            .any(|p| !crate::helpers::headers::trim_ows(p).is_empty())
+                        {
                             return Some(ctx.report_with(
                                 &LIST_MEMBER_EMPTY,
                                 "Timing-Allow-Origin header contains empty member".into(),
@@ -210,7 +210,10 @@ impl Rule for TimingAllowOriginValid {
                     if !crate::helpers::uri::is_valid_serialized_origin(m) {
                         return Some(self.violation(
                             ctx.severity,
-                            format!("Timing-Allow-Origin contains invalid origin: '{}'", m),
+                            format!(
+                                "Timing-Allow-Origin contains invalid origin: '{}'",
+                                crate::helpers::shown::shown_in_finding(m)
+                            ),
                         ));
                     }
                 }
@@ -314,8 +317,12 @@ mod tests {
         );
     }
 
+    /// The octet is a member deriving from none of the three alternatives, and
+    /// that is what the finding says. It used to be a verdict about the octet
+    /// class, reached before any member had been read — which also meant a
+    /// legible origin written beside the octet was never measured.
     #[test]
-    fn non_utf8_header_is_violation() {
+    fn an_octet_is_a_value_deriving_from_none_of_the_alternatives() {
         use crate::test_helpers::make_headers_from_pairs;
         use hyper::header::HeaderValue;
 
@@ -341,8 +348,8 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
-        assert!(v.is_some());
-        assert!(v.unwrap().message.contains("non-ASCII"));
+        let v = v.expect("a finding");
+        assert!(v.message.contains("invalid origin"), "{}", v.message);
     }
 
     #[test]

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -541,7 +541,7 @@ sources:
     snippet: Timing-Allow-Origin = 1#( origin-or-null / wildcard )
     cited_by:
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 170
+      line: 166
   - label: timing_allow_origin_valid (2)
     section: § 3.5.2
     snippet: Server-side applications may return the Timing-Allow-Origin HTTP response header to allow the User Agent to fully expose, to the document origin(s) specified, the values of attributes that would have been zero due to those cross-origin restrictions.
@@ -553,7 +553,7 @@ sources:
     snippet: 'The header’s value is represented by the following ABNF [RFC5234] (using List Extension, [RFC9110]):'
     cited_by:
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 181
+      line: 177
   - label: timing_allow_origin_valid (4)
     section: § 3.5.2
     snippet: The recipient MAY combine multiple Timing-Allow-Origin header fields by appending each subsequent field value to the combined field value in order, separated by a comma.
@@ -6659,7 +6659,7 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 85
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 187
+      line: 183
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
       line: 92
     - file: lint-http-rules/src/rules/upgrade_header_syntax.rs
@@ -8630,8 +8630,6 @@ sources:
       line: 102
     - file: lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
       line: 107
-    - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 156
     - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
       line: 114
     - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs


### PR DESCRIPTION
Both readers of a serialized origin named the octet class before the value had been measured against anything: `*`, the case-sensitive `null` and the origin itself are all inside visible US-ASCII, so a value holding an octet above it has already failed every alternative the grammar offers. The finding that says so was sitting one branch below.

So both read octets, both show the value through the finding renderer, and the fourth verdict goes. Timing-Allow-Origin gains the case its early return was hiding — a legible origin written beside a bad octet is now measured — and its three `str::trim`s become `trim_ows`, since the emptiness questions are the list construct's and %xA0 is a member's own octet rather than space around it.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
