### PR TITLE
A cross-origin policy is spelled in ASCII

### DIFF
--- a/lint-http-rules/src/rules/cross_origin_embedder_policy_valid.rs
+++ b/lint-http-rules/src/rules/cross_origin_embedder_policy_valid.rs
@@ -115,14 +115,17 @@ impl Rule for CrossOriginEmbedderPolicyValid {
                 ));
             }
 
-            let val = match crate::helpers::headers::get_header_str(
-                headers,
-                "cross-origin-embedder-policy",
-            ) {
-                Some(v) => v.trim(),
-                None => return Some(self.violation(ctx.severity, "Cross-Origin-Embedder-Policy header contains non-ASCII or control characters"
-                            .into())),
-            };
+            // Read as the octets the sender wrote. The value is one of three
+            // strings, all of them inside visible US-ASCII, so a value the string
+            // reader refuses is a value none of the three spell — which is what
+            // the finding below says, with the value in hand.
+            let hv = headers
+                .get_all("cross-origin-embedder-policy")
+                .iter()
+                .next()
+                .expect("a field line, since the count above is one");
+            let line = crate::helpers::headers::field_line_as_written(hv);
+            let val = crate::helpers::headers::trim_ows(&line);
 
             // Must not be a comma-separated list
             if crate::helpers::list::list_members(val).count() != 1 {
@@ -146,7 +149,7 @@ impl Rule for CrossOriginEmbedderPolicyValid {
 
             Some(self.cited(&HTML_7_1_4, ctx.severity, format!(
                     "Cross-Origin-Embedder-Policy value '{}' does not enable cross-origin isolation (use 'require-corp' or 'credentialless')",
-                    val
+                    crate::helpers::shown::shown_in_finding(val)
                 )))
         };
         Vec::from_iter(finding())
@@ -249,7 +252,7 @@ mod tests {
     }
 
     #[test]
-    fn non_utf8_is_violation() {
+    fn an_obs_text_octet_is_a_value_none_of_them_spell() {
         use crate::test_helpers::make_headers_from_pairs;
         use hyper::header::HeaderValue;
 
@@ -275,8 +278,10 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
-        assert!(v.is_some());
-        assert!(v.unwrap().message.contains("non-ASCII"));
+        assert_eq!(
+            v.expect("a finding").message,
+            "Cross-Origin-Embedder-Policy value 'ÿ' does not enable cross-origin isolation (use 'require-corp' or 'credentialless')"
+        );
     }
 
     #[test]

--- a/lint-http-rules/src/rules/cross_origin_opener_policy_valid.rs
+++ b/lint-http-rules/src/rules/cross_origin_opener_policy_valid.rs
@@ -118,14 +118,17 @@ impl Rule for CrossOriginOpenerPolicyValid {
                 ));
             }
 
-            let val = match crate::helpers::headers::get_header_str(
-                headers,
-                "cross-origin-opener-policy",
-            ) {
-                Some(v) => v.trim(),
-                None => return Some(self.violation(ctx.severity, "Cross-Origin-Opener-Policy header contains non-ASCII or control characters"
-                            .into())),
-            };
+            // Read as the octets the sender wrote. The value is a structured-field
+            // item whose four accepted spellings are all inside visible US-ASCII,
+            // so a value the string reader refuses is a value none of them spell —
+            // which is what the finding below says, with the value in hand.
+            let hv = headers
+                .get_all("cross-origin-opener-policy")
+                .iter()
+                .next()
+                .expect("a field line, since the count above is one");
+            let line = crate::helpers::headers::field_line_as_written(hv);
+            let val = crate::helpers::headers::trim_ows(&line);
 
             // Must not be a comma-separated list
             if crate::helpers::list::list_members(val).count() != 1 {
@@ -156,7 +159,7 @@ impl Rule for CrossOriginOpenerPolicyValid {
                 ctx.severity,
                 format!(
                     "Cross-Origin-Opener-Policy contains unsupported value: '{}'",
-                    val
+                    crate::helpers::shown::shown_in_finding(val)
                 ),
             ))
         };
@@ -263,7 +266,7 @@ mod tests {
     }
 
     #[test]
-    fn non_utf8_is_violation() {
+    fn an_obs_text_octet_is_a_value_none_of_them_spell() {
         use crate::test_helpers::make_headers_from_pairs;
         use hyper::header::HeaderValue;
 
@@ -289,8 +292,10 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
-        assert!(v.is_some());
-        assert!(v.unwrap().message.contains("non-ASCII"));
+        assert_eq!(
+            v.expect("a finding").message,
+            "Cross-Origin-Opener-Policy contains unsupported value: 'ÿ'"
+        );
     }
 
     #[test]

--- a/lint-http-rules/src/rules/cross_origin_resource_policy_valid.rs
+++ b/lint-http-rules/src/rules/cross_origin_resource_policy_valid.rs
@@ -110,14 +110,17 @@ impl Rule for CrossOriginResourcePolicyValid {
                 ));
             }
 
-            let val = match crate::helpers::headers::get_header_str(
-                headers,
-                "cross-origin-resource-policy",
-            ) {
-                Some(v) => v.trim(),
-                None => return Some(self.violation(ctx.severity, "Cross-Origin-Resource-Policy header contains non-ASCII or control characters"
-                            .into())),
-            };
+            // Read as the octets the sender wrote. § 3.7's alternation is three
+            // case-sensitive literals, all of them inside visible US-ASCII, so a
+            // value the string reader refuses is a value none of the three spell —
+            // which is what the finding below says, with the value in hand.
+            let hv = headers
+                .get_all("cross-origin-resource-policy")
+                .iter()
+                .next()
+                .expect("a field line, since the count above is one");
+            let line = crate::helpers::headers::field_line_as_written(hv);
+            let val = crate::helpers::headers::trim_ows(&line);
 
             // Must not be a comma-separated list
             if crate::helpers::list::list_members(val).count() != 1 {
@@ -143,7 +146,7 @@ impl Rule for CrossOriginResourcePolicyValid {
                 ctx.severity,
                 format!(
                     "Cross-Origin-Resource-Policy contains unsupported value: '{}'",
-                    val
+                    crate::helpers::shown::shown_in_finding(val)
                 ),
             ))
         };
@@ -251,7 +254,7 @@ mod tests {
     }
 
     #[test]
-    fn non_utf8_is_violation() {
+    fn an_obs_text_octet_is_a_value_none_of_them_spell() {
         use crate::test_helpers::make_headers_from_pairs;
         use hyper::header::HeaderValue;
 
@@ -277,8 +280,10 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
-        assert!(v.is_some());
-        assert!(v.unwrap().message.contains("non-ASCII"));
+        assert_eq!(
+            v.expect("a finding").message,
+            "Cross-Origin-Resource-Policy contains unsupported value: 'ÿ'"
+        );
     }
 
     #[test]

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -30,13 +30,13 @@ sources:
     snippet: Cross-Origin-Resource-Policy = %s"same-origin" / %s"same-site" / %s"cross-origin" ; case-sensitive
     cited_by:
     - file: lint-http-rules/src/rules/cross_origin_resource_policy_valid.rs
-      line: 135
+      line: 138
   - label: cross_origin_resource_policy_valid (2)
     section: § 3.7
     snippet: If policy is neither `same-origin`, `same-site`, nor `cross-origin`, then set policy to null.
     cited_by:
     - file: lint-http-rules/src/rules/cross_origin_resource_policy_valid.rs
-      line: 136
+      line: 139
   - label: lint-http-rules/src/helpers/uri.rs
     section: § 3.2
     snippet: The origin serialization defined here is more constrained than [RFC3986]’s grammar in two substantial ways.
@@ -124,13 +124,13 @@ sources:
     snippet: An embedder policy value is one of three strings that controls the fetching of cross-origin resources without explicit permission from resource owners.
     cited_by:
     - file: lint-http-rules/src/rules/cross_origin_embedder_policy_valid.rs
-      line: 140
+      line: 143
   - label: cross_origin_opener_policy_valid
     section: § 7.1.3.1
     snippet: Let parsedItem be the result of getting a structured field value given `Cross-Origin-Opener-Policy` and "item" from response's header list.
     cited_by:
     - file: lint-http-rules/src/rules/cross_origin_opener_policy_valid.rs
-      line: 145
+      line: 148
   - label: origin_isolated_header_valid
     section: § 7.1.2
     snippet: This header is a structured header whose value must be a boolean.


### PR DESCRIPTION
The three Cross-Origin-* policy rules read their field lines as the octets the sender wrote instead of through the string reader. Each value is an alternation of literal strings, all of them inside visible US-ASCII, so a value the reader refused is a value none of the alternatives spell — which is what the unsupported-value finding one branch below already said, and it can quote what arrived.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
