### PR TITLE
An origin that is unreadable is still present

### DIFF
--- a/lint-http-rules/src/rules/access_control_allow_credentials_when_origin.rs
+++ b/lint-http-rules/src/rules/access_control_allow_credentials_when_origin.rs
@@ -105,25 +105,22 @@ impl Rule for AccessControlAllowCredentialsWhenOrigin {
                 return None;
             }
 
-            // Validate Access-Control-Allow-Origin header values (ensure UTF-8, and detect any '*')
-            let mut acao_has_star = false;
-            for hv in headers.get_all("access-control-allow-origin").iter() {
-                let s = match hv.to_str() {
-                    Ok(v) => v.trim(),
-                    Err(_) => {
-                        return Some(self.violation(ctx.severity, "Access-Control-Allow-Origin header contains non-ASCII or control characters".into()))
-                    }
-                };
-                for token in crate::helpers::list::list_members(s) {
-                    if token == "*" {
-                        acao_has_star = true;
-                        break;
-                    }
-                }
-                if acao_has_star {
-                    break;
-                }
-            }
+            // The only question asked of Access-Control-Allow-Origin here is
+            // whether a `*` is among its members, so the lines are read as the
+            // octets the sender wrote and nothing is said about what they hold:
+            // an octet is not a `*`, and the value belongs to
+            // `access_control_allow_origin_valid`, which measures it against the
+            // three alternatives. Reporting it from inside a reading this narrow
+            // was a claim about a field this rule only scans.
+            let acao_has_star = crate::helpers::headers::field_lines_as_written(
+                headers,
+                "access-control-allow-origin",
+            )
+            .iter()
+            .any(|line| {
+                crate::helpers::list::list_members(crate::helpers::headers::trim_ows(line))
+                    .any(|member| member == "*")
+            });
 
             let acc_count = headers
                 .get_all("access-control-allow-credentials")
@@ -133,12 +130,19 @@ impl Rule for AccessControlAllowCredentialsWhenOrigin {
                 return None; // nothing to check
             }
 
-            let acc_val = match crate::helpers::headers::get_header_str(headers, "access-control-allow-credentials") {
-                Some(v) => v.trim(),
-                None => {
-                    return Some(self.violation(ctx.severity, "Access-Control-Allow-Credentials header contains non-ASCII or control characters".into()))
-                }
-            };
+            // Same reading, same reason: the question is whether this value is
+            // the word `true`, and an octet is not it. No rule owns this field's
+            // syntax today, so a value that is neither `true` nor `false` goes
+            // unreported — which is a gap in the catalogue rather than a verdict
+            // this rule can make from inside a pairing check.
+            let acc_line = crate::helpers::headers::field_lines_as_written(
+                headers,
+                "access-control-allow-credentials",
+            )
+            .into_iter()
+            .next()
+            .expect("a field line, since the count above is non-zero");
+            let acc_val = crate::helpers::headers::trim_ows(&acc_line);
 
             // If credentials is 'true' (case-insensitive) and any AC-Allow-Origin header contains '*', violation.
             // `*` and credentials are mutually exclusive by construction: the CORS check only
@@ -212,7 +216,7 @@ mod tests {
     }
 
     #[test]
-    fn non_utf8_acao_is_violation() {
+    fn an_obs_text_octet_in_the_origin_is_not_a_wildcard() {
         use crate::test_helpers::make_headers_from_pairs;
         use hyper::header::HeaderValue;
 
@@ -237,12 +241,16 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
-        assert!(v.is_some());
-        assert!(v.unwrap().message.contains("non-ASCII"));
+        assert!(
+            v.is_none(),
+            "the value is this rule's business only if it is `*`, and the octet's own \
+             finding is access_control_allow_origin_valid's: {:?}",
+            v
+        );
     }
 
     #[test]
-    fn non_utf8_acc_is_violation() {
+    fn an_obs_text_octet_in_the_credentials_is_not_the_word_true() {
         use crate::test_helpers::make_headers_from_pairs;
         use hyper::header::HeaderValue;
 
@@ -267,8 +275,11 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
-        assert!(v.is_some());
-        assert!(v.unwrap().message.contains("non-ASCII"));
+        assert!(
+            v.is_none(),
+            "a credentials value that is not `true` pairs with nothing, whatever it holds: {:?}",
+            v
+        );
     }
 
     #[test]

--- a/lint-http-rules/src/rules/origin_matching_for_cors.rs
+++ b/lint-http-rules/src/rules/origin_matching_for_cors.rs
@@ -106,29 +106,38 @@ impl Rule for OriginMatchingForCors {
             let req = &tx.request;
             let headers = &req.headers;
 
-            // Nothing to do if request did not include Origin header
-            let origin = crate::helpers::headers::get_header_str(headers, "origin")?.trim();
+            // Nothing to do if request did not include Origin header. The line is
+            // read as the octets the sender wrote: `Origin` is `null` or a
+            // serialized origin, both inside visible US-ASCII, so a value the
+            // string reader refuses is a value the syntax check below refuses —
+            // and refusing it here first meant the rule said nothing at all.
+            let origin_line = crate::helpers::headers::field_lines_as_written(headers, "origin")
+                .into_iter()
+                .next()?;
+            let origin = crate::helpers::headers::trim_ows(&origin_line);
 
             // Validate origin syntax using shared helper (handles "null" and serialized origins).
             if let Some(reason) = crate::helpers::uri::validate_origin_value(origin) {
                 return Some(self.violation(
                     ctx.severity,
-                    format!("Invalid Origin header value '{}': {}", origin, reason),
+                    format!(
+                        "Invalid Origin header value '{}': {}",
+                        crate::helpers::shown::shown_in_finding(origin),
+                        reason
+                    ),
                 ));
             }
 
             let resp = tx.response.as_ref()?;
 
-            // Check for Access-Control-Allow-Origin header in response
-            let mut acao_values: Vec<String> = Vec::new();
-            for hv in resp.headers.get_all("access-control-allow-origin").iter() {
-                match hv.to_str() {
-                    Ok(s) => acao_values.push(s.to_string()),
-                    Err(_) => {
-                        return Some(self.violation(ctx.severity, "Access-Control-Allow-Origin header contains non-ASCII or control characters".into()));
-                    }
-                }
-            }
+            // Check for Access-Control-Allow-Origin header in response. Read as
+            // written for the same reason as the request's `Origin`: this rule
+            // compares the two byte for byte, so a value it cannot read is a
+            // value that does not match, which the finding at the end says.
+            let acao_values = crate::helpers::headers::field_lines_as_written(
+                &resp.headers,
+                "access-control-allow-origin",
+            );
             if acao_values.is_empty() {
                 return None;
             }
@@ -140,7 +149,7 @@ impl Rule for OriginMatchingForCors {
             }
 
             // Now we have exactly one header field; validate its value semantics
-            let acao_raw = acao_values[0].trim();
+            let acao_raw = crate::helpers::headers::trim_ows(&acao_values[0]);
             // Must be a single value (not a comma-separated list)
             let members: Vec<String> = crate::helpers::list::list_members(acao_raw)
                 .map(|m| m.to_string())
@@ -152,7 +161,8 @@ impl Rule for OriginMatchingForCors {
                 ));
             }
 
-            let acao_val = members.into_iter().next().unwrap().trim().to_string();
+            let acao_val = members.into_iter().next().unwrap();
+            let acao_val = crate::helpers::headers::trim_ows(&acao_val).to_string();
 
             // `*` is permitted only when credentials are not allowed. The CORS check short-
             // circuits on `*` *only* for a request that does not carry credentials; a
@@ -181,7 +191,8 @@ impl Rule for OriginMatchingForCors {
                     ctx.severity,
                     format!(
                         "Access-Control-Allow-Origin '{}' does not match request Origin '{}'",
-                        acao_val, origin
+                        crate::helpers::shown::shown_in_finding(&acao_val),
+                        crate::helpers::shown::shown_in_finding(origin)
                     ),
                 ));
             }
@@ -216,6 +227,69 @@ mod tests {
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
         assert!(v.is_none());
+    }
+
+    #[test]
+    fn an_obs_text_octet_in_the_origin_is_a_syntax_finding() {
+        use hyper::header::HeaderValue;
+
+        let rule = OriginMatchingForCors;
+        let mut tx = make_test_transaction_with_response(
+            200,
+            &[("access-control-allow-origin", "https://example.com")],
+        );
+        let mut hdrs = hyper::HeaderMap::new();
+        hdrs.insert(
+            "origin",
+            HeaderValue::from_bytes(b"https://exa\xffmple.com").expect("a field line"),
+        );
+        tx.request.headers = hdrs;
+
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        );
+        // The rule used to say nothing here: the value never reached the origin
+        // syntax check, because the reader refused it first.
+        let msg = v.expect("a finding").message;
+        assert!(
+            msg.starts_with("Invalid Origin header value 'https://exa\u{ff}mple.com'"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn an_obs_text_octet_in_the_allowed_origin_does_not_match() {
+        use hyper::header::HeaderValue;
+
+        let rule = OriginMatchingForCors;
+        let mut tx = make_test_transaction();
+        tx.request.headers = make_headers_from_pairs(&[("origin", "https://example.com")]);
+        let mut hdrs = hyper::HeaderMap::new();
+        hdrs.insert(
+            "access-control-allow-origin",
+            HeaderValue::from_bytes(b"https://exa\xffmple.com").expect("a field line"),
+        );
+        tx.response = Some(crate::http_transaction::ResponseInfo {
+            status: 200,
+            version: "HTTP/1.1".into(),
+            headers: hdrs,
+            body_length: None,
+            trailers: None,
+        });
+
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        );
+        assert_eq!(
+            v.expect("a finding").message,
+            "Access-Control-Allow-Origin 'https://exa\u{ff}mple.com' does not match request Origin 'https://example.com'"
+        );
     }
 
     #[rstest]

--- a/lint-http-rules/src/rules/request_origin_header_present_for_cors.rs
+++ b/lint-http-rules/src/rules/request_origin_header_present_for_cors.rs
@@ -105,10 +105,19 @@ impl Rule for RequestOriginHeaderPresentForCors {
                 && (headers.get("access-control-request-method").is_some()
                     || headers.get("access-control-request-headers").is_some())
             {
-                // Origin must be present
-                match crate::helpers::headers::get_header_str(headers, "origin") {
+                // Origin must be present. Presence is `get_all`, not a successful
+                // decode: a field line carrying an octet outside visible US-ASCII
+                // is a header the sender wrote, and calling it *missing* named the
+                // one defect this rule can be certain is not there. The syntax
+                // check below is what the value answers to.
+                match crate::helpers::headers::field_lines_as_written(headers, "origin")
+                    .into_iter()
+                    .next()
+                {
                     Some(origin_val) => {
-                        if let Some(err) = crate::helpers::uri::validate_origin_value(origin_val) {
+                        if let Some(err) = crate::helpers::uri::validate_origin_value(
+                            crate::helpers::headers::trim_ows(&origin_val),
+                        ) {
                             return Some(self.violation(
                                 ctx.severity,
                                 format!("Origin header invalid: {}", err),
@@ -136,8 +145,9 @@ impl Rule for RequestOriginHeaderPresentForCors {
                         if !target_authority.eq_ignore_ascii_case(host_authority) {
                             // they differ; require Origin header
                             // cite(Fetch § 3.2): "The `Origin` request header indicates where a fetch originates from."
-                            if crate::helpers::headers::get_header_str(headers, "origin").is_none()
-                            {
+                            // Presence, again — an unreadable line is a header that
+                            // is there.
+                            if headers.get("origin").is_none() {
                                 return Some(
                                     self.cited(
                                         &FETCH_3_2,
@@ -168,6 +178,32 @@ mod tests {
     use rstest::rstest;
 
     use crate::test_helpers::{make_headers_from_pairs, make_test_transaction};
+
+    #[test]
+    fn a_preflight_origin_holding_an_octet_is_present_and_invalid() {
+        use hyper::header::HeaderValue;
+
+        let rule = RequestOriginHeaderPresentForCors;
+        let mut tx = make_test_transaction();
+        tx.request.method = "OPTIONS".into();
+        let mut hdrs = make_headers_from_pairs(&[("access-control-request-method", "POST")]);
+        hdrs.insert(
+            "origin",
+            HeaderValue::from_bytes(b"https://exa\xffmple.com").expect("a field line"),
+        );
+        tx.request.headers = hdrs;
+
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        );
+        // The sender wrote the header, so "missing" was the one thing it was
+        // not: the value answers to the origin syntax instead.
+        let msg = v.expect("a finding").message;
+        assert!(msg.starts_with("Origin header invalid: "), "{msg}");
+    }
 
     #[rstest]
     fn preflight_without_origin_is_violation() {

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -8,15 +8,15 @@ sources:
     snippet: If credentials is `true`, then return success.
     cited_by:
     - file: lint-http-rules/src/rules/access_control_allow_credentials_when_origin.rs
-      line: 149
+      line: 153
   - label: access_control_allow_credentials_when_origin (2)
     section: § 4.10
     snippet: If request’s credentials mode is not "include" and origin is `*`, then return success.
     cited_by:
     - file: lint-http-rules/src/rules/access_control_allow_credentials_when_origin.rs
-      line: 148
+      line: 152
     - file: lint-http-rules/src/rules/origin_matching_for_cors.rs
-      line: 161
+      line: 171
   - label: access_control_allow_origin_valid
     section: § 3.3.3
     snippet: Indicates whether the response can be shared, via returning the literal value of the `Origin` request header (which can be `null`) or `*` in a response.
@@ -24,7 +24,7 @@ sources:
     - file: lint-http-rules/src/rules/access_control_allow_origin_valid.rs
       line: 136
     - file: lint-http-rules/src/rules/origin_matching_for_cors.rs
-      line: 137
+      line: 146
   - label: cross_origin_resource_policy_valid
     section: § 3.7
     snippet: Cross-Origin-Resource-Policy = %s"same-origin" / %s"same-site" / %s"cross-origin" ; case-sensitive
@@ -60,7 +60,7 @@ sources:
     snippet: If the result of byte-serializing a request origin with request is not origin, then return failure.
     cited_by:
     - file: lint-http-rules/src/rules/origin_matching_for_cors.rs
-      line: 177
+      line: 187
   - label: refresh_header_syntax
     section: § 2.2.2
     snippet: Return the values of all headers in list whose name is a byte-case-insensitive match for name, separated from each other by 0x2C 0x20
@@ -78,7 +78,7 @@ sources:
     snippet: The `Origin` request header indicates where a fetch originates from.
     cited_by:
     - file: lint-http-rules/src/rules/request_origin_header_present_for_cors.rs
-      line: 138
+      line: 147
   - label: sec_fetch_dest_value_valid
     section: § 2.2.5
     snippet: 'A destination type is one of: the empty string, "audio", "audioworklet", "document", "embed", "font", "frame", "iframe", "image", "json", "manifest", "object", "paintworklet", "report", "script", "serviceworker", "sharedworker", "style", "text", "track", "video", "webidentity", "worker", or "xslt".'


### PR DESCRIPTION
The three remaining readers of Origin and Access-Control-Allow-Origin read their field lines as the octets the sender wrote. Each was making a different wrong claim: the preflight rule called a header the sender wrote missing, the matching rule said nothing at all where its own syntax check had the answer, and the credentials rule reported a value it only scans for a wildcard. Both fields are inside visible US-ASCII, so every octet now lands on the check that owns it.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
