### PR TITLE
A legacy header value is spelled in ASCII

### DIFF
--- a/lint-http-rules/src/rules/x_frame_options_value_valid.rs
+++ b/lint-http-rules/src/rules/x_frame_options_value_valid.rs
@@ -111,16 +111,17 @@ impl Rule for XFrameOptionsValueValid {
                 ));
             }
 
-            // cite(RFC 9110 § 5.5): "newly defined fields SHOULD limit their values to visible US-ASCII octets (VCHAR), SP, and HTAB"
-            let val = match crate::helpers::headers::get_header_str(headers, "x-frame-options") {
-                Some(v) => v.trim(),
-                None => {
-                    return Some(self.violation(
-                        ctx.severity,
-                        "X-Frame-Options header contains non-ASCII or control characters".into(),
-                    ))
-                }
-            };
+            // Read as the octets the sender wrote. Both conforming spellings are
+            // inside visible US-ASCII, so a value the string reader refuses is a
+            // value that is neither of them — which the unsupported-value finding
+            // at the end says, and it can quote what arrived.
+            let hv = headers
+                .get_all("x-frame-options")
+                .iter()
+                .next()
+                .expect("a field line, since the count above is one");
+            let line = crate::helpers::headers::field_line_as_written(hv);
+            let val = crate::helpers::headers::trim_ows(&line);
 
             // The two conforming values; the match is case-insensitive because the
             // processing model lowercases each value before comparing.
@@ -136,21 +137,30 @@ impl Rule for XFrameOptionsValueValid {
             // sender believes otherwise. Flag it with a targeted message rather than
             // the generic unsupported-value one.
             // cite(HTML Speculative Loading § 7.7): "In particular, HTTP Header Field X-Frame-Options specified an `ALLOW-FROM` variant of the header, but that is not to be implemented."
-            if val.len() >= 10 && val[..10].eq_ignore_ascii_case("ALLOW-FROM") {
+            // `get` rather than `[..10]`: one `char` per octet is not one *byte*
+            // per octet once an `obs-text` octet is in the value, so a byte index
+            // can land inside a code point and the slice would panic.
+            if val
+                .get(..10)
+                .is_some_and(|prefix| prefix.eq_ignore_ascii_case("ALLOW-FROM"))
+            {
                 return Some(self.cited(
                     &HTML_SPECULATIVE_LOADING_7_7,
                     ctx.severity,
                     format!(
                         "X-Frame-Options: ALLOW-FROM is obsolete and not implemented by browsers \
                          (use the Content-Security-Policy frame-ancestors directive instead): '{}'",
-                        val
+                        crate::helpers::shown::shown_in_finding(val)
                     ),
                 ));
             }
 
             Some(self.violation(
                 ctx.severity,
-                format!("X-Frame-Options contains unsupported value: '{}'", val),
+                format!(
+                    "X-Frame-Options contains unsupported value: '{}'",
+                    crate::helpers::shown::shown_in_finding(val)
+                ),
             ))
         };
         Vec::from_iter(finding())
@@ -236,6 +246,40 @@ mod tests {
     }
 
     #[test]
+    fn an_octet_inside_the_obsolete_prefix_is_measured_not_sliced() {
+        use hyper::header::HeaderValue;
+
+        let rule = XFrameOptionsValueValid;
+        let mut tx = make_test_transaction();
+        let mut hdrs = hyper::HeaderMap::new();
+        // The tenth octet is inside a code point that takes two bytes in the
+        // decoded line, which is what a byte-indexed slice would have split.
+        hdrs.insert(
+            "x-frame-options",
+            HeaderValue::from_bytes(b"ALLOW-FRO\xffM https://example.com").expect("a field line"),
+        );
+        tx.response = Some(crate::http_transaction::ResponseInfo {
+            status: 200,
+            version: "HTTP/1.1".into(),
+            headers: hdrs,
+            body_length: None,
+            trailers: None,
+        });
+
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        );
+        let msg = v.expect("a finding").message;
+        assert!(
+            msg.starts_with("X-Frame-Options contains unsupported value:"),
+            "{msg}"
+        );
+    }
+
+    #[test]
     fn multiple_headers_violation() {
         use crate::test_helpers::make_headers_from_pairs;
         use hyper::header::HeaderValue;
@@ -265,7 +309,7 @@ mod tests {
     }
 
     #[test]
-    fn non_utf8_header_value_is_violation() {
+    fn an_obs_text_octet_is_a_value_none_of_them_spell() {
         use crate::test_helpers::make_headers_from_pairs;
         use hyper::header::HeaderValue;
 
@@ -291,8 +335,10 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
-        assert!(v.is_some());
-        assert!(v.unwrap().message.contains("non-ASCII"));
+        assert_eq!(
+            v.expect("a finding").message,
+            "X-Frame-Options contains unsupported value: 'ÿ'"
+        );
     }
 
     #[test]

--- a/lint-http-rules/src/rules/x_xss_protection_value_valid.rs
+++ b/lint-http-rules/src/rules/x_xss_protection_value_valid.rs
@@ -114,16 +114,17 @@ impl Rule for XXssProtectionValueValid {
                 ));
             }
 
-            // cite(RFC 9110 § 5.5): "newly defined fields SHOULD limit their values to visible US-ASCII octets (VCHAR), SP, and HTAB"
-            let val = match crate::helpers::headers::get_header_str(headers, "x-xss-protection") {
-                Some(v) => v.trim(),
-                None => {
-                    return Some(self.violation(
-                        ctx.severity,
-                        "X-XSS-Protection header contains non-ASCII or control characters".into(),
-                    ))
-                }
-            };
+            // Read as the octets the sender wrote. Every spelling this rule
+            // accepts is inside visible US-ASCII, so a value the string reader
+            // refuses is a value none of them spell — which the unsupported-value
+            // finding at the end says, and it can quote what arrived.
+            let hv = headers
+                .get_all("x-xss-protection")
+                .iter()
+                .next()
+                .expect("a field line, since the count above is one");
+            let line = crate::helpers::headers::field_line_as_written(hv);
+            let val = crate::helpers::headers::trim_ows(&line);
 
             // Accept exactly "0" or "1;mode=block" (allow whitespace around separators, case-insensitive)
             // `1` and `1; report=<uri>` are documented values that this rule rejects anyway.
@@ -137,7 +138,10 @@ impl Rule for XXssProtectionValueValid {
 
             // Split on ';' and validate structure: exactly two parts, first is '1', second is 'mode=block'
             // cite(MDN X-XSS-Protection): "Enables XSS filtering. Rather than sanitizing the page, the browser will prevent rendering of the page if an attack is detected."
-            let parts: Vec<&str> = val.split(';').map(|s| s.trim()).collect();
+            let parts: Vec<&str> = val
+                .split(';')
+                .map(crate::helpers::headers::trim_ows)
+                .collect();
             if parts.len() == 2
                 && parts[0].eq_ignore_ascii_case("1")
                 && parts[1].eq_ignore_ascii_case("mode=block")
@@ -148,7 +152,10 @@ impl Rule for XXssProtectionValueValid {
             Some(self.cited(
                 &MDN_X_XSS_PROTECTION,
                 ctx.severity,
-                format!("X-XSS-Protection contains unsupported value: '{}'", val),
+                format!(
+                    "X-XSS-Protection contains unsupported value: '{}'",
+                    crate::helpers::shown::shown_in_finding(val)
+                ),
             ))
         };
         Vec::from_iter(finding())
@@ -236,7 +243,7 @@ mod tests {
     }
 
     #[test]
-    fn non_utf8_header_value_is_violation() {
+    fn an_obs_text_octet_is_a_value_none_of_them_spell() {
         use crate::test_helpers::make_headers_from_pairs;
         use hyper::header::HeaderValue;
 
@@ -262,8 +269,10 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
-        assert!(v.is_some());
-        assert!(v.unwrap().message.contains("non-ASCII"));
+        assert_eq!(
+            v.expect("a finding").message,
+            "X-XSS-Protection contains unsupported value: 'ÿ'"
+        );
     }
 
     #[test]

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -188,7 +188,7 @@ sources:
     snippet: For each value of rawXFrameOptions, append value, converted to ASCII lowercase, to xFrameOptions.
     cited_by:
     - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
-      line: 128
+      line: 129
   - label: x_frame_options_value_valid (2)
     section: § 7.7
     snippet: HTTP response header is a way of controlling whether and how a Document may be loaded inside of a child navigable
@@ -200,7 +200,7 @@ sources:
     snippet: In particular, HTTP Header Field X-Frame-Options specified an `ALLOW-FROM` variant of the header, but that is not to be implemented.
     cited_by:
     - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
-      line: 138
+      line: 139
   - label: x_frame_options_value_valid (4)
     section: § 7.7
     snippet: It was originally defined in HTTP Header Field X-Frame-Options, but the definition and processing model here supersedes that document.
@@ -212,7 +212,7 @@ sources:
     snippet: X-Frame-Options = "DENY" / "SAMEORIGIN"
     cited_by:
     - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
-      line: 127
+      line: 128
 - label: HTML Semantics
   url: https://html.spec.whatwg.org/multipage/semantics.html
   type: text/html
@@ -778,17 +778,17 @@ sources:
     snippet: Disables XSS filtering.
     cited_by:
     - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
-      line: 133
+      line: 134
   - label: x_xss_protection_value_valid (2)
     snippet: Enables XSS filtering. Rather than sanitizing the page, the browser will prevent rendering of the page if an attack is detected.
     cited_by:
     - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
-      line: 139
+      line: 140
   - label: x_xss_protection_value_valid (3)
     snippet: Even though this feature can protect users of older web browsers that don't support CSP, in some cases, X-XSS-Protection can create XSS vulnerabilities in otherwise safe websites.
     cited_by:
     - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
-      line: 132
+      line: 133
   - label: x_xss_protection_value_valid (4)
     snippet: response header was a feature of Internet Explorer, Chrome and Safari that stopped pages from loading when they detected reflected cross-site scripting
     cited_by:
@@ -9280,14 +9280,6 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
       line: 680
-  - label: x_frame_options_value_valid
-    section: § 5.5
-    snippet: newly defined fields SHOULD limit their values to visible US-ASCII octets (VCHAR), SP, and HTAB
-    cited_by:
-    - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
-      line: 114
-    - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
-      line: 117
 - label: RFC 9111
   url: https://www.rfc-editor.org/rfc/rfc9111.html
   fragments:


### PR DESCRIPTION
X-Frame-Options and X-XSS-Protection read their field lines as the octets the sender wrote. Every spelling either rule accepts is inside visible US-ASCII, so the refused value is a value none of them spell, which the unsupported-value finding below already said. The obsolete ALLOW-FROM prefix is matched through a checked slice: one char per octet is not one byte per octet, and a byte index can land inside a code point.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
