### PR TITLE
An entity tag may hold the octet it was dropped for

### DIFF
--- a/lint-http-rules/src/helpers/validator.rs
+++ b/lint-http-rules/src/helpers/validator.rs
@@ -15,7 +15,7 @@
 //!
 //! [`check_entity_tag`] is the grammar underneath all of it.
 
-use crate::helpers::headers::get_header_str;
+use crate::helpers::headers::{field_lines_as_written, trim_ows};
 use crate::helpers::list::split_commas_respecting_quotes;
 use hyper::HeaderMap;
 
@@ -27,10 +27,10 @@ use hyper::HeaderMap;
 /// it represents an existence condition rather than a specific validator.
 pub fn inm_matches_known(inm: &str, known: &str) -> bool {
     fn normalize(s: &str) -> &str {
-        let s = s.trim();
+        let s = trim_ows(s);
         // cite(RFC 9110 § 13.1.2, label: If-None-Match weak comparison): "A recipient MUST use the weak comparison function when comparing entity tags for If-None-Match"
         if let Some(rest) = s.strip_prefix("W/") {
-            rest.trim()
+            trim_ows(rest)
         } else {
             s
         }
@@ -38,7 +38,7 @@ pub fn inm_matches_known(inm: &str, known: &str) -> bool {
 
     let known_norm = normalize(known);
     for member in split_commas_respecting_quotes(inm) {
-        let t = member.trim();
+        let t = trim_ows(member);
         if t == "*" {
             return false;
         }
@@ -72,7 +72,14 @@ pub fn extract_validators_from_response(headers: &HeaderMap) -> (Option<String>,
 
 /// One validator field, trimmed, if the response carries a readable one.
 fn validator(headers: &HeaderMap, name: &str) -> Option<String> {
-    get_header_str(headers, name).map(|value| value.trim().to_string())
+    // As written, because `etagc = %x21 / %x23-7E / obs-text`: an octet at or
+    // above %x80 is a character an entity tag *generates*, so a decode that
+    // refuses it drops a legal validator and every question asked of the pair
+    // is then answered about a response that did offer one.
+    field_lines_as_written(headers, name)
+        .into_iter()
+        .next()
+        .map(|line| trim_ows(&line).to_string())
 }
 
 /// Extract **strong** validators from a response's headers.
@@ -109,9 +116,9 @@ pub fn extract_strong_validators_from_response(
 ///
 // cite(RFC 9110 § 8.8.3.2): "two entity tags are equivalent if their opaque-tags match character-by-character, regardless of either or both being tagged as "weak"."
 pub fn normalize_etag(s: &str) -> String {
-    let trimmed = s.trim();
+    let trimmed = trim_ows(s);
     if trimmed.len() >= 2 && (trimmed.starts_with("W/") || trimmed.starts_with("w/")) {
-        trimmed[2..].trim().to_string()
+        trim_ows(&trimmed[2..]).to_string()
     } else {
         trimmed.to_string()
     }
@@ -133,11 +140,11 @@ pub fn normalize_etag(s: &str) -> String {
 // cite(RFC 9110 § 8.8.3): "An entity tag consists of an opaque quoted string, possibly prefixed by a weakness indicator."
 pub fn check_entity_tag(val: &str) -> Result<(), EntityTagDefect> {
     // cite(RFC 9110 § 8.8.3, label: entity-tag grammar): "entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE"
-    let s = val.trim();
+    let s = trim_ows(val);
 
     let rest = if let Some(stripped) = s.strip_prefix("W/") {
         stripped
-    } else if s.len() >= 2 && s[..2].eq_ignore_ascii_case("w/") {
+    } else if s.get(..2).is_some_and(|p| p.eq_ignore_ascii_case("w/")) {
         // `%s"W/"` — the `%s` prefix is what makes the case part of the
         // production, and RFC 5234 § 2.3 says an unprefixed string would have
         // been case-insensitive. A `w/` is therefore a weakness indicator the
@@ -260,16 +267,27 @@ mod tests {
     }
 
     #[test]
-    fn non_utf8_headers_are_skipped() {
+    fn an_obs_text_octet_is_part_of_the_tag_not_a_reason_to_drop_it() {
         let mut headers = HeaderMap::new();
-        // create invalid bytes
-        let bad = HeaderValue::from_bytes(&[0xff]).unwrap();
+        // `etagc` generates this octet, so the response did offer a validator
+        // and the old decode answered that it had offered none.
+        let bad = HeaderValue::from_bytes(b"\"caf\xe9\"").expect("a field line");
         headers.insert("etag", bad);
         let (etag, _lm) = extract_validators_from_response(&headers);
-        assert!(
-            etag.is_none(),
-            "invalid etag should not panic or return value"
+        assert_eq!(
+            etag.expect("a validator"),
+            ['"', 'c', 'a', 'f', '\u{e9}', '"']
+                .iter()
+                .collect::<String>()
         );
+    }
+
+    #[test]
+    fn a_tag_whose_second_octet_is_obs_text_is_measured_not_sliced() {
+        // One `char` per octet is not one *byte* per octet: `a%xFF"` puts byte
+        // index 2 inside a code point, which a `[..2]` would have split.
+        let val: String = [0x61u8, 0xff, 0x22].into_iter().map(char::from).collect();
+        assert!(check_entity_tag(&val).is_err());
     }
 
     #[test]

--- a/lint-http-rules/src/rules/cache_validation_chain.rs
+++ b/lint-http-rules/src/rules/cache_validation_chain.rs
@@ -126,9 +126,15 @@ impl Rule for CacheValidationChain {
             // form — and therefore cannot be matched against a previously observed
             // ETag.  Skip the rule in that case to avoid spurious warnings.
             // cite(RFC 9110 § 13.1.2): "The "If-None-Match" header field makes the request method conditional on a recipient cache or origin server either not having any current representation of the target resource, when the field value is "*""
-            let inm_lines = || crate::helpers::headers::field_lines(&req.headers, "if-none-match");
-            if inm_lines()
-                .flat_map(crate::helpers::list::split_commas_respecting_quotes)
+            // As written: an `If-None-Match` member is an entity tag, and `etagc`
+            // admits `obs-text`, so a line the string reader drops is a validator
+            // the client did send — invisible to the comparison below and quoted
+            // into the finding as a placeholder.
+            let inm_lines =
+                crate::helpers::headers::field_lines_as_written(&req.headers, "if-none-match");
+            if inm_lines
+                .iter()
+                .flat_map(|line| crate::helpers::list::split_commas_respecting_quotes(line))
                 .any(|member| member == "*")
             {
                 return None;
@@ -154,16 +160,15 @@ impl Rule for CacheValidationChain {
             // cite(RFC 9111 § 4.3.1): "SHOULD send the Last-Modified value (using If-Modified-Since) if the request is not for a subrange, a single stored response is being validated, and that response contains a Last-Modified value."
             if let Some(known_etag) = etag {
                 if has_inm
-                    && !inm_lines()
+                    && !inm_lines
+                        .iter()
                         .any(|line| crate::helpers::validator::inm_matches_known(line, &known_etag))
                 {
-                    // A field line that is not text matched nothing, and is what
-                    // the finding has to quote when it is all the request sent.
-                    let reported = inm_lines().next().unwrap_or("<non-UTF8 If-None-Match>");
+                    let reported = inm_lines.first().map_or("", String::as_str);
                     // cite(RFC 9111 § 4.3.1): "It then updates that request with one or more precondition header fields. These contain validator metadata sourced from a stored response(s) that has the same URI."
                     return Some(self.cited(&RFC_9111_4_3_1, ctx.severity, format!(
                             "Conditional request uses If-None-Match '{}' which does not match most recent validator '{}' from history; cache validation chain may be broken",
-                            reported.trim(),
+                            crate::helpers::headers::trim_ows(reported),
                             known_etag
                         )));
                 }
@@ -286,6 +291,38 @@ mod tests {
             &crate::test_helpers::make_test_config_with_enabled_rules(&["cache_validation_chain"]),
         );
         assert!(v.is_none());
+    }
+
+    #[test]
+    fn an_obs_text_tag_matches_the_one_the_response_offered() {
+        use hyper::header::HeaderValue;
+
+        let rule = CacheValidationChain;
+        let mut prev = make_prev(200, &[]);
+        let mut resp_headers = hyper::HeaderMap::new();
+        resp_headers.insert(
+            "etag",
+            HeaderValue::from_bytes(b"\"caf\xe9\"").expect("a field line"),
+        );
+        prev.response.as_mut().expect("a response").headers = resp_headers;
+
+        let mut tx = crate::test_helpers::make_test_transaction();
+        let mut req_headers = hyper::HeaderMap::new();
+        req_headers.insert(
+            "if-none-match",
+            HeaderValue::from_bytes(b"\"caf\xe9\"").expect("a field line"),
+        );
+        tx.request.headers = req_headers;
+
+        // Both sides used to be dropped by the decode: the response offered no
+        // validator this rule could see, and the request quoted a placeholder.
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["cache_validation_chain"]),
+        );
+        assert!(v.is_none(), "{v:?}");
     }
 
     #[test]

--- a/lint-http-rules/src/rules/conditional_headers_consistent.rs
+++ b/lint-http-rules/src/rules/conditional_headers_consistent.rs
@@ -131,7 +131,11 @@ impl Rule for ConditionalHeadersConsistent {
             }
 
             // If-Range should only be sent in requests that contain Range
-            if let Some(hv) = req.headers.get_all("if-range").iter().next() {
+            if let Some(line) =
+                crate::helpers::headers::field_lines_as_written(&req.headers, "if-range")
+                    .into_iter()
+                    .next()
+            {
                 // If-Range exists
                 // cite(RFC 9110 § 13.1.5): "A client MUST NOT generate an If-Range header field in a request that does not contain a Range header field."
                 if req.headers.get("range").is_none() {
@@ -141,13 +145,12 @@ impl Rule for ConditionalHeadersConsistent {
                 // Validate If-Range content: if it's an entity-tag, it MUST NOT be weak.
                 // (A weak marker is the `W/` prefix; a bare quoted-string is a strong tag and
                 // fine, and a date is left to date-validity rules.)
-                let Ok(s) = hv.to_str() else {
-                    return Some(self.violation(
-                        ctx.severity,
-                        "If-Range header contains non-UTF8 value".into(),
-                    ));
-                };
-                let trimmed = s.trim();
+                //
+                // Read as the octets the sender wrote, and this rule says nothing
+                // about what they are: `etagc` admits `obs-text`, so an octet
+                // inside a tag is a value the production generates, and the one
+                // question asked here is whether the value opens with `W/`.
+                let trimmed = crate::helpers::headers::trim_ows(&line);
                 // cite(RFC 9110 § 13.1.5): "A client MUST NOT generate an If-Range header field containing an entity tag that is marked as weak."
                 if trimmed.starts_with("W/") {
                     return Some(self.cited(
@@ -344,16 +347,17 @@ mod tests {
     }
 
     #[rstest]
-    fn if_range_with_non_utf8_reports_violation() {
+    fn if_range_holding_an_obs_text_octet_is_not_this_rules_finding() {
         use hyper::header::HeaderValue;
         use hyper::HeaderMap;
 
         let mut tx = crate::test_helpers::make_test_transaction();
         let mut hm = HeaderMap::new();
         hm.insert("range", "bytes=0-1".parse().unwrap());
-        // Create a non-UTF8 header value by using arbitrary bytes that don't form valid UTF-8
-        let non_utf8 = HeaderValue::from_bytes(&[0xFF, 0xFF]).expect("create header value");
-        hm.insert("if-range", non_utf8);
+        // `etagc` generates this octet, and the only question this rule asks of
+        // the value is whether it opens with `W/`.
+        let obs_text = HeaderValue::from_bytes(b"\"caf\xe9\"").expect("create header value");
+        hm.insert("if-range", obs_text);
         tx.request.headers = hm;
 
         let rule = ConditionalHeadersConsistent;
@@ -363,8 +367,7 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
-        assert!(v.is_some());
-        assert!(v.unwrap().message.contains("non-UTF8"));
+        assert!(v.is_none(), "{v:?}");
     }
 
     #[rstest]

--- a/lint-http-rules/src/rules/range_request_and_caching.rs
+++ b/lint-http-rules/src/rules/range_request_and_caching.rs
@@ -260,13 +260,12 @@ impl Rule for RangeRequestAndCaching {
                     )));
             };
 
-            // Present and unreadable is not absent. `conditional_headers_consistent`
-            // reports a non-ASCII `If-Range`; a "carries none of them" finding here
-            // would be false about the message on the wire.
-            let Ok(if_range) = raw_if_range.to_str() else {
-                return None;
-            };
-            let if_range = if_range.trim();
+            // Read as the octets the sender wrote: `etagc` admits `obs-text`, so a
+            // tag holding one is a validator this client did send, and refusing to
+            // read it answered every question below about a request that carried
+            // nothing.
+            let if_range = crate::helpers::headers::field_line_as_written(raw_if_range);
+            let if_range = crate::helpers::headers::trim_ows(&if_range);
 
             // A weak tag in `If-Range` violates §13.1.5 outright, and the rule that
             // owns the field's syntax says so. Declining keeps the two findings from

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1715,7 +1715,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 67
     - file: lint-http-rules/src/helpers/validator.rs
-      line: 146
+      line: 153
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 242
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
@@ -5469,9 +5469,9 @@ sources:
     snippet: A recipient MUST ignore the If-Modified-Since header field if the received field value is not a valid HTTP-date, the field value has more than one member, or if the request method is neither GET nor HEAD.
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 172
+      line: 175
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 190
+      line: 193
   - label: conditional_headers_consistent (3)
     section: § 13.1.4
     snippet: A recipient MUST ignore If-Unmodified-Since if the request contains an If-Match header field
@@ -5483,19 +5483,19 @@ sources:
     snippet: A recipient MUST ignore the If-Unmodified-Since header field if the received field value is not a valid HTTP-date (including when the field value appears to be a list of dates).
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 173
+      line: 176
   - label: conditional_headers_consistent (5)
     section: § 13.1.5
     snippet: A client MUST NOT generate an If-Range header field containing an entity tag that is marked as weak.
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 151
+      line: 154
   - label: conditional_headers_consistent (6)
     section: § 13.1.5
     snippet: A client MUST NOT generate an If-Range header field in a request that does not contain a Range header field.
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 136
+      line: 140
   - label: conditional_request_handling
     section: § 13.1.2
     snippet: An origin server that evaluates an If-None-Match condition MUST NOT perform the requested method if the condition evaluates to false; instead, the origin server MUST respond with either a) the 304 (Not Modified) status code if the request method is GET or HEAD or b) the 412 (Precondition Failed) status code for all other request methods.
@@ -6977,7 +6977,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 28
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 169
+      line: 172
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
       line: 257
     - file: lint-http-rules/src/rules/content_type_valid.rs
@@ -7551,7 +7551,7 @@ sources:
     snippet: An entity tag consists of an opaque quoted string, possibly prefixed by a weakness indicator.
     cited_by:
     - file: lint-http-rules/src/helpers/validator.rs
-      line: 133
+      line: 140
     - file: lint-http-rules/src/rules/etag_syntax.rs
       line: 141
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
@@ -7563,13 +7563,13 @@ sources:
     snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/validator.rs
-      line: 135
+      line: 142
   - label: lint-http-rules/src/helpers/validator.rs (2)
     section: § 8.8.3
     snippet: etagc      = %x21 / %x23-7E / obs-text ; VCHAR except double quotes, plus obs-text
     cited_by:
     - file: lint-http-rules/src/helpers/validator.rs
-      line: 178
+      line: 185
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
       line: 167
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
@@ -7581,7 +7581,7 @@ sources:
     snippet: two entity tags are equivalent if their opaque-tags match character-by-character, regardless of either or both being tagged as "weak".
     cited_by:
     - file: lint-http-rules/src/helpers/validator.rs
-      line: 110
+      line: 117
   - label: Vary grammar
     section: § 12.5.5
     snippet: 'Vary = #( "*" / field-name )'
@@ -8251,19 +8251,19 @@ sources:
     snippet: A valid entity-tag can be distinguished from a valid HTTP-date by examining the first three characters for a DQUOTE.
     cited_by:
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 279
+      line: 278
   - label: range_request_and_caching (2)
     section: § 13.1.5
     snippet: Note that the If-Range comparison is by exact match, including when the validator is an HTTP-date, and so it differs from the "earlier than or equal to" comparison used when evaluating an If-Unmodified-Since conditional.
     cited_by:
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 296
+      line: 295
   - label: range_request_and_caching (3)
     section: § 13.1.5
     snippet: Range header field containing an HTTP-date unless the client has no entity tag for the corresponding representation and the date is a strong validator in the sense defined by Section 8.8.2.2.
     cited_by:
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 290
+      line: 289
   - label: range_request_and_caching (4)
     section: § 15.3.7.3
     snippet: A client that has received multiple partial responses to GET requests on a target resource MAY combine those responses into a larger continuous range if they share the same strong validator.
@@ -9380,15 +9380,15 @@ sources:
     snippet: It then updates that request with one or more precondition header fields. These contain validator metadata sourced from a stored response(s) that has the same URI.
     cited_by:
     - file: lint-http-rules/src/rules/cache_validation_chain.rs
-      line: 163
+      line: 168
     - file: lint-http-rules/src/rules/cache_validation_chain.rs
-      line: 199
+      line: 204
   - label: cache_validation_chain (2)
     section: § 4.3.1
     snippet: MUST send the relevant entity tags (using If-Match, If-None-Match, or If-Range) if the entity tags were provided in the stored response(s) being validated.
     cited_by:
     - file: lint-http-rules/src/rules/cache_validation_chain.rs
-      line: 153
+      line: 159
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
       line: 252
   - label: cache_validation_chain (3)
@@ -9396,7 +9396,7 @@ sources:
     snippet: SHOULD send the Last-Modified value (using If-Modified-Since) if the request is not for a subrange, a single stored response is being validated, and that response contains a Last-Modified value.
     cited_by:
     - file: lint-http-rules/src/rules/cache_validation_chain.rs
-      line: 154
+      line: 160
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
       line: 225
   - label: caching_directive_interaction


### PR DESCRIPTION
The conditional-request readers stop folding: etagc admits obs-text, so a validator carrying one is a validator the sender wrote. The shared validator helper returned none for such a response, If-Range was reported for an encoding by one rule and skipped by the other, and If-None-Match quoted a placeholder into a mismatch it could not have measured. check_entity_tag also stops slicing at a byte index, which panicked once a value could hold a code point wider than one byte.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
