### PR TITLE
The last two fields read their own octets

### DIFF
--- a/lint-http-rules/src/rules/content_security_policy_valid.rs
+++ b/lint-http-rules/src/rules/content_security_policy_valid.rs
@@ -56,10 +56,13 @@ impl ContentSecurityPolicyValid {
             ));
         }
 
-        let mut parts = directive.split_whitespace();
-        let name = parts
-            .next()
-            .expect("split_whitespace yields at least one item since the directive is not empty");
+        // ASCII whitespace, not Unicode: the value is one `char` per octet, so
+        // %xA0 is an `obs-text` octet the sender wrote inside a token and not a
+        // separator between two of them.
+        let mut parts = directive.split_ascii_whitespace();
+        let name = parts.next().expect(
+            "split_ascii_whitespace yields at least one item since the directive is not empty",
+        );
 
         // A CSP directive-name is narrower than the HTTP `token`: only
         // letters, digits and `-`. Enforcing `token` here let typos like
@@ -72,8 +75,10 @@ impl ContentSecurityPolicyValid {
             return Some(self.violation(
                 severity,
                 format!(
-                    "Invalid character '{}' in CSP directive-name '{}', at position {}",
-                    c, name, position
+                    "Invalid character {} in CSP directive-name '{}', at position {}",
+                    crate::helpers::shown::describe_char(c),
+                    crate::helpers::shown::shown_in_finding(name),
+                    position
                 ),
             ));
         }
@@ -248,15 +253,18 @@ impl Rule for ContentSecurityPolicyValid {
         let finding = || -> Option<Violation> {
             let resp = tx.response.as_ref()?;
 
-            for line in resp.headers.get_all("content-security-policy").iter() {
-                let Ok(policy) = line.to_str() else {
-                    return Some(self.violation(
-                        ctx.severity,
-                        "Content-Security-Policy header value is not valid UTF-8".into(),
-                    ));
-                };
+            // Read as the octets the sender wrote. A `directive-name` is
+            // `1*( ALPHA / DIGIT / "-" )`, so an octet outside visible US-ASCII is
+            // a character the name cannot hold and the check in
+            // `directive_defect` names it — where the deleted branch could only
+            // say the whole policy was unreadable.
+            for policy in crate::helpers::headers::field_lines_as_written(
+                &resp.headers,
+                "content-security-policy",
+            ) {
+                let policy = policy.as_str();
 
-                if policy.trim().is_empty() {
+                if crate::helpers::headers::trim_ows(policy).is_empty() {
                     return Some(self.violation(
                         ctx.severity,
                         "Content-Security-Policy header MUST not be empty".into(),
@@ -264,9 +272,11 @@ impl Rule for ContentSecurityPolicyValid {
                 }
 
                 for (position, directive) in policy.split(';').enumerate() {
-                    if let Some(defect) =
-                        self.directive_defect(directive.trim(), position, ctx.severity)
-                    {
+                    if let Some(defect) = self.directive_defect(
+                        crate::helpers::headers::trim_ows(directive),
+                        position,
+                        ctx.severity,
+                    ) {
                         return Some(defect);
                     }
                 }
@@ -441,7 +451,7 @@ mod tests {
     }
 
     #[test]
-    fn non_utf8_header_is_violation() {
+    fn an_obs_text_octet_in_a_directive_name_is_named() {
         let rule = ContentSecurityPolicyValid;
         let cfg = make_cfg();
 
@@ -458,7 +468,10 @@ mod tests {
             &cfg,
         )
         .unwrap();
-        assert!(v.message.contains("not valid UTF-8"));
+        assert_eq!(
+            v.message,
+            "Invalid character 0xFF in CSP directive-name '\u{ff}', at position 0"
+        );
     }
 
     #[test]

--- a/lint-http-rules/src/rules/origin_isolated_header_valid.rs
+++ b/lint-http-rules/src/rules/origin_isolated_header_valid.rs
@@ -101,21 +101,18 @@ impl Rule for OriginIsolatedHeaderValid {
                 ));
             }
 
-            let val = match crate::helpers::headers::get_header_str(
-                &resp.headers,
-                "origin-agent-cluster",
-            ) {
-                Some(v) => v.trim(),
-                None => {
-                    return Some(
-                        self.violation(
-                            ctx.severity,
-                            "Origin-Agent-Cluster header contains non-ASCII or control characters"
-                                .into(),
-                        ),
-                    )
-                }
-            };
+            // Read as the octets the sender wrote. The only value this field ever
+            // carries is the two characters `?1`, so an octet outside visible
+            // US-ASCII is a value that is not it — which the finding at the end
+            // says, with the value in hand.
+            let hv = resp
+                .headers
+                .get_all("origin-agent-cluster")
+                .iter()
+                .next()
+                .expect("a field line, since the count above is one");
+            let line = crate::helpers::headers::field_line_as_written(hv);
+            let val = crate::helpers::headers::trim_ows(&line);
 
             // Must not be a comma-separated list
             // cite(HTML § 7.1.2): "This header is a structured header whose value must be a boolean."
@@ -136,7 +133,7 @@ impl Rule for OriginIsolatedHeaderValid {
                 return None;
             }
 
-            Some(self.cited(&HTML_7_1_2, ctx.severity, format!("Origin-Agent-Cluster header value '{}' is invalid: expected '?1' to request an origin-keyed agent cluster", val)))
+            Some(self.cited(&HTML_7_1_2, ctx.severity, format!("Origin-Agent-Cluster header value '{}' is invalid: expected '?1' to request an origin-keyed agent cluster", crate::helpers::shown::shown_in_finding(val))))
         };
         Vec::from_iter(finding())
     }
@@ -216,7 +213,7 @@ mod tests {
     }
 
     #[test]
-    fn non_utf8_is_violation() -> anyhow::Result<()> {
+    fn an_obs_text_octet_is_a_value_that_is_not_the_boolean() -> anyhow::Result<()> {
         use hyper::header::HeaderValue;
         let rule = OriginIsolatedHeaderValid;
         let mut tx = crate::test_helpers::make_test_transaction();
@@ -237,34 +234,11 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
-        assert!(v.is_some());
-        Ok(())
-    }
-
-    #[test]
-    fn non_utf8_is_violation_message_contains_hint() -> anyhow::Result<()> {
-        use hyper::header::HeaderValue;
-        let rule = OriginIsolatedHeaderValid;
-        let mut tx = crate::test_helpers::make_test_transaction();
-        let mut hdrs =
-            crate::test_helpers::make_headers_from_pairs(&[("origin-agent-cluster", "?1")]);
-        hdrs.insert("origin-agent-cluster", HeaderValue::from_bytes(&[0xff])?);
-        tx.response = Some(crate::http_transaction::ResponseInfo {
-            status: 200,
-            version: "HTTP/1.1".into(),
-            headers: hdrs,
-            body_length: None,
-            trailers: None,
-        });
-
-        let v = crate::test_helpers::run_rule(
-            &rule,
-            &tx,
-            &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        assert_eq!(
+            v.expect("a finding").message,
+            "Origin-Agent-Cluster header value '\u{ff}' is invalid: expected '?1' to request an \
+             origin-keyed agent cluster"
         );
-        let msg = v.unwrap().message;
-        assert!(msg.contains("non-ASCII") || msg.contains("control"));
         Ok(())
     }
 

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -136,13 +136,13 @@ sources:
     snippet: This header is a structured header whose value must be a boolean.
     cited_by:
     - file: lint-http-rules/src/rules/origin_isolated_header_valid.rs
-      line: 121
+      line: 118
   - label: origin_isolated_header_valid (2)
     section: § 7.1.2
     snippet: values that are not the structured header boolean true value (i.e., `?1`) will be ignored.
     cited_by:
     - file: lint-http-rules/src/rules/origin_isolated_header_valid.rs
-      line: 134
+      line: 131
 - label: HTML Links
   url: https://html.spec.whatwg.org/multipage/links.html
   type: text/html
@@ -418,7 +418,7 @@ sources:
     snippet: directive-name = 1*( ALPHA / DIGIT / "-" )
     cited_by:
     - file: lint-http-rules/src/rules/content_security_policy_valid.rs
-      line: 67
+      line: 70
   - label: content_security_policy_valid (2)
     section: § 2.3
     snippet: hash-algorithm = "sha256" / "sha384" / "sha512"


### PR DESCRIPTION
Content-Security-Policy and Origin-Agent-Cluster stop reading through the string reader. A directive-name is letters, digits and hyphens, so the octet is named by the character check already there; the agent cluster's only value is the two characters ?1, so the octet is a value that is not it. The policy's directives split on ASCII whitespace now: one char per octet makes an obs-text octet part of a name rather than a separator between two.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
