### PR TITLE
The last helpers trim what a value may hold

### DIFF
--- a/lint-http-rules/src/helpers/cache_control.rs
+++ b/lint-http-rules/src/helpers/cache_control.rs
@@ -135,7 +135,7 @@ pub fn members(lines: &[String]) -> impl Iterator<Item = &str> {
 /// line, not the member, is what its finding is about — and the two must agree
 /// about the member boundary, which is why the split lives here once.
 pub fn members_of(line: &str) -> Vec<&str> {
-    if line.trim().is_empty() {
+    if crate::helpers::headers::trim_ows(line).is_empty() {
         return Vec::new();
     }
     // `,` is the list separator the grammar prints; `;` is a tolerance for the

--- a/lint-http-rules/src/helpers/cookie.rs
+++ b/lint-http-rules/src/helpers/cookie.rs
@@ -73,7 +73,7 @@ impl CookiePathDefect<'_> {
 /// asymmetry was already here when the errors were strings; naming the variants
 /// is what made it visible enough to write down.
 pub fn validate_cookie_path(s: &str) -> Result<(), CookiePathDefect<'_>> {
-    let v = s.trim();
+    let v = crate::helpers::headers::trim_ows(s);
     // Empty and non-`/` values are not a *syntax* error: §5.2.4 has the user
     // agent replace them with the default-path. That semantics is cited at the
     // sole call site (`cookie_path_valid`); here we flag them as the
@@ -252,8 +252,8 @@ pub fn split_set_cookie(line: &str) -> (&str, impl Iterator<Item = Attribute<'_>
         .filter(|segment| !segment.is_empty())
         .map(|segment| match segment.split_once('=') {
             Some((name, value)) => Attribute {
-                name: name.trim(),
-                value: Some(value.trim()),
+                name: crate::helpers::headers::trim_ows(name),
+                value: Some(crate::helpers::headers::trim_ows(value)),
             },
             None => Attribute {
                 name: segment,
@@ -320,8 +320,8 @@ pub fn parse_set_cookie(
     }
 
     let mut kv = pair.splitn(2, '=');
-    let name = kv.next()?.trim().to_string();
-    let value = kv.next().unwrap_or("").trim().to_string();
+    let name = crate::helpers::headers::trim_ows(kv.next()?).to_string();
+    let value = crate::helpers::headers::trim_ows(kv.next().unwrap_or("")).to_string();
 
     let mut domain_attr: Option<String> = None;
     let mut path_attr: Option<String> = None;
@@ -420,8 +420,8 @@ pub fn parse_cookie_header(s: &str) -> Vec<(String, String)> {
     s.split(';')
         .filter_map(|piece| {
             let mut kv = piece.splitn(2, '=');
-            let name = kv.next()?.trim().to_string();
-            let value = kv.next().unwrap_or("").trim().to_string();
+            let name = crate::helpers::headers::trim_ows(kv.next()?).to_string();
+            let value = crate::helpers::headers::trim_ows(kv.next().unwrap_or("")).to_string();
             Some((name, value))
         })
         .collect()

--- a/lint-http-rules/src/helpers/domain.rs
+++ b/lint-http-rules/src/helpers/domain.rs
@@ -92,7 +92,7 @@ impl CookieDomainDefect {
 /// Validate a domain name suitable for a cookie `Domain` attribute.
 /// Returns Ok(()) when syntactically valid, or the named defect.
 pub fn validate_cookie_domain(s: &str) -> Result<(), CookieDomainDefect> {
-    let s = s.trim();
+    let s = crate::helpers::headers::trim_ows(s);
     if s.is_empty() {
         return Err(CookieDomainDefect::Empty);
     }

--- a/lint-http-rules/src/helpers/quoted_string.rs
+++ b/lint-http-rules/src/helpers/quoted_string.rs
@@ -286,6 +286,14 @@ pub fn check_quoted_string(val: &str) -> Result<(), QuotedStringDefect> {
 /// used to render on the way out, which put a rendered `String` between the
 /// only reporter and the four defects the production has.
 ///
+/// **The trim is `OWS` and the choice is a reading of `qdtext`.** A
+/// `quoted-string` admits `obs-text` between its quotes, so `"%xA0"` holds a
+/// character the production generates and is *not* an empty value; `SP` and
+/// `HTAB` are the only whitespace this question can have meant. A Unicode-aware
+/// trim answered that `"%xA0"` and `""` are the same value, which is the
+/// difference between a parameter that names nothing and one that names an
+/// octet.
+///
 /// The empty verdict itself belongs to no def: a `quoted-string` holding
 /// nothing derives from § 5.6.4 exactly as written, so what an empty one means
 /// is the *field's* question and each caller answers it. That is the same line
@@ -293,7 +301,7 @@ pub fn check_quoted_string(val: &str) -> Result<(), QuotedStringDefect> {
 /// not exist, and `charset=""`, a well-formed pair of DQUOTEs around no name.
 pub fn quoted_string_inner_trimmed_is_empty(val: &str) -> Result<bool, QuotedStringDefect> {
     // Reuse `unescape_quoted_string` to perform unescaping and validation
-    unescape_quoted_string(val).map(|s| s.trim().is_empty())
+    unescape_quoted_string(val).map(|s| crate::helpers::headers::trim_ows(&s).is_empty())
 }
 
 /// Unescape a well-formed HTTP `quoted-string` value and return its inner contents.
@@ -331,6 +339,18 @@ pub fn unescape_quoted_string(val: &str) -> Result<String, QuotedStringDefect> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// An `obs-text` octet between the quotes is content, so the value is not
+    /// an empty one — the reading the `OWS` trim makes.
+    #[test]
+    fn an_obs_text_octet_is_not_an_empty_quoted_string() {
+        let val: String = std::iter::once('"')
+            .chain(std::iter::once('\u{a0}'))
+            .chain(std::iter::once('"'))
+            .collect();
+        assert_eq!(quoted_string_inner_trimmed_is_empty(&val), Ok(false));
+        assert_eq!(quoted_string_inner_trimmed_is_empty("\" \t\""), Ok(true));
+    }
 
     /// `qdtext` and `quoted-pair` allow different octets after their respective
     /// positions, and a backslash does not widen the set to "anything".

--- a/lint-http-rules/src/helpers/qvalue.rs
+++ b/lint-http-rules/src/helpers/qvalue.rs
@@ -23,9 +23,12 @@
 /// The leading/trailing trim is a tolerance, not the grammar: a `qvalue` has no
 /// whitespace in it anywhere. Every caller trims before asking, so it changes
 /// no verdict today; it is kept because nothing depends on it being strict and
-/// removing it would be a silent trap for a caller that does not trim.
+/// removing it would be a silent trap for a caller that does not trim. It is
+/// `OWS` rather than `str::trim` for the reason every trim in these helpers is:
+/// the callers hold one `char` per octet, and `%xA0` is an octet a sender wrote
+/// rather than padding to be taken off.
 pub fn valid_qvalue(s: &str) -> bool {
-    let s = s.trim();
+    let s = crate::helpers::headers::trim_ows(s);
     // The three-decimal cap and the "1 may only be followed by zeroes" asymmetry are
     // both in the production; neither is arbitrary.
     // cite(RFC 9110 § 12.4.2, label: qvalue grammar): "qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )"

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -7473,7 +7473,7 @@ sources:
     snippet: qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )
     cited_by:
     - file: lint-http-rules/src/helpers/qvalue.rs
-      line: 31
+      line: 34
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
       line: 305
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs


### PR DESCRIPTION
Five modules with one or two trims each: a cookie pair and its attributes, a Domain attribute, a Cache-Control line, a qvalue and the question of whether a quoted-string holds nothing. All are OWS now, because their callers hold one char per octet. The quoted-string one is a reading rather than a sweep: qdtext admits obs-text, so a value holding that octet is not an empty one, which is the difference between a parameter that names nothing and one that names an octet.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
