### PR TITLE
An HTTP/3 authority is read like an HTTP/2 one

### DIFF
--- a/docs/rules/http3_pseudo_headers_valid.md
+++ b/docs/rules/http3_pseudo_headers_valid.md
@@ -24,6 +24,9 @@ For schemes with a mandatory authority component (including `http` and `https`),
 - [RFC 9114 §4.3.2](https://www.rfc-editor.org/rfc/rfc9114.html#section-4.3.2): Response Pseudo-Header Fields
 - [RFC 9114 §4.4](https://www.rfc-editor.org/rfc/rfc9114.html#section-4.4): The CONNECT Method
 - [RFC 9110 §7.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.1): Determining the Target Resource (asterisk-form request target)
+- [RFC 3986 §3.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.1): Scheme — `scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`, the name before the first colon
+- [RFC 3986 §3.2.2](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.2): Host — `host = IP-literal / IPv4address / reg-name`, where the square brackets of the IP literal are the only ones the URI syntax admits anywhere
+- [RFC 3986 §3.2.3](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.3): Port — `port = *DIGIT`, which has no lower bound, no upper bound, and admits the empty string
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
+++ b/lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
@@ -4,8 +4,41 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::uri::{
+    host_and_port, scheme_name, RFC_3986_3_1, RFC_3986_3_2_2, RFC_3986_3_2_3,
+    URI_HOST_BRACKET_FORBIDDEN, URI_HOST_CHARACTER_FORBIDDEN, URI_HOST_CLOSING_BRACKET_MISSING,
+    URI_HOST_IP_LITERAL_MALFORMED, URI_PORT_CHARACTER_FORBIDDEN, URI_SCHEME_CHARACTER_FORBIDDEN,
+    URI_SCHEME_EMPTY, URI_SCHEME_LEADING_LETTER_MISSING,
+};
+use crate::violations::ViolationDef;
 
 pub struct Http3PseudoHeadersValid;
+
+/// The authority's and the scheme's defects, which is all this rule borrows —
+/// the same eight the HTTP/2 twin declares, for the same values.
+///
+/// § 4.3.1 conveys the authority portion of the target URI and the scheme
+/// portion of the request target; neither is a production this document writes,
+/// so a bracket, a host character, a port digit or a scheme's first letter is
+/// the same defect here, in a `Host` field and in an HTTP/2 request. **The two
+/// version rules had read the same value to different depths**: the twin has
+/// measured this authority against `uri-host [ ":" port ]` since it was
+/// converted, and this one only ever looked for an `@`.
+///
+/// Everything else here is about *which* pseudo-header a message carries and
+/// where — a missing `:method`, a CONNECT with no authority, an asterisk target
+/// on a method that may not use one. None of that is a defect of a production,
+/// and the documents that require it write no grammar to name it after.
+static DECLARED: &[&ViolationDef] = &[
+    &URI_HOST_CLOSING_BRACKET_MISSING,
+    &URI_HOST_IP_LITERAL_MALFORMED,
+    &URI_HOST_BRACKET_FORBIDDEN,
+    &URI_HOST_CHARACTER_FORBIDDEN,
+    &URI_PORT_CHARACTER_FORBIDDEN,
+    &URI_SCHEME_EMPTY,
+    &URI_SCHEME_LEADING_LETTER_MISSING,
+    &URI_SCHEME_CHARACTER_FORBIDDEN,
+];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -79,7 +112,14 @@ severity = "error"
             RFC_9114_4_3_2,
             RFC_9114_4_4,
             RFC_9110_7_1,
+            RFC_3986_3_1,
+            RFC_3986_3_2_2,
+            RFC_3986_3_2_3,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -224,6 +264,31 @@ impl Rule for Http3PseudoHeadersValid {
                             crate::helpers::shown::shown_in_finding(&shown)
                         )));
                 }
+
+                // `uri-host [ ":" port ]` is one question with one answer, and
+                // the shared reader is where it lives — the same call the HTTP/2
+                // twin makes on the same value. § 4.4 names the two components
+                // and writes neither, so the bracket, the address inside it and
+                // the port's digits answer to RFC 3986.
+                // cite(RFC 9114 § 4.4): "The :authority pseudo-header field contains the host and port to connect to"
+                if let Some(authority) = crate::helpers::uri::extract_authority_from_request_target(
+                    uri_trimmed,
+                )
+                .filter(|_| crate::helpers::uri::scheme_authority_marker(uri_trimmed).is_none())
+                {
+                    if let Err(defect) =
+                        crate::helpers::uri::validate_host_and_optional_port(&authority)
+                    {
+                        return Some(ctx.report_with(
+                            host_and_port(defect),
+                            format!(
+                                "HTTP/3 CONNECT ':authority' '{}' is not a host and port: {}",
+                                crate::helpers::shown::shown_in_finding(&authority),
+                                defect.message()
+                            ),
+                        ));
+                    }
+                }
             } else {
                 // Non-CONNECT: the request-target is either the asterisk-form (OPTIONS
                 // only) or a path. RFC 9110 § 7.1 permits "*" for OPTIONS and forbids it
@@ -280,17 +345,52 @@ impl Rule for Http3PseudoHeadersValid {
                 // (RFC 3986 § 3.2.1, at the shared helper).
                 // cite(RFC 9114 § 4.3.1): "The authority MUST NOT include the deprecated userinfo subcomponent for URIs of scheme "http" or "https"."
                 if let Some(marker) = crate::helpers::uri::scheme_authority_marker(uri_trimmed) {
+                    // The scheme is the characters before the marker, and the
+                    // helper carries the production. Nothing here asks whether it
+                    // is one anybody serves — this pseudo-header is not
+                    // restricted to http and https — only whether it is a scheme
+                    // name at all, which is the reading the twin already makes.
+                    // cite(RFC 9114 § 4.3.1): "Contains the scheme portion of the target URI (Section 3.1 of [URI])."
+                    if let Some(defect) = crate::helpers::uri::scheme_if_present(uri_trimmed) {
+                        return Some(ctx.report_with(
+                            scheme_name(defect),
+                            format!(
+                                "Request target's scheme is not a scheme name: {}",
+                                defect.message()
+                            ),
+                        ));
+                    }
+
                     let scheme = &uri_trimmed[..marker];
-                    if let Some(authority) = authority.filter(|a| a.contains('@')) {
+
+                    if let Some(authority) = authority.as_ref().filter(|a| a.contains('@')) {
                         if scheme.eq_ignore_ascii_case("http")
                             || scheme.eq_ignore_ascii_case("https")
                         {
-                            let shown = crate::helpers::uri::userinfo_password_withheld(&authority)
-                                .unwrap_or(authority);
+                            let shown = crate::helpers::uri::userinfo_password_withheld(authority)
+                                .unwrap_or_else(|| authority.clone());
                             return Some(self.cited(&RFC_9114_4_3_1, ctx.severity, format!(
                                     "HTTP/3 ':authority' '{}' of an '{scheme}' target includes the deprecated userinfo subcomponent and its '@' delimiter",
                                     crate::helpers::shown::shown_in_finding(&shown)
                                 )));
+                        }
+                    }
+
+                    // The same `uri-host [ ":" port ]` reading the CONNECT branch
+                    // makes, on the authority this target reassembled.
+                    // cite(RFC 9114 § 4.3.1): "Contains the authority portion of the target URI (Section 3.2 of [URI])."
+                    if let Some(ref authority) = authority {
+                        if let Err(defect) =
+                            crate::helpers::uri::validate_host_and_optional_port(authority)
+                        {
+                            return Some(ctx.report_with(
+                                host_and_port(defect),
+                                format!(
+                                    "HTTP/3 ':authority' '{}' is not a host and port: {}",
+                                    crate::helpers::shown::shown_in_finding(authority),
+                                    defect.message()
+                                ),
+                            ));
                         }
                     }
                 }
@@ -345,6 +445,51 @@ mod tests {
             resp.version = "HTTP/3.0".into();
         }
         tx
+    }
+
+    /// The authority and the scheme answer to the same ids the HTTP/2 twin
+    /// reports, on the same values — the reading this rule was missing.
+    #[rstest]
+    #[case("https://exa mple.com/p", "uri_host_character_forbidden")]
+    #[case("https://[::1/p", "uri_host_closing_bracket_missing")]
+    #[case("https://example.com:80a/p", "uri_port_character_forbidden")]
+    #[case("1https://example.com/p", "uri_scheme_leading_letter_missing")]
+    fn an_authority_or_scheme_defect_answers_to_its_production(
+        #[case] target: &str,
+        #[case] expected: &str,
+    ) {
+        let rule = Http3PseudoHeadersValid;
+        let mut tx = make_h3_transaction();
+        tx.request.method = "GET".into();
+        tx.request.uri = target.into();
+
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .expect("a finding");
+        assert_eq!(v.violation, expected, "{}", v.message);
+    }
+
+    /// A CONNECT's authority is measured too, and its port is where the twin
+    /// looks first.
+    #[rstest]
+    fn a_connect_authority_is_measured_against_the_production() {
+        let rule = Http3PseudoHeadersValid;
+        let mut tx = make_h3_transaction();
+        tx.request.method = "CONNECT".into();
+        tx.request.uri = "example.com:80a".into();
+
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .expect("a finding");
+        assert_eq!(v.violation, "uri_port_character_forbidden", "{}", v.message);
     }
 
     // --- :method pseudo-header required ---

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -6157,7 +6157,7 @@ sources:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 453
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 231
+      line: 296
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 330
   - label: http2_pseudo_headers_valid (2)
@@ -6167,7 +6167,7 @@ sources:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 454
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 232
+      line: 297
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 301
   - label: http2_pseudo_headers_valid (3)
@@ -10563,7 +10563,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 415
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 256
+      line: 321
   - label: host_and_authority_consistent (3)
     section: § 4.3.1
     snippet: If these fields are present, they MUST NOT be empty.
@@ -10613,39 +10613,53 @@ sources:
     snippet: All HTTP/3 requests MUST include exactly one value for the :method, :scheme, and :path pseudo-header fields, unless the request is a CONNECT request; see Section 4.4.
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 163
+      line: 203
   - label: http3_pseudo_headers_valid (2)
+    section: § 4.3.1
+    snippet: Contains the authority portion of the target URI (Section 3.2 of [URI]).
+    cited_by:
+    - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
+      line: 381
+  - label: http3_pseudo_headers_valid (3)
+    section: § 4.3.1
+    snippet: Contains the scheme portion of the target URI (Section 3.1 of [URI]).
+    cited_by:
+    - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
+      line: 353
+  - label: http3_pseudo_headers_valid (4)
     section: § 4.3.1
     snippet: The authority MUST NOT include the deprecated userinfo subcomponent for URIs of scheme "http" or "https".
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 281
-  - label: http3_pseudo_headers_valid (3)
+      line: 346
+  - label: http3_pseudo_headers_valid (5)
     section: § 4.3.1
     snippet: This pseudo-header field MUST NOT be empty for "http" or "https" URIs; "http" or "https" URIs that do not contain a path component MUST include a value of / (ASCII 0x2f).
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 240
-  - label: http3_pseudo_headers_valid (4)
+      line: 305
+  - label: http3_pseudo_headers_valid (6)
     section: § 4.3.2
     snippet: For responses, a single ":status" pseudo-header field is defined that carries the HTTP status code; see Section 15 of [HTTP].
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 314
-  - label: http3_pseudo_headers_valid (5)
+      line: 414
+  - label: http3_pseudo_headers_valid (7)
     section: § 4.3.2
     snippet: This pseudo-header field MUST be included in all responses; otherwise, the response is malformed (see Section 4.1.2).
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 315
-  - label: http3_pseudo_headers_valid (6)
+      line: 415
+  - label: http3_pseudo_headers_valid (8)
     section: § 4.4
     snippet: The :authority pseudo-header field contains the host and port to connect to
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 179
+      line: 219
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 215
+      line: 255
+    - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
+      line: 273
   - label: http3_settings_frame
     section: § 11.2.2
     snippet: The entries in Table 3 are registered by this document


### PR DESCRIPTION
The two version rules read the same value to different depths: the HTTP/2 twin has measured its authority against uri-host [ ":" port ] and its target's scheme against the scheme production since it was converted, while this one only ever looked for an '@'. Both readings are here now, on both the CONNECT and the non-CONNECT branch, under the eight ids the twin already declares.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
