### PR TITLE
An origin reader answers with its defect

### DIFF
--- a/docs/rules/origin_matching_for_cors.md
+++ b/docs/rules/origin_matching_for_cors.md
@@ -26,6 +26,8 @@ This check applies to server responses (RuleScope::Server).
 - [RFC 6454](https://www.rfc-editor.org/rfc/rfc6454.html): The Web Origin Concept
 - [Fetch §4.10](https://fetch.spec.whatwg.org/#concept-cors-check): Fetch CORS check — the response origin must byte-match the request `Origin` (or be `*` for a non-credentialed request); this rule's matching logic lives here (two of its three cites)
 - [MDN Access-Control-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin): Access-Control-Allow-Origin
+- [RFC 3986 §2](https://www.rfc-editor.org/rfc/rfc3986.html#section-2): Characters — the limited set a URI is composed from, every other octet being percent-encoded before the reference is formed
+- [RFC 3986 §3.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.1): Scheme — `scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`, the name before the first colon
 
 ## Configuration
 

--- a/docs/rules/request_origin_header_present_for_cors.md
+++ b/docs/rules/request_origin_header_present_for_cors.md
@@ -20,6 +20,8 @@ The rule validates that `Origin` is present where required and that its value is
 - [RFC 6454 §7.1](https://www.rfc-editor.org/rfc/rfc6454.html#section-7.1): Origin header field syntax the value is validated against (`serialized-origin` / `null`)
 - [Fetch §3.2](https://fetch.spec.whatwg.org/#origin-header): Origin header — used for CORS fetches and any request whose method is neither GET nor HEAD (where both inline cites resolve)
 - [MDN Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Origin): Origin
+- [RFC 3986 §2](https://www.rfc-editor.org/rfc/rfc3986.html#section-2): Characters — the limited set a URI is composed from, every other octet being percent-encoded before the reference is formed
+- [RFC 3986 §3.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.1): Scheme — `scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`, the name before the first colon
 
 ## Configuration
 

--- a/lint-http-rules/src/helpers/uri.rs
+++ b/lint-http-rules/src/helpers/uri.rs
@@ -357,16 +357,60 @@ pub fn extract_origin_if_absolute(s: &str) -> Option<String> {
     Some(origin)
 }
 
+/// Why an `Origin` field value derives from neither alternative of
+/// `origin-list-or-null`.
+///
+/// The rendered `Option<String>` this replaced carried four sentences, and one
+/// of them — *"Invalid scheme in Origin"* — was a [`SchemeNameDefect`] that had
+/// already been typed and was then thrown away at the door. That is 2.5's
+/// correction in miniature: a `String` between a typed reader and its two
+/// callers hides which production was broken, and the catalogue cannot name
+/// what it cannot see.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OriginDefect<'a> {
+    /// A `/` after the authority. `serialized-origin = scheme "://" host [ ":"
+    /// port ]` has no path component at all, which is the whole point of the
+    /// field: an origin says where a request came from without saying what it
+    /// was reading. No production is broken by the slash — the value simply
+    /// derives from a different rule of RFC 3986 — so this stays the field's own
+    /// finding.
+    PathPresent,
+    /// The characters before the `://` are not a scheme name.
+    Scheme(SchemeNameDefect<'a>),
+    /// A character no part of a URI is composed from.
+    Character(char),
+    /// Neither `null` nor anything a `serialized-origin` generates: no `://`
+    /// at all, or an authority the shared predicate refuses. **Deriving from
+    /// none of my alternatives is what the catalogue cannot name**, which is why
+    /// this variant carries no id and the two callers word it themselves.
+    NotSerialized,
+}
+
+impl OriginDefect<'_> {
+    /// The finding fragment.
+    pub fn message(self) -> String {
+        match self {
+            Self::PathPresent => "Origin must not include a path".to_string(),
+            Self::Scheme(defect) => format!("Invalid scheme in Origin: {}", defect.message()),
+            Self::Character(c) => format!(
+                "Origin holds {}, which no part of a URI is composed from",
+                crate::helpers::shown::describe_char(c)
+            ),
+            Self::NotSerialized => "Origin is not a valid serialized origin".to_string(),
+        }
+    }
+}
+
 /// Validate an `Origin` header value. Accepts `null` or a serialized origin
-/// of the form `scheme://host[:port]`. Returns `None` if valid or
-/// `Some(msg)` describing the problem.
-pub fn validate_origin_value(s: &str) -> Option<String> {
+/// of the form `scheme://host[:port]`, and answers with the typed defect
+/// otherwise.
+pub fn validate_origin_value(s: &str) -> Result<(), OriginDefect<'_>> {
     let s_trim = trim_ows(s);
     // The `%x6E %x75 %x6C %x6C` hex literals spell lowercase `null` byte-for-byte,
     // so the comparison is case-sensitive.
     // cite(RFC 6454 § 7.1): "origin-list-or-null = %x6E %x75 %x6C %x6C / origin-list"
     if s_trim == "null" {
-        return None;
+        return Ok(());
     }
     // Must be an origin (absolute with no path). The grammar has no path component,
     // which is the whole point of the header: an origin reveals where a request came
@@ -375,10 +419,10 @@ pub fn validate_origin_value(s: &str) -> Option<String> {
     if let Some(colon_pos) = scheme_authority_marker(s_trim) {
         // no path allowed
         if s_trim[colon_pos + 3..].contains('/') {
-            return Some("Origin must not include a path".into());
+            return Err(OriginDefect::PathPresent);
         }
-        if scheme_if_present(s_trim).is_some() {
-            return Some("Invalid scheme in Origin".into());
+        if let Some(defect) = scheme_if_present(s_trim) {
+            return Err(OriginDefect::Scheme(defect));
         }
         // The alphabet, before the authority question below it. This was
         // `contains_whitespace`, one sixth of the same set, so an `Origin` value
@@ -392,10 +436,7 @@ pub fn validate_origin_value(s: &str) -> Option<String> {
         //
         // cite(RFC 3986 § 2): "A URI is composed from a limited set of characters consisting of digits, letters, and a few graphic symbols."
         if let Some(c) = find_non_uri_char(s_trim) {
-            return Some(format!(
-                "Origin holds {}, which no part of a URI is composed from",
-                crate::helpers::shown::describe_char(c)
-            ));
+            return Err(OriginDefect::Character(c));
         }
         // The authority itself — host present, bracketed IPv6 well formed, port
         // numeric and in range, no userinfo — is checked by the shared
@@ -404,12 +445,12 @@ pub fn validate_origin_value(s: &str) -> Option<String> {
         // host reports the same generic reason, so callers that inspect the
         // string do not need to handle multiple error forms.
         if !crate::helpers::uri::is_valid_serialized_origin(s_trim) {
-            return Some("Origin is not a valid serialized origin".into());
+            return Err(OriginDefect::NotSerialized);
         }
-        return None;
+        return Ok(());
     }
 
-    Some("Origin is not a valid serialized origin".into())
+    Err(OriginDefect::NotSerialized)
 }
 
 /// The authority component of the **target URI**, which is not always in the
@@ -2354,30 +2395,40 @@ mod tests {
         let padded: String = std::iter::once('\u{a0}')
             .chain("https://example.com".chars())
             .collect();
-        assert!(validate_origin_value(&padded).is_some());
+        assert!(validate_origin_value(&padded).is_err());
         assert!(!is_valid_serialized_origin(&padded));
         // The `OWS` a field value may carry beside its content is still taken.
-        assert!(validate_origin_value(" https://example.com\t").is_none());
+        assert!(validate_origin_value(" https://example.com\t").is_ok());
     }
 
     #[test]
     fn validate_origin_value_cases() {
-        assert!(validate_origin_value("null").is_none());
-        assert!(validate_origin_value("NULL").is_some());
-        assert!(validate_origin_value("https://example.com").is_none());
-        assert!(validate_origin_value("http:///bad").is_some());
-        assert!(validate_origin_value("https://exa mple").is_some());
-        assert!(validate_origin_value("invalid-origin").is_some());
+        assert!(validate_origin_value("null").is_ok());
+        assert!(validate_origin_value("NULL").is_err());
+        assert!(validate_origin_value("https://example.com").is_ok());
+        assert!(validate_origin_value("http:///bad").is_err());
+        assert!(validate_origin_value("https://exa mple").is_err());
+        assert!(validate_origin_value("invalid-origin").is_err());
         // The authority is validated too, not merely required to be non-empty.
-        assert!(validate_origin_value("http://host:notaport").is_some());
-        assert!(validate_origin_value("https://user@example.com").is_some());
+        assert!(validate_origin_value("http://host:notaport").is_err());
+        assert!(validate_origin_value("https://user@example.com").is_err());
         // A port outside the sixteen-bit namespace is the finding; `0` is
         // inside it, reserved rather than invalid.
-        assert!(validate_origin_value("http://example.com:65536").is_some());
-        assert!(validate_origin_value("http://example.com:0").is_none());
-        // invalid scheme in Origin
-        let m = validate_origin_value("1http://example.com").unwrap();
-        assert!(m.contains("Invalid scheme"));
+        assert!(validate_origin_value("http://example.com:65536").is_err());
+        assert!(validate_origin_value("http://example.com:0").is_ok());
+    }
+
+    /// The four variants, each named and each rendered — the split between them
+    /// is a decision rather than a coincidence, which is why the messages are
+    /// pinned beside the variants.
+    #[test]
+    fn each_origin_defect_names_the_production_it_broke() {
+        // The scheme half was already typed and the rendered `String` this
+        // enum replaced threw the type away at the door.
+        let m = validate_origin_value("1http://example.com")
+            .expect_err("a leading digit is no scheme name");
+        assert!(matches!(m, OriginDefect::Scheme(_)), "{m:?}");
+        assert!(m.message().contains("Invalid scheme"), "{}", m.message());
 
         // This function names the path itself, because § 3.2's *first*
         // terminator is the one an `Origin` sender most plausibly wrote by
@@ -2389,9 +2440,10 @@ mod tests {
         // running at. Neither could see a character outside the URI set that was
         // not whitespace, so `<` reached the serialized-origin predicate — which
         // asks where the authority *ends*, not what it may hold — and passed.
-        let angle = validate_origin_value("https://exa<mple.com").unwrap();
+        let angle = validate_origin_value("https://exa<mple.com").expect_err("no URI holds '<'");
+        assert_eq!(angle, OriginDefect::Character('<'));
         assert_eq!(
-            angle,
+            angle.message(),
             "Origin holds '<', which no part of a URI is composed from"
         );
         assert_eq!(extract_origin_if_absolute("http://exa<mple.com/p"), None);
@@ -2400,12 +2452,14 @@ mod tests {
             None
         );
 
-        let path = validate_origin_value("https://example.com/p").unwrap();
-        assert_eq!(path, "Origin must not include a path");
+        let path = validate_origin_value("https://example.com/p")
+            .expect_err("a serialized origin has no path component");
+        assert_eq!(path, OriginDefect::PathPresent);
+        assert_eq!(path.message(), "Origin must not include a path");
         for after in ["https://example.com?x=1", "https://example.com#frag"] {
             assert_eq!(
-                validate_origin_value(after).unwrap(),
-                "Origin is not a valid serialized origin",
+                validate_origin_value(after).expect_err("neither alternative"),
+                OriginDefect::NotSerialized,
                 "for {after}"
             );
         }
@@ -2511,11 +2565,12 @@ mod tests {
 
     #[test]
     fn validate_origin_missing_host_reports_missing() {
-        let m = validate_origin_value("http://").unwrap();
-        // we now return the generic "not a valid serialized origin" message for
-        // missing authority, rather than a specialized one; callers that care
-        // about details should inspect the string content appropriately.
-        assert!(m.contains("not a valid serialized origin"));
+        // An authority the shared predicate refuses is the same verdict as no
+        // `://` at all: the value derives from neither alternative, and that is
+        // one variant rather than a specialized sentence per way of failing.
+        let m = validate_origin_value("http://").expect_err("an origin needs a host");
+        assert_eq!(m, OriginDefect::NotSerialized);
+        assert!(m.message().contains("not a valid serialized origin"));
     }
 
     #[test]

--- a/lint-http-rules/src/rules/origin_matching_for_cors.rs
+++ b/lint-http-rules/src/rules/origin_matching_for_cors.rs
@@ -4,6 +4,26 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::uri::{
+    origin_defect, RFC_3986_2, RFC_3986_3_1, URI_CHARACTER_FORBIDDEN,
+    URI_SCHEME_CHARACTER_FORBIDDEN, URI_SCHEME_EMPTY, URI_SCHEME_LEADING_LETTER_MISSING,
+};
+use crate::violations::ViolationDef;
+
+/// The two productions an `Origin` borrows, and no more.
+///
+/// `origin-list-or-null = %x6E %x75 %x6C %x6C / origin-list` is RFC 6454's, and
+/// what a `serialized-origin` is made of is RFC 3986's: a scheme name, and the
+/// alphabet a URI is composed from. The other two verdicts the shared reader
+/// gives — a path where the production has no path component, and a value
+/// deriving from neither alternative — stay this rule's own, because *derives
+/// from none of my alternatives* is the finding no subject can hold.
+static DECLARED: &[&ViolationDef] = &[
+    &URI_SCHEME_EMPTY,
+    &URI_SCHEME_LEADING_LETTER_MISSING,
+    &URI_SCHEME_CHARACTER_FORBIDDEN,
+    &URI_CHARACTER_FORBIDDEN,
+];
 
 pub struct OriginMatchingForCors;
 
@@ -49,7 +69,17 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[RFC_6454, FETCH_4_10, MDN_ACCESS_CONTROL_ALLOW_ORIGIN]
+        &[
+            RFC_6454,
+            FETCH_4_10,
+            MDN_ACCESS_CONTROL_ALLOW_ORIGIN,
+            RFC_3986_2,
+            RFC_3986_3_1,
+        ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -116,16 +146,21 @@ impl Rule for OriginMatchingForCors {
                 .next()?;
             let origin = crate::helpers::headers::trim_ows(&origin_line);
 
-            // Validate origin syntax using shared helper (handles "null" and serialized origins).
-            if let Some(reason) = crate::helpers::uri::validate_origin_value(origin) {
-                return Some(self.violation(
-                    ctx.severity,
-                    format!(
-                        "Invalid Origin header value '{}': {}",
-                        crate::helpers::shown::shown_in_finding(origin),
-                        reason
-                    ),
-                ));
+            // Validate origin syntax using shared helper (handles "null" and
+            // serialized origins). Two of its four verdicts are productions the
+            // catalogue names — the scheme and the URI alphabet — and two are
+            // this field's own: a path where the production has no component for
+            // one, and a value deriving from neither alternative.
+            if let Err(defect) = crate::helpers::uri::validate_origin_value(origin) {
+                let message = format!(
+                    "Invalid Origin header value '{}': {}",
+                    crate::helpers::shown::shown_in_finding(origin),
+                    defect.message()
+                );
+                return Some(match origin_defect(defect) {
+                    Some(def) => ctx.report_with(def, message),
+                    None => self.violation(ctx.severity, message),
+                });
             }
 
             let resp = tx.response.as_ref()?;
@@ -227,6 +262,34 @@ mod tests {
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
         assert!(v.is_none());
+    }
+
+    /// The two productions the shared reader borrows report under their own
+    /// ids; the two verdicts about the field's own grammar do not.
+    #[rstest]
+    #[case("1http://example.com", Some("uri_scheme_leading_letter_missing"))]
+    #[case("https://exa<mple.com", Some("uri_character_forbidden"))]
+    #[case("https://example.com/p", None)]
+    #[case("invalid-origin", None)]
+    fn an_origin_defect_reports_under_the_production_it_broke(
+        #[case] origin: &str,
+        #[case] expected: Option<&str>,
+    ) {
+        let rule = OriginMatchingForCors;
+        let mut tx = make_test_transaction_with_response(
+            200,
+            &[("access-control-allow-origin", "https://example.com")],
+        );
+        tx.request.headers = make_headers_from_pairs(&[("origin", origin)]);
+
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .expect("a finding");
+        assert_eq!(v.violation, expected.unwrap_or_default(), "{}", v.message);
     }
 
     #[test]

--- a/lint-http-rules/src/rules/request_origin_header_present_for_cors.rs
+++ b/lint-http-rules/src/rules/request_origin_header_present_for_cors.rs
@@ -4,6 +4,22 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::uri::{
+    origin_defect, RFC_3986_2, RFC_3986_3_1, URI_CHARACTER_FORBIDDEN,
+    URI_SCHEME_CHARACTER_FORBIDDEN, URI_SCHEME_EMPTY, URI_SCHEME_LEADING_LETTER_MISSING,
+};
+use crate::violations::ViolationDef;
+
+/// The same four `origin_matching_for_cors` declares, read from the other side
+/// of the exchange: one rule asks whether the response echoed the `Origin`, the
+/// other whether the request carried one, and both measure the same value
+/// against the same two RFC 3986 productions.
+static DECLARED: &[&ViolationDef] = &[
+    &URI_SCHEME_EMPTY,
+    &URI_SCHEME_LEADING_LETTER_MISSING,
+    &URI_SCHEME_CHARACTER_FORBIDDEN,
+    &URI_CHARACTER_FORBIDDEN,
+];
 
 pub struct RequestOriginHeaderPresentForCors;
 
@@ -50,7 +66,17 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[RFC_6454_7_1, FETCH_3_2, MDN_ORIGIN]
+        &[
+            RFC_6454_7_1,
+            FETCH_3_2,
+            MDN_ORIGIN,
+            RFC_3986_2,
+            RFC_3986_3_1,
+        ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -115,13 +141,14 @@ impl Rule for RequestOriginHeaderPresentForCors {
                     .next()
                 {
                     Some(origin_val) => {
-                        if let Some(err) = crate::helpers::uri::validate_origin_value(
+                        if let Err(defect) = crate::helpers::uri::validate_origin_value(
                             crate::helpers::headers::trim_ows(&origin_val),
                         ) {
-                            return Some(self.violation(
-                                ctx.severity,
-                                format!("Origin header invalid: {}", err),
-                            ));
+                            let message = format!("Origin header invalid: {}", defect.message());
+                            return Some(match origin_defect(defect) {
+                                Some(def) => ctx.report_with(def, message),
+                                None => self.violation(ctx.severity, message),
+                            });
                         }
                     }
                     None => {

--- a/lint-http-rules/src/violations/uri.rs
+++ b/lint-http-rules/src/violations/uri.rs
@@ -28,7 +28,7 @@
 //! rule that can name the transport.
 
 use crate::helpers::uri::{
-    HostAndPortDefect, PercentEncodingDefect, SchemeNameDefect, UriHostDefect,
+    HostAndPortDefect, OriginDefect, PercentEncodingDefect, SchemeNameDefect, UriHostDefect,
 };
 use crate::lint::Severity;
 use crate::rules::SpecRef;
@@ -248,6 +248,24 @@ pub fn scheme_name(defect: SchemeNameDefect<'_>) -> &'static ViolationDef {
         SchemeNameDefect::Empty => &URI_SCHEME_EMPTY,
         SchemeNameDefect::DoesNotBeginWithLetter(_) => &URI_SCHEME_LEADING_LETTER_MISSING,
         SchemeNameDefect::BadCharacter { .. } => &URI_SCHEME_CHARACTER_FORBIDDEN,
+    }
+}
+
+/// The defect a parsed [`OriginDefect`] reports as, where the catalogue names
+/// one.
+///
+/// Two of the four variants have no id and the reason is the same for both: a
+/// path after the authority and a value deriving from neither `null` nor a
+/// serialized origin are statements about *this field's* production, and
+/// "derives from none of my alternatives" is the finding no subject has ever
+/// been able to hold (2.63's rule, and `Access-Control-Allow-Origin`'s reading
+/// one commit later). The other two are somebody else's productions: the scheme
+/// name RFC 3986 § 3.1 writes, and the alphabet § 2 draws.
+pub fn origin_defect(defect: OriginDefect<'_>) -> Option<&'static ViolationDef> {
+    match defect {
+        OriginDefect::Scheme(defect) => Some(scheme_name(defect)),
+        OriginDefect::Character(_) => Some(&URI_CHARACTER_FORBIDDEN),
+        OriginDefect::PathPresent | OriginDefect::NotSerialized => None,
     }
 }
 

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -16,7 +16,7 @@ sources:
     - file: lint-http-rules/src/rules/access_control_allow_credentials_when_origin.rs
       line: 172
     - file: lint-http-rules/src/rules/origin_matching_for_cors.rs
-      line: 171
+      line: 206
   - label: CORS check reads the field
     section: § 4.10
     snippet: Let credentials be the result of getting `Access-Control-Allow-Credentials` from response’s header list.
@@ -30,7 +30,7 @@ sources:
     - file: lint-http-rules/src/rules/access_control_allow_origin_valid.rs
       line: 136
     - file: lint-http-rules/src/rules/origin_matching_for_cors.rs
-      line: 146
+      line: 181
   - label: cross_origin_resource_policy_valid
     section: § 3.7
     snippet: Cross-Origin-Resource-Policy = %s"same-origin" / %s"same-site" / %s"cross-origin" ; case-sensitive
@@ -48,25 +48,25 @@ sources:
     snippet: The origin serialization defined here is more constrained than [RFC3986]’s grammar in two substantial ways.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1365
+      line: 1406
   - label: lint-http-rules/src/helpers/uri.rs (2)
     section: § 3.2
     snippet: This supplants the definition in The Web Origin Concept
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1360
+      line: 1401
   - label: lint-http-rules/src/helpers/uri.rs (3)
     section: § 3.2
     snippet: serialized-origin = serialized-scheme "://" serialized-host [ ":" serialized-port ]
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1359
+      line: 1400
   - label: origin_matching_for_cors
     section: § 4.10
     snippet: If the result of byte-serializing a request origin with request is not origin, then return failure.
     cited_by:
     - file: lint-http-rules/src/rules/origin_matching_for_cors.rs
-      line: 187
+      line: 222
   - label: refresh_header_syntax
     section: § 2.2.2
     snippet: Return the values of all headers in list whose name is a byte-case-insensitive match for name, separated from each other by 0x2C 0x20
@@ -78,13 +78,13 @@ sources:
     snippet: It is used for all HTTP fetches whose request’s response tainting is "cors", as well as those where request’s method is neither `GET` nor `HEAD`.
     cited_by:
     - file: lint-http-rules/src/rules/request_origin_header_present_for_cors.rs
-      line: 103
+      line: 129
   - label: request_origin_header_present_for_cors (2)
     section: § 3.2
     snippet: The `Origin` request header indicates where a fetch originates from.
     cited_by:
     - file: lint-http-rules/src/rules/request_origin_header_present_for_cors.rs
-      line: 147
+      line: 174
   - label: sec_fetch_dest_value_valid
     section: § 2.2.5
     snippet: 'A destination type is one of: the empty string, "audio", "audioworklet", "document", "embed", "font", "frame", "iframe", "image", "json", "manifest", "object", "paintworklet", "report", "script", "serviceworker", "sharedworker", "style", "text", "track", "video", "webidentity", "worker", or "xslt".'
@@ -348,7 +348,7 @@ sources:
     snippet: A URL’s port is either null or a 16-bit unsigned integer that identifies a networking port.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1425
+      line: 1466
   - label: refresh_header_syntax
     section: § 1.1
     snippet: A code point is found that is not a URL unit.
@@ -1170,7 +1170,7 @@ sources:
     - file: lint-http-rules/src/helpers/ipv6.rs
       line: 49
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1193
+      line: 1234
     - file: lint-http-rules/src/rules/host_header.rs
       line: 257
   - label: lint-http-rules/src/helpers/ipv6.rs (2)
@@ -1180,7 +1180,7 @@ sources:
     - file: lint-http-rules/src/helpers/ipv6.rs
       line: 50
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1194
+      line: 1235
     - file: lint-http-rules/src/violations/uri.rs
       line: 206
   - label: lint-http-rules/src/helpers/uri.rs
@@ -1190,7 +1190,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 119
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 393
+      line: 437
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
       line: 283
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
@@ -1274,7 +1274,7 @@ sources:
     snippet: URIs that differ in the replacement of an unreserved character with its corresponding percent-encoded US-ASCII octet are equivalent
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 731
+      line: 772
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
       line: 72
   - label: lint-http-rules/src/helpers/uri.rs (10)
@@ -1282,7 +1282,7 @@ sources:
     snippet: percent-encoded octets in the ranges of ALPHA (%41-%5A and %61-%7A), DIGIT (%30-%39), hyphen (%2D), period (%2E), underscore (%5F), or tilde (%7E) should not be created by URI producers and, when found in a URI, should be decoded to their corresponding unreserved characters by URI normalizers
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 818
+      line: 859
   - label: lint-http-rules/src/helpers/uri.rs (11)
     section: § 2.3
     snippet: unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
@@ -1290,19 +1290,19 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 136
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 730
+      line: 771
   - label: lint-http-rules/src/helpers/uri.rs (12)
     section: § 2.4
     snippet: The only exception is for percent-encoded octets corresponding to characters in the unreserved set, which can be decoded at any time.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 817
+      line: 858
   - label: lint-http-rules/src/helpers/uri.rs (13)
     section: § 2.4
     snippet: When a URI is dereferenced, the components and subcomponents significant to the scheme-specific dereferencing process (if any) must be parsed and separated before the percent-encoded octets within those components can be safely decoded, as otherwise the data may be mistaken for component delimiters.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 734
+      line: 775
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
       line: 179
   - label: lint-http-rules/src/helpers/uri.rs (14)
@@ -1316,7 +1316,7 @@ sources:
     snippet: Scheme names consist of a sequence of characters beginning with a letter and followed by any combination of letters, digits, plus ("+"), period ("."), or hyphen ("-").
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 997
+      line: 1038
   - label: lint-http-rules/src/helpers/uri.rs (16)
     section: § 3.1
     snippet: scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
@@ -1324,7 +1324,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 314
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 996
+      line: 1037
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 1077
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
@@ -1348,7 +1348,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 224
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1407
+      line: 1448
   - label: lint-http-rules/src/helpers/uri.rs (18)
     section: § 3.2.1
     snippet: Applications should not render as clear text any data after the first colon (":") character found within a userinfo subcomponent unless the data after the colon is the empty string (indicating no password).
@@ -1374,7 +1374,7 @@ sources:
     snippet: IP-literal = "[" ( IPv6address / IPvFuture  ) "]"
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1072
+      line: 1113
     - file: lint-http-rules/src/violations/uri.rs
       line: 178
     - file: lint-http-rules/src/violations/uri.rs
@@ -1384,15 +1384,15 @@ sources:
     snippet: IPvFuture  = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1163
+      line: 1204
   - label: host grammar
     section: § 3.2.2
     snippet: host        = IP-literal / IPv4address / reg-name
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 519
+      line: 560
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1068
+      line: 1109
   - label: reg-name
     section: § 3.2.2
     snippet: reg-name    = *( unreserved / pct-encoded / sub-delims )
@@ -1400,7 +1400,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 286
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1069
+      line: 1110
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 271
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
@@ -1416,11 +1416,11 @@ sources:
     snippet: The port subcomponent of authority is designated by an optional port number in decimal following the host and delimited from it by a single colon (":") character.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1195
-    - file: lint-http-rules/src/helpers/uri.rs
       line: 1236
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1262
+      line: 1277
+    - file: lint-http-rules/src/helpers/uri.rs
+      line: 1303
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 291
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
@@ -1434,7 +1434,7 @@ sources:
     snippet: URI producers and normalizers should omit the port component and its ":" delimiter if port is empty or if its value would be the same as that of the scheme's default.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1263
+      line: 1304
   - label: pchar
     section: § 3.3
     snippet: pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
@@ -1460,7 +1460,7 @@ sources:
     snippet: A relative reference that begins with two slash characters is termed a network-path reference; such references are rarely used.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 862
+      line: 903
   - label: relative-part
     section: § 4.2
     snippet: relative-part = "//" authority path-abempty / path-absolute / path-noscheme / path-empty
@@ -1482,43 +1482,43 @@ sources:
     snippet: If the base URI has a defined authority component and an empty path, then return a string consisting of "/" concatenated with the reference's path
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 834
+      line: 875
   - label: lint-http-rules/src/helpers/uri.rs (28)
     section: § 5.2.3
     snippet: return a string consisting of the reference's path component appended to all but the last segment of the base URI's path
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 838
+      line: 879
   - label: lint-http-rules/src/helpers/uri.rs (29)
     section: § 5.2.4
     snippet: This is done after the path is extracted from a reference, whether or not the path was relative, in order to remove any invalid or extraneous dot-segments prior to forming the target URI.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 650
+      line: 691
   - label: lint-http-rules/src/helpers/uri.rs (30)
     section: § 5.4.2
     snippet: Some applications fail to separate the reference's query and/or fragment components from the path component before merging it with the base path and removing dot-segments.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 816
+      line: 857
   - label: lint-http-rules/src/helpers/uri.rs (31)
     section: § 5.4.2
     snippet: parsers must remove the dot-segments "." and ".." when they are complete components of a path, but not when they are only part of a segment.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 820
+      line: 861
   - label: lint-http-rules/src/helpers/uri.rs (32)
     section: § 6.2.2
     snippet: Syntax-based normalization includes such techniques as case normalization, percent-encoding normalization, and removal of dot-segments.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 815
+      line: 856
   - label: lint-http-rules/src/helpers/uri.rs (33)
     section: § 6.2.2.1
     snippet: For all URIs, the hexadecimal digits within a percent-encoding triplet (e.g., "%3a" versus "%3A") are case-insensitive and therefore should be normalized to use uppercase letters for the digits A-F.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 733
+      line: 774
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 92
   - label: lint-http-rules/src/helpers/uri.rs (34)
@@ -1526,7 +1526,7 @@ sources:
     snippet: The other generic syntax components are assumed to be case-sensitive unless specifically defined otherwise by the scheme (see Section 6.2.3).
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 821
+      line: 862
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
       line: 402
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
@@ -1536,7 +1536,7 @@ sources:
     snippet: the scheme and host are case-insensitive and therefore should be normalized to lowercase
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 520
+      line: 561
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
       line: 401
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
@@ -1546,13 +1546,13 @@ sources:
     snippet: These URIs should be normalized by decoding any percent-encoded octet that corresponds to an unreserved character, as described in Section 2.3.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 732
+      line: 773
   - label: lint-http-rules/src/helpers/uri.rs (37)
     section: § 6.2.2.3
     snippet: URI normalizers should remove dot-segments by applying the remove_dot_segments algorithm to the path, as described in Section 5.2.4.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 819
+      line: 860
   - label: location_header_uri_valid
     section: § 4.1
     snippet: URI-reference = URI / relative-ref
@@ -2405,7 +2405,7 @@ sources:
     snippet: Reserved port numbers include values at the edges of each range, e.g., 0, 1023, 1024, etc., which may be used to extend these ranges or the overall port number space in the future.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1238
+      line: 1279
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 336
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
@@ -2415,7 +2415,7 @@ sources:
     snippet: TCP, UDP, UDP-Lite, SCTP, and DCCP use 16-bit namespaces for their port number registries.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1237
+      line: 1278
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 335
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
@@ -2428,15 +2428,15 @@ sources:
     snippet: origin-list-or-null = %x6E %x75 %x6C %x6C / origin-list
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 367
+      line: 411
   - label: lint-http-rules/src/helpers/uri.rs (2)
     section: § 7.1
     snippet: serialized-origin = scheme "://" host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 374
+      line: 418
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1361
+      line: 1402
 - label: RFC 6455
   url: https://www.rfc-editor.org/rfc/rfc6455.html
   fragments:
@@ -7527,7 +7527,7 @@ sources:
     snippet: A URI reference is resolved to its absolute form in order to obtain the "target URI".
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 435
+      line: 476
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
       line: 266
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
@@ -7537,7 +7537,7 @@ sources:
     snippet: Host = uri-host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1261
+      line: 1302
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 129
     - file: lint-http-rules/src/rules/host_header.rs
@@ -7549,7 +7549,7 @@ sources:
     snippet: In HTTP/2 [HTTP/2] and HTTP/3 [HTTP/3], the Host header field is, in some cases, supplanted by the ":authority" pseudo-header field of a request's control data.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 437
+      line: 478
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 316
     - file: lint-http-rules/src/rules/host_header.rs
@@ -7561,7 +7561,7 @@ sources:
     snippet: The "Host" header field in a request provides the host and port information from the target URI, enabling the origin server to distinguish among resources while servicing requests for multiple host names.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 436
+      line: 477
   - label: If-None-Match weak comparison
     section: § 13.1.2
     snippet: A recipient MUST use the weak comparison function when comparing entity tags for If-None-Match
@@ -9943,7 +9943,7 @@ sources:
     snippet: A server MUST respond with a 400 (Bad Request) status code to any HTTP/1.1 request message that lacks a Host header field and to any request message that contains more than one Host header field line or a Host header field with an invalid field value.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 441
+      line: 482
     - file: lint-http-rules/src/rules/host_header.rs
       line: 200
   - label: request-target forms
@@ -9951,9 +9951,9 @@ sources:
     snippet: request-target = origin-form / absolute-form / authority-form / asterisk-form
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 473
+      line: 514
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 546
+      line: 587
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 13
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
@@ -9963,19 +9963,19 @@ sources:
     snippet: If the request-target is in authority-form, the target URI's authority component is the request-target.  Otherwise, the target URI's authority component is the field value of the Host header field.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 439
+      line: 480
   - label: lint-http-rules/src/helpers/uri.rs (3)
     section: § 3.3
     snippet: If there is no Host header field or if its field value is empty or invalid, the target URI's authority component is empty.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 440
+      line: 481
   - label: lint-http-rules/src/helpers/uri.rs (4)
     section: § 3.3
     snippet: The target URI is the request-target when the request-target is in absolute-form.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 438
+      line: 479
     - file: lint-http-rules/src/rules/post_creates_resource.rs
       line: 161
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs


### PR DESCRIPTION
validate_origin_value returned a rendered string, and one of its four sentences was a scheme defect that had already been typed and was then thrown away at the door. The enum keeps all four apart: the scheme and the URI alphabet are productions the catalogue names, while a path where the production has no path component and a value deriving from neither alternative stay the two reading rules' own findings.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
