### PR TITLE
A repeated field line is one defect, not thirty

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1295,6 +1295,10 @@ severity = "warn"
 # Weakness indicator is not written W/
 severity = "warn"
 
+[violations.field_line_duplicated]
+# A field is written on more lines than its definition allows
+severity = "warn"
+
 [violations.http_date_malformed]
 # Timestamp derives from no HTTP-date format
 severity = "warn"

--- a/docs/rules/access_control_allow_origin_valid.md
+++ b/docs/rules/access_control_allow_origin_valid.md
@@ -16,6 +16,7 @@ This rule checks that the `Access-Control-Allow-Origin` response header is synta
 - [Fetch §3.3.3](https://fetch.spec.whatwg.org/#http-access-control-allow-origin): `Access-Control-Allow-Origin` carries one value: an echoed origin, `null`, or `*`
 - [Fetch §3.2](https://fetch.spec.whatwg.org/#origin-header): Governing origin syntax: `serialized-origin` ends at its authority, so a path (not even a trailing slash), a query or a fragment all disqualify it; the host inside it is a `reg-name` or a bracketed `IP-literal`, so a character outside those productions or a malformed percent-encoding disqualifies it too; and `origin-or-null`'s `null` is case-sensitive
 - [RFC 6454 §7.1](https://www.rfc-editor.org/rfc/rfc6454.html#section-7.1): Historical origin syntax the non-`*` value is validated against — `serialized-origin = scheme "://" host [ ":" port ]`, and `null` via origin-list-or-null; Fetch §3.2 supplants it
+- [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order — a sender MUST NOT write multiple field lines of one name, in the headers or the trailers, unless at least one alternative of the field's definition allows the lines to be recombined as a comma-separated list
 
 ## Configuration
 

--- a/docs/rules/cross_origin_embedder_policy_valid.md
+++ b/docs/rules/cross_origin_embedder_policy_valid.md
@@ -14,6 +14,7 @@ This rule checks the `Cross-Origin-Embedder-Policy` response header value and en
 
 - [MDN Cross-Origin-Embedder-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Embedder-Policy): Cross-Origin-Embedder-Policy
 - [HTML §7.1.4](https://html.spec.whatwg.org/multipage/browsers.html#cross-origin-embedder-policy): The `Cross-Origin-Embedder-Policy` header — its value is one of the three embedder policy strings `unsafe-none`, `require-corp`, `credentialless`
+- [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order — a sender MUST NOT write multiple field lines of one name, in the headers or the trailers, unless at least one alternative of the field's definition allows the lines to be recombined as a comma-separated list
 
 ## Configuration
 

--- a/docs/rules/cross_origin_opener_policy_valid.md
+++ b/docs/rules/cross_origin_opener_policy_valid.md
@@ -15,6 +15,7 @@ This rule checks the `Cross-Origin-Opener-Policy` response header value and ensu
 - [MDN Cross-Origin-Opener-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Opener-Policy): Cross-Origin-Opener-Policy
 - [HTML §7.1.3.1](https://html.spec.whatwg.org/multipage/browsers.html#the-coop-headers): The `Cross-Origin-Opener-Policy` header is parsed as a single structured-field item (token); `same-origin-plus-COEP` is derived from `same-origin` + a compatible COEP, never set directly
 - [HTML](https://html.spec.whatwg.org/multipage/browsers.html#cross-origin-opener-policies): “Cross-origin opener policies” — the possible opener policy values and their meanings
+- [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order — a sender MUST NOT write multiple field lines of one name, in the headers or the trailers, unless at least one alternative of the field's definition allows the lines to be recombined as a comma-separated list
 
 ## Configuration
 

--- a/docs/rules/cross_origin_resource_policy_valid.md
+++ b/docs/rules/cross_origin_resource_policy_valid.md
@@ -14,6 +14,7 @@ This rule checks the `Cross-Origin-Resource-Policy` response header value and en
 
 - [Fetch §3.7](https://fetch.spec.whatwg.org/#cross-origin-resource-policy-header): `Cross-Origin-Resource-Policy` — the case-sensitive `same-origin`/`same-site`/`cross-origin` grammar, and unrecognized values set to null
 - [MDN Cross-Origin-Resource-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Resource-Policy): Cross-Origin-Resource-Policy
+- [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order — a sender MUST NOT write multiple field lines of one name, in the headers or the trailers, unless at least one alternative of the field's definition allows the lines to be recombined as a comma-separated list
 
 ## Configuration
 

--- a/docs/rules/origin_isolated_header_valid.md
+++ b/docs/rules/origin_isolated_header_valid.md
@@ -16,6 +16,7 @@ Checks the `Origin-Agent-Cluster` response header and ensures it uses the struct
 
 - [HTML §7.1.2](https://html.spec.whatwg.org/multipage/browsers.html#origin-keyed-agent-clusters): `Origin-Agent-Cluster` — a structured-header boolean; only the `?1` true value requests an origin-keyed agent cluster
 - [RFC 9651 §3](https://www.rfc-editor.org/rfc/rfc9651.html#section-3): Structured Headers boolean values (§3–§4)
+- [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order — a sender MUST NOT write multiple field lines of one name, in the headers or the trailers, unless at least one alternative of the field's definition allows the lines to be recombined as a comma-separated list
 
 ## Configuration
 

--- a/docs/rules/origin_matching_for_cors.md
+++ b/docs/rules/origin_matching_for_cors.md
@@ -28,6 +28,7 @@ This check applies to server responses (RuleScope::Server).
 - [MDN Access-Control-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin): Access-Control-Allow-Origin
 - [RFC 3986 §2](https://www.rfc-editor.org/rfc/rfc3986.html#section-2): Characters — the limited set a URI is composed from, every other octet being percent-encoded before the reference is formed
 - [RFC 3986 §3.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.1): Scheme — `scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`, the name before the first colon
+- [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order — a sender MUST NOT write multiple field lines of one name, in the headers or the trailers, unless at least one alternative of the field's definition allows the lines to be recombined as a comma-separated list
 
 ## Configuration
 

--- a/docs/rules/sec_fetch_dest_value_valid.md
+++ b/docs/rules/sec_fetch_dest_value_valid.md
@@ -13,6 +13,7 @@ Validate the `Sec-Fetch-Dest` request header follows the Fetch Metadata specific
 ## Specifications
 
 - [Fetch Metadata §2.1](https://www.w3.org/TR/fetch-metadata/#sec-fetch-dest-header): Fetch Metadata (W3C) — `Sec-Fetch-Dest`: an sf-token whose valid values are Fetch's request destinations
+- [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order — a sender MUST NOT write multiple field lines of one name, in the headers or the trailers, unless at least one alternative of the field's definition allows the lines to be recombined as a comma-separated list
 
 ## Configuration
 

--- a/docs/rules/sec_fetch_mode_value_valid.md
+++ b/docs/rules/sec_fetch_mode_value_valid.md
@@ -13,6 +13,7 @@ Requests that include the `Sec-Fetch-Mode` request header must use one of the ca
 ## Specifications
 
 - [Fetch Metadata §2.2](https://www.w3.org/TR/fetch-metadata/#sec-fetch-mode-header): Fetch Metadata (W3C) — `Sec-Fetch-Mode`: an sf-token whose valid values are the five request modes
+- [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order — a sender MUST NOT write multiple field lines of one name, in the headers or the trailers, unless at least one alternative of the field's definition allows the lines to be recombined as a comma-separated list
 
 ## Configuration
 

--- a/docs/rules/sec_fetch_site_value_valid.md
+++ b/docs/rules/sec_fetch_site_value_valid.md
@@ -13,6 +13,7 @@ Requests that include the `Sec-Fetch-Site` request header must use one of the ca
 ## Specifications
 
 - [Fetch Metadata §2.3](https://www.w3.org/TR/fetch-metadata/#sec-fetch-site-header): Fetch Metadata (W3C) — `Sec-Fetch-Site`: an sf-token whose valid values are the four initiator/target relationships
+- [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order — a sender MUST NOT write multiple field lines of one name, in the headers or the trailers, unless at least one alternative of the field's definition allows the lines to be recombined as a comma-separated list
 
 ## Configuration
 

--- a/docs/rules/sec_fetch_user_value_valid.md
+++ b/docs/rules/sec_fetch_user_value_valid.md
@@ -13,6 +13,7 @@ Requests that include the `Sec-Fetch-User` request header MUST only include the 
 ## Specifications
 
 - [Fetch Metadata §2.4](https://www.w3.org/TR/fetch-metadata/#sec-fetch-user-header): Fetch Metadata (W3C) — `Sec-Fetch-User` header (boolean, serialized as `?1`)
+- [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order — a sender MUST NOT write multiple field lines of one name, in the headers or the trailers, unless at least one alternative of the field's definition allows the lines to be recombined as a comma-separated list
 
 ## Configuration
 

--- a/docs/rules/singleton_fields_not_repeated.md
+++ b/docs/rules/singleton_fields_not_repeated.md
@@ -20,7 +20,7 @@ Reports a message writing more than one field line of a singleton field. RFC 911
 
 ## Specifications
 
-- [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order: the MUST NOT this rule enforces — multiple field lines with one name in a message, headers or trailers, unless the field's definition has a comma-separated-list alternative
+- [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order — a sender MUST NOT write multiple field lines of one name, in the headers or the trailers, unless at least one alternative of the field's definition allows the lines to be recombined as a comma-separated list
 - [RFC 9110 §5.5](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5): Field Values: what a singleton field is, and the sentence saying that detecting an erroneously repeated one improves interoperability
 - [RFC 9110 §5.6.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1): Lists: the `#rule` extension — the shape a field's definition has when §5.3's exception applies to it, and the shape none of the sixteen grammars in this rule's table has
 - [RFC 9111 §5.1](https://www.rfc-editor.org/rfc/rfc9111.html#section-5.1): Age — defined as a singleton header field in as many words, with the recipient's first-member recovery beside it, which is a recipient's SHOULD and not a sender's licence

--- a/docs/rules/x_frame_options_value_valid.md
+++ b/docs/rules/x_frame_options_value_valid.md
@@ -14,6 +14,7 @@ The `X-Frame-Options` response header protects content from being embedded in fr
 
 - [HTML Speculative Loading §7.7](https://html.spec.whatwg.org/multipage/speculative-loading.html#the-x-frame-options-header): Governing definition: conformance ABNF `"DENY" / "SAMEORIGIN"`, case-insensitive processing, `ALLOW-FROM` not to be implemented
 - [RFC 7034 §2.1](https://www.rfc-editor.org/rfc/rfc7034.html#section-2.1): Historical definition (including the dropped `ALLOW-FROM` variant); superseded by the HTML Standard
+- [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order — a sender MUST NOT write multiple field lines of one name, in the headers or the trailers, unless at least one alternative of the field's definition allows the lines to be recombined as a comma-separated list
 
 ## Configuration
 

--- a/docs/rules/x_xss_protection_value_valid.md
+++ b/docs/rules/x_xss_protection_value_valid.md
@@ -14,6 +14,7 @@ This rule checks that the `X-XSS-Protection` response header, when present, uses
 
 - [MDN X-XSS-Protection](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-XSS-Protection): X-XSS-Protection
 - [OWASP Secure Headers](https://owasp.org/www-project-secure-headers/): OWASP guidance
+- [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order — a sender MUST NOT write multiple field lines of one name, in the headers or the trailers, unless at least one alternative of the field's definition allows the lines to be recombined as a comma-separated list
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/access_control_allow_origin_valid.rs
+++ b/lint-http-rules/src/rules/access_control_allow_origin_valid.rs
@@ -4,6 +4,14 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::field::{FIELD_LINE_DUPLICATED, RFC_9110_5_3};
+use crate::violations::ViolationDef;
+
+/// The one entry a field with no list form always has available: its own
+/// repetition. What the *value* may be is this rule's own three-way
+/// alternation, which no subject can name — so the repetition is the only
+/// finding here the catalogue holds.
+static DECLARED: &[&ViolationDef] = &[&FIELD_LINE_DUPLICATED];
 
 pub struct AccessControlAllowOriginValid;
 
@@ -60,7 +68,12 @@ severity = "warn"
             FETCH_3_3_3,
             FETCH_3_2,
             RFC_6454_7_1,
+            RFC_9110_5_3,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -135,7 +148,7 @@ impl Rule for AccessControlAllowOriginValid {
             // header carries one value — an echoed origin, `null`, or `*` — not a list.
             // cite(Fetch § 3.3.3): "Indicates whether the response can be shared, via returning the literal value of the `Origin` request header (which can be `null`) or `*` in a response."
             if acao_count > 1 {
-                return Some(self.cited(&FETCH_3_3_3, ctx.severity, "Multiple Access-Control-Allow-Origin header fields present; only a single value ('*' or a single origin) is allowed".into()));
+                return Some(ctx.report_with(&FIELD_LINE_DUPLICATED, "Multiple Access-Control-Allow-Origin header fields present; only a single value ('*' or a single origin) is allowed".into()));
             }
 
             // There is a single header field; validate its single value semantics and origin syntax.

--- a/lint-http-rules/src/rules/cross_origin_embedder_policy_valid.rs
+++ b/lint-http-rules/src/rules/cross_origin_embedder_policy_valid.rs
@@ -4,6 +4,13 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::field::{FIELD_LINE_DUPLICATED, RFC_9110_5_3};
+use crate::violations::ViolationDef;
+
+/// The one entry a field with no list form always has available: its own
+/// repetition. The value on each line here is measured by the checks below;
+/// what § 5.3 forbids is there being two lines at all.
+static DECLARED: &[&ViolationDef] = &[&FIELD_LINE_DUPLICATED];
 
 pub struct CrossOriginEmbedderPolicyValid;
 
@@ -43,7 +50,11 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[MDN_CROSS_ORIGIN_EMBEDDER_POLICY, HTML_7_1_4]
+        &[MDN_CROSS_ORIGIN_EMBEDDER_POLICY, HTML_7_1_4, RFC_9110_5_3]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -109,8 +120,8 @@ impl Rule for CrossOriginEmbedderPolicyValid {
             }
 
             if count > 1 {
-                return Some(self.violation(
-                    ctx.severity,
+                return Some(ctx.report_with(
+                    &FIELD_LINE_DUPLICATED,
                     "Multiple Cross-Origin-Embedder-Policy header fields present".into(),
                 ));
             }

--- a/lint-http-rules/src/rules/cross_origin_opener_policy_valid.rs
+++ b/lint-http-rules/src/rules/cross_origin_opener_policy_valid.rs
@@ -4,6 +4,13 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::field::{FIELD_LINE_DUPLICATED, RFC_9110_5_3};
+use crate::violations::ViolationDef;
+
+/// The one entry a field with no list form always has available: its own
+/// repetition. The value on each line here is measured by the checks below;
+/// what § 5.3 forbids is there being two lines at all.
+static DECLARED: &[&ViolationDef] = &[&FIELD_LINE_DUPLICATED];
 
 pub struct CrossOriginOpenerPolicyValid;
 
@@ -49,7 +56,16 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[MDN_CROSS_ORIGIN_OPENER_POLICY, HTML_7_1_3_1, HTML]
+        &[
+            MDN_CROSS_ORIGIN_OPENER_POLICY,
+            HTML_7_1_3_1,
+            HTML,
+            RFC_9110_5_3,
+        ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -112,8 +128,8 @@ impl Rule for CrossOriginOpenerPolicyValid {
             }
 
             if count > 1 {
-                return Some(self.violation(
-                    ctx.severity,
+                return Some(ctx.report_with(
+                    &FIELD_LINE_DUPLICATED,
                     "Multiple Cross-Origin-Opener-Policy header fields present".into(),
                 ));
             }

--- a/lint-http-rules/src/rules/cross_origin_resource_policy_valid.rs
+++ b/lint-http-rules/src/rules/cross_origin_resource_policy_valid.rs
@@ -4,6 +4,13 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::field::{FIELD_LINE_DUPLICATED, RFC_9110_5_3};
+use crate::violations::ViolationDef;
+
+/// The one entry a field with no list form always has available: its own
+/// repetition. The value on each line here is measured by the checks below;
+/// what § 5.3 forbids is there being two lines at all.
+static DECLARED: &[&ViolationDef] = &[&FIELD_LINE_DUPLICATED];
 
 pub struct CrossOriginResourcePolicyValid;
 
@@ -43,7 +50,11 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[FETCH_3_7, MDN_CROSS_ORIGIN_RESOURCE_POLICY]
+        &[FETCH_3_7, MDN_CROSS_ORIGIN_RESOURCE_POLICY, RFC_9110_5_3]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -104,8 +115,8 @@ impl Rule for CrossOriginResourcePolicyValid {
             }
 
             if count > 1 {
-                return Some(self.violation(
-                    ctx.severity,
+                return Some(ctx.report_with(
+                    &FIELD_LINE_DUPLICATED,
                     "Multiple Cross-Origin-Resource-Policy header fields present".into(),
                 ));
             }

--- a/lint-http-rules/src/rules/origin_isolated_header_valid.rs
+++ b/lint-http-rules/src/rules/origin_isolated_header_valid.rs
@@ -4,6 +4,13 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::field::{FIELD_LINE_DUPLICATED, RFC_9110_5_3};
+use crate::violations::ViolationDef;
+
+/// The one entry a field with no list form always has available: its own
+/// repetition. The value on each line here is measured by the checks below;
+/// what § 5.3 forbids is there being two lines at all.
+static DECLARED: &[&ViolationDef] = &[&FIELD_LINE_DUPLICATED];
 
 pub struct OriginIsolatedHeaderValid;
 
@@ -39,7 +46,11 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[HTML_7_1_2, RFC_9651_3]
+        &[HTML_7_1_2, RFC_9651_3, RFC_9110_5_3]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -95,8 +106,8 @@ impl Rule for OriginIsolatedHeaderValid {
             }
 
             if count > 1 {
-                return Some(self.violation(
-                    ctx.severity,
+                return Some(ctx.report_with(
+                    &FIELD_LINE_DUPLICATED,
                     "Multiple Origin-Agent-Cluster header fields present".into(),
                 ));
             }

--- a/lint-http-rules/src/rules/origin_matching_for_cors.rs
+++ b/lint-http-rules/src/rules/origin_matching_for_cors.rs
@@ -4,6 +4,7 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::field::{FIELD_LINE_DUPLICATED, RFC_9110_5_3};
 use crate::violations::uri::{
     origin_defect, RFC_3986_2, RFC_3986_3_1, URI_CHARACTER_FORBIDDEN,
     URI_SCHEME_CHARACTER_FORBIDDEN, URI_SCHEME_EMPTY, URI_SCHEME_LEADING_LETTER_MISSING,
@@ -23,6 +24,7 @@ static DECLARED: &[&ViolationDef] = &[
     &URI_SCHEME_LEADING_LETTER_MISSING,
     &URI_SCHEME_CHARACTER_FORBIDDEN,
     &URI_CHARACTER_FORBIDDEN,
+    &FIELD_LINE_DUPLICATED,
 ];
 
 pub struct OriginMatchingForCors;
@@ -75,6 +77,7 @@ severity = "warn"
             MDN_ACCESS_CONTROL_ALLOW_ORIGIN,
             RFC_3986_2,
             RFC_3986_3_1,
+            RFC_9110_5_3,
         ]
     }
 
@@ -180,7 +183,7 @@ impl Rule for OriginMatchingForCors {
             // Multiple header fields are not permitted; treat as violation early
             // cite(Fetch § 3.3.3): "Indicates whether the response can be shared, via returning the literal value of the `Origin` request header (which can be `null`) or `*` in a response."
             if acao_values.len() > 1 {
-                return Some(self.violation(ctx.severity, "Multiple Access-Control-Allow-Origin header fields present; only a single value is allowed".into()));
+                return Some(ctx.report_with(&FIELD_LINE_DUPLICATED, "Multiple Access-Control-Allow-Origin header fields present; only a single value is allowed".into()));
             }
 
             // Now we have exactly one header field; validate its value semantics

--- a/lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
+++ b/lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
@@ -4,6 +4,13 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::field::{FIELD_LINE_DUPLICATED, RFC_9110_5_3};
+use crate::violations::ViolationDef;
+
+/// The one entry a field with no list form always has available: its own
+/// repetition. The value on each line here is measured by the checks below;
+/// what § 5.3 forbids is there being two lines at all.
+static DECLARED: &[&ViolationDef] = &[&FIELD_LINE_DUPLICATED];
 
 /// `Sec-Fetch-Dest` header must be one of the canonical destination tokens
 /// defined by Fetch (`empty`, `audio`, `audioworklet`, `document`, `embed`,
@@ -40,7 +47,11 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[FETCH_METADATA_2_1]
+        &[FETCH_METADATA_2_1, RFC_9110_5_3]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -101,8 +112,8 @@ impl Rule for SecFetchDestValueValid {
             // the field.
             // cite(RFC 9110 § 5.3): "a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list"
             if count > 1 {
-                return Some(self.violation(
-                    ctx.severity,
+                return Some(ctx.report_with(
+                    &FIELD_LINE_DUPLICATED,
                     "Multiple Sec-Fetch-Dest header fields present".into(),
                 ));
             }

--- a/lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
+++ b/lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
@@ -4,6 +4,13 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::field::{FIELD_LINE_DUPLICATED, RFC_9110_5_3};
+use crate::violations::ViolationDef;
+
+/// The one entry a field with no list form always has available: its own
+/// repetition. The value on each line here is measured by the checks below;
+/// what § 5.3 forbids is there being two lines at all.
+static DECLARED: &[&ViolationDef] = &[&FIELD_LINE_DUPLICATED];
 
 /// `Sec-Fetch-Mode` header must be one of the canonical values listed in
 /// the Fetch Metadata spec: `cors`, `no-cors`, `same-origin`, `navigate`, or `websocket`.
@@ -37,7 +44,11 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[FETCH_METADATA_2_2]
+        &[FETCH_METADATA_2_2, RFC_9110_5_3]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -93,8 +104,8 @@ impl Rule for SecFetchModeValueValid {
             // the field.
             // cite(RFC 9110 § 5.3): "a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list"
             if count > 1 {
-                return Some(self.violation(
-                    ctx.severity,
+                return Some(ctx.report_with(
+                    &FIELD_LINE_DUPLICATED,
                     "Multiple Sec-Fetch-Mode header fields present".into(),
                 ));
             }

--- a/lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
+++ b/lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
@@ -4,6 +4,13 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::field::{FIELD_LINE_DUPLICATED, RFC_9110_5_3};
+use crate::violations::ViolationDef;
+
+/// The one entry a field with no list form always has available: its own
+/// repetition. The value on each line here is measured by the checks below;
+/// what § 5.3 forbids is there being two lines at all.
+static DECLARED: &[&ViolationDef] = &[&FIELD_LINE_DUPLICATED];
 
 /// `Sec-Fetch-Site` header must be one of the canonical values listed in
 /// the Fetch Metadata spec: `cross-site`, `same-origin`, `same-site`, or `none`.
@@ -37,7 +44,11 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[FETCH_METADATA_2_3]
+        &[FETCH_METADATA_2_3, RFC_9110_5_3]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -93,8 +104,8 @@ impl Rule for SecFetchSiteValueValid {
             // the field.
             // cite(RFC 9110 § 5.3): "a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list"
             if count > 1 {
-                return Some(self.violation(
-                    ctx.severity,
+                return Some(ctx.report_with(
+                    &FIELD_LINE_DUPLICATED,
                     "Multiple Sec-Fetch-Site header fields present".into(),
                 ));
             }

--- a/lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
+++ b/lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
@@ -4,6 +4,13 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::field::{FIELD_LINE_DUPLICATED, RFC_9110_5_3};
+use crate::violations::ViolationDef;
+
+/// The one entry a field with no list form always has available: its own
+/// repetition. The value on each line here is measured by the checks below;
+/// what § 5.3 forbids is there being two lines at all.
+static DECLARED: &[&ViolationDef] = &[&FIELD_LINE_DUPLICATED];
 
 /// `Sec-Fetch-User` header must be the structured-boolean true (serialized as `?1`) when present.
 /// The header is request-scoped and only expected on navigation requests. Multiple header
@@ -36,7 +43,11 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[FETCH_METADATA_2_4]
+        &[FETCH_METADATA_2_4, RFC_9110_5_3]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -98,8 +109,8 @@ impl Rule for SecFetchUserValueValid {
             // the field.
             // cite(RFC 9110 § 5.3): "a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list"
             if count > 1 {
-                return Some(self.violation(
-                    ctx.severity,
+                return Some(ctx.report_with(
+                    &FIELD_LINE_DUPLICATED,
                     "Multiple Sec-Fetch-User header fields present".into(),
                 ));
             }

--- a/lint-http-rules/src/rules/singleton_fields_not_repeated.rs
+++ b/lint-http-rules/src/rules/singleton_fields_not_repeated.rs
@@ -4,6 +4,17 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::field::{FIELD_LINE_DUPLICATED, RFC_9110_5_3};
+use crate::violations::ViolationDef;
+
+/// The one entry, and this rule is the widest declarer of it there will be.
+///
+/// Sixteen fields with no rule of their own are counted here; every other
+/// declarer reads one field and reports the same sentence about it. What stays
+/// this rule's own is the *table* — which field definitions have no
+/// comma-separated-list alternative — because that is a reading of sixteen
+/// documents rather than of § 5.3.
+static DECLARED: &[&ViolationDef] = &[&FIELD_LINE_DUPLICATED];
 
 pub struct SingletonFieldsNotRepeated;
 
@@ -99,14 +110,6 @@ const SINGLETON_FIELDS: &[(&str, &str)] = &[
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_9110_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("5.3"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
-    note: "Field Order: the MUST NOT this rule enforces — multiple field lines with \
-           one name in a message, headers or trailers, unless the field's \
-           definition has a comma-separated-list alternative",
-};
 const RFC_9110_5_5: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
     section: Some("5.5"),
@@ -189,6 +192,10 @@ severity = "error"
         &[RFC_9110_5_3, RFC_9110_5_5, RFC_9110_5_6_1, RFC_9111_5_1]
     }
 
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
+    }
+
     fn examples(&self) -> &'static [crate::rules::Example] {
         use crate::rules::{Compliance, Example};
         &[
@@ -237,7 +244,7 @@ impl Rule for SingletonFieldsNotRepeated {
                         .and_then(|resp| judge(&resp.headers, resp.trailers.as_ref(), "Response"))
                 })?;
 
-            Some(self.violation(ctx.severity, message))
+            Some(ctx.report_with(&FIELD_LINE_DUPLICATED, message))
         };
         Vec::from_iter(finding())
     }

--- a/lint-http-rules/src/rules/x_frame_options_value_valid.rs
+++ b/lint-http-rules/src/rules/x_frame_options_value_valid.rs
@@ -4,6 +4,13 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::field::{FIELD_LINE_DUPLICATED, RFC_9110_5_3};
+use crate::violations::ViolationDef;
+
+/// The one entry a field with no list form always has available: its own
+/// repetition. The value on each line here is measured by the checks below;
+/// what § 5.3 forbids is there being two lines at all.
+static DECLARED: &[&ViolationDef] = &[&FIELD_LINE_DUPLICATED];
 
 pub struct XFrameOptionsValueValid;
 
@@ -39,7 +46,11 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[HTML_SPECULATIVE_LOADING_7_7, RFC_7034_2_1]
+        &[HTML_SPECULATIVE_LOADING_7_7, RFC_7034_2_1, RFC_9110_5_3]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -105,8 +116,8 @@ impl Rule for XFrameOptionsValueValid {
             // the field.
             // cite(RFC 9110 § 5.3): "a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list"
             if count > 1 {
-                return Some(self.violation(
-                    ctx.severity,
+                return Some(ctx.report_with(
+                    &FIELD_LINE_DUPLICATED,
                     "Multiple X-Frame-Options header fields present".into(),
                 ));
             }

--- a/lint-http-rules/src/rules/x_xss_protection_value_valid.rs
+++ b/lint-http-rules/src/rules/x_xss_protection_value_valid.rs
@@ -4,6 +4,13 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::field::{FIELD_LINE_DUPLICATED, RFC_9110_5_3};
+use crate::violations::ViolationDef;
+
+/// The one entry a field with no list form always has available: its own
+/// repetition. The value on each line here is measured by the checks below;
+/// what § 5.3 forbids is there being two lines at all.
+static DECLARED: &[&ViolationDef] = &[&FIELD_LINE_DUPLICATED];
 
 pub struct XXssProtectionValueValid;
 
@@ -43,7 +50,11 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[MDN_X_XSS_PROTECTION, OWASP_SECURE_HEADERS]
+        &[MDN_X_XSS_PROTECTION, OWASP_SECURE_HEADERS, RFC_9110_5_3]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -108,8 +119,8 @@ impl Rule for XXssProtectionValueValid {
             // not repeat the field.
             // cite(RFC 9110 § 5.3): "a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list"
             if count > 1 {
-                return Some(self.violation(
-                    ctx.severity,
+                return Some(ctx.report_with(
+                    &FIELD_LINE_DUPLICATED,
                     "Multiple X-XSS-Protection header fields present".into(),
                 ));
             }

--- a/lint-http-rules/src/violations/field.rs
+++ b/lint-http-rules/src/violations/field.rs
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `field` defects — what is wrong with a field *line* rather than with the
+//! value written on it.
+//!
+//! **The first subject in this catalogue that is not a production.** Every
+//! other one is a grammar somebody wrote down — a `token`, an `http_date`, a
+//! `uri` — and the defect is a value that does not derive from it. This one is
+//! a sentence about the *shape of a message*: RFC 9110 § 5.3 forbids a sender
+//! from writing two field lines of one name unless that field's definition has
+//! a comma-separated-list alternative, and a message breaking it carries values
+//! that are each perfectly well formed.
+//!
+//! That is why it is shared as widely as it is. **Thirty-six rules in this tree
+//! report a repeated field line today**, one field apiece, in thirty-six
+//! wordings of one sentence — and `singleton_fields_not_repeated` reports it for
+//! sixteen more fields that have no rule of their own. The spread is
+//! deliberate: that rule's own prose says eight singleton fields are left to the
+//! rules that read their values, "with the joined value in the finding". So the
+//! sentence was always one claim reported from many places, which is the
+//! definition of a subject in this campaign.
+//!
+//! **What it is not.** It is not "this field appeared twice" as a matter of
+//! counting: `#`-list fields are *meant* to arrive on several lines, and § 5.3's
+//! own exception says so. The defect is a repetition the field's definition does
+//! not admit, so every declarer is a rule that has read that definition — which
+//! is also why no gate can find the next declarer for you.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// The MUST NOT, its exception, and the recombination that makes the exception
+/// the whole of the difference.
+pub const RFC_9110_5_3: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
+    note: "Field Order — a sender MUST NOT write multiple field lines of one name, in the \
+           headers or the trailers, unless at least one alternative of the field's definition \
+           allows the lines to be recombined as a comma-separated list",
+};
+
+defects! {
+    /// More field lines of one name than the field's definition admits.
+    ///
+    /// The values on them may each be well formed; what is wrong is that there
+    /// are two. A recipient recombining them by § 5.3's rule gets one value the
+    /// sender never wrote — `Content-Type: text/html` twice becomes
+    /// `text/html, text/html`, which is not a `media-type` — and a recipient
+    /// that takes the first, or the last, silently obeys one of two
+    /// instructions.
+    ///
+    /// `warn` rather than `error`: every value is legible and most recipients
+    /// resolve the ambiguity the same way, so this is a sender defect a
+    /// deployment can carry rather than a message a recipient must reject.
+    /// Where a document says otherwise about its own field — `Content-Length`'s
+    /// framing, for one — the rule reading that field says so at its own site.
+    ///
+    // cite(RFC 9110 § 5.3): "a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list"
+    FIELD_LINE_DUPLICATED = {
+        id: "field_line_duplicated",
+        title: "A field is written on more lines than its definition allows",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_5_3),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One entry, and the shape of the id is the argument for it: the subject
+    /// is `field`, the part is the `line`, and the defect is that there is more
+    /// than one of them. Nothing here narrows to a field name — a def naming
+    /// the field that noticed the defect is the campaign's own recorded error.
+    #[test]
+    fn the_subject_is_the_line_and_not_the_field_that_carried_it() {
+        assert_eq!(FIELD_LINE_DUPLICATED.id, "field_line_duplicated");
+        assert_eq!(FIELD_LINE_DUPLICATED.default_severity, Severity::Warn);
+        assert_eq!(FIELD_LINE_DUPLICATED.spec, Some(RFC_9110_5_3));
+    }
+}

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -42,6 +42,7 @@ pub mod credentials;
 pub mod delta_seconds;
 pub mod domain;
 pub mod etag;
+pub mod field;
 pub mod http_date;
 pub mod language;
 pub mod list;
@@ -363,7 +364,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 120;
+        const FLOOR: usize = 121;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -16,7 +16,7 @@ sources:
     - file: lint-http-rules/src/rules/access_control_allow_credentials_when_origin.rs
       line: 172
     - file: lint-http-rules/src/rules/origin_matching_for_cors.rs
-      line: 206
+      line: 209
   - label: CORS check reads the field
     section: § 4.10
     snippet: Let credentials be the result of getting `Access-Control-Allow-Credentials` from response’s header list.
@@ -28,21 +28,21 @@ sources:
     snippet: Indicates whether the response can be shared, via returning the literal value of the `Origin` request header (which can be `null`) or `*` in a response.
     cited_by:
     - file: lint-http-rules/src/rules/access_control_allow_origin_valid.rs
-      line: 136
+      line: 149
     - file: lint-http-rules/src/rules/origin_matching_for_cors.rs
-      line: 181
+      line: 184
   - label: cross_origin_resource_policy_valid
     section: § 3.7
     snippet: Cross-Origin-Resource-Policy = %s"same-origin" / %s"same-site" / %s"cross-origin" ; case-sensitive
     cited_by:
     - file: lint-http-rules/src/rules/cross_origin_resource_policy_valid.rs
-      line: 138
+      line: 149
   - label: cross_origin_resource_policy_valid (2)
     section: § 3.7
     snippet: If policy is neither `same-origin`, `same-site`, nor `cross-origin`, then set policy to null.
     cited_by:
     - file: lint-http-rules/src/rules/cross_origin_resource_policy_valid.rs
-      line: 139
+      line: 150
   - label: lint-http-rules/src/helpers/uri.rs
     section: § 3.2
     snippet: The origin serialization defined here is more constrained than [RFC3986]’s grammar in two substantial ways.
@@ -66,7 +66,7 @@ sources:
     snippet: If the result of byte-serializing a request origin with request is not origin, then return failure.
     cited_by:
     - file: lint-http-rules/src/rules/origin_matching_for_cors.rs
-      line: 222
+      line: 225
   - label: refresh_header_syntax
     section: § 2.2.2
     snippet: Return the values of all headers in list whose name is a byte-case-insensitive match for name, separated from each other by 0x2C 0x20
@@ -90,7 +90,7 @@ sources:
     snippet: 'A destination type is one of: the empty string, "audio", "audioworklet", "document", "embed", "font", "frame", "iframe", "image", "json", "manifest", "object", "paintworklet", "report", "script", "serviceworker", "sharedworker", "style", "text", "track", "video", "webidentity", "worker", or "xslt".'
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 157
+      line: 168
   - label: timing_allow_origin_valid
     section: § 3.2
     snippet: origin-or-null = serialized-origin / %s"null" ; case-sensitive
@@ -130,25 +130,25 @@ sources:
     snippet: An embedder policy value is one of three strings that controls the fetching of cross-origin resources without explicit permission from resource owners.
     cited_by:
     - file: lint-http-rules/src/rules/cross_origin_embedder_policy_valid.rs
-      line: 143
+      line: 154
   - label: cross_origin_opener_policy_valid
     section: § 7.1.3.1
     snippet: Let parsedItem be the result of getting a structured field value given `Cross-Origin-Opener-Policy` and "item" from response's header list.
     cited_by:
     - file: lint-http-rules/src/rules/cross_origin_opener_policy_valid.rs
-      line: 148
+      line: 164
   - label: origin_isolated_header_valid
     section: § 7.1.2
     snippet: This header is a structured header whose value must be a boolean.
     cited_by:
     - file: lint-http-rules/src/rules/origin_isolated_header_valid.rs
-      line: 118
+      line: 129
   - label: origin_isolated_header_valid (2)
     section: § 7.1.2
     snippet: values that are not the structured header boolean true value (i.e., `?1`) will be ignored.
     cited_by:
     - file: lint-http-rules/src/rules/origin_isolated_header_valid.rs
-      line: 131
+      line: 142
 - label: HTML Links
   url: https://html.spec.whatwg.org/multipage/links.html
   type: text/html
@@ -194,31 +194,31 @@ sources:
     snippet: For each value of rawXFrameOptions, append value, converted to ASCII lowercase, to xFrameOptions.
     cited_by:
     - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
-      line: 129
+      line: 140
   - label: x_frame_options_value_valid (2)
     section: § 7.7
     snippet: HTTP response header is a way of controlling whether and how a Document may be loaded inside of a child navigable
     cited_by:
     - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
-      line: 94
+      line: 105
   - label: x_frame_options_value_valid (3)
     section: § 7.7
     snippet: In particular, HTTP Header Field X-Frame-Options specified an `ALLOW-FROM` variant of the header, but that is not to be implemented.
     cited_by:
     - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
-      line: 139
+      line: 150
   - label: x_frame_options_value_valid (4)
     section: § 7.7
     snippet: It was originally defined in HTTP Header Field X-Frame-Options, but the definition and processing model here supersedes that document.
     cited_by:
     - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
-      line: 93
+      line: 104
   - label: x_frame_options_value_valid (5)
     section: § 7.7
     snippet: X-Frame-Options = "DENY" / "SAMEORIGIN"
     cited_by:
     - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
-      line: 128
+      line: 139
 - label: HTML Semantics
   url: https://html.spec.whatwg.org/multipage/semantics.html
   type: text/html
@@ -455,90 +455,90 @@ sources:
     snippet: HTTP request header exposes a request’s destination to a server
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 93
+      line: 104
   - label: sec_fetch_dest_value_valid (2)
     section: § 2.1
     snippet: If r’s destination is the empty string, set header’s value to the string "empty"
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 160
+      line: 171
   - label: sec_fetch_dest_value_valid (3)
     section: § 2.1
     snippet: In order to support forward-compatibility with as-yet-unknown request types, servers SHOULD ignore this header if it contains an invalid value.
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 155
+      line: 166
     - file: lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
-      line: 139
+      line: 150
     - file: lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
-      line: 145
+      line: 156
   - label: sec_fetch_dest_value_valid (4)
     section: § 2.1
     snippet: It is a Structured Field whose value MUST be a token.
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 124
+      line: 135
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 137
+      line: 148
     - file: lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
-      line: 116
+      line: 127
     - file: lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
-      line: 125
+      line: 136
   - label: sec_fetch_dest_value_valid (5)
     section: § 2.1
     snippet: Valid Sec-Fetch-Dest values include the set of valid request destinations defined by [Fetch].
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 156
+      line: 167
   - label: sec_fetch_mode_value_valid
     section: § 2.2
     snippet: HTTP request header exposes a request’s mode to a server
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
-      line: 85
+      line: 96
   - label: sec_fetch_mode_value_valid (2)
     section: § 2.2
     snippet: Valid Sec-Fetch-Mode values include "cors", "navigate", "no-cors", "same-origin", and "websocket".
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
-      line: 140
+      line: 151
   - label: sec_fetch_site_value_valid
     section: § 2.3
     snippet: HTTP request header exposes the relationship between a request initiator’s origin and its target’s origin
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
-      line: 85
+      line: 96
   - label: sec_fetch_site_value_valid (2)
     section: § 2.3
     snippet: It is a Structured Field whose value is a token.
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
-      line: 117
+      line: 128
     - file: lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
-      line: 130
+      line: 141
   - label: sec_fetch_site_value_valid (3)
     section: § 2.3
     snippet: Valid Sec-Fetch-Site values include "cross-site", "same-origin", "same-site", and "none".
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
-      line: 146
+      line: 157
   - label: sec_fetch_user_value_valid
     snippet: 'Sec-Fetch-User = sf-boolean Note: The header is delivered only for navigation requests, and only when its value is true.'
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
-      line: 132
+      line: 143
   - label: sec_fetch_user_value_valid (2)
     section: § 2.4
     snippet: HTTP request header exposes whether or not a navigation request was triggered by user activation.
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
-      line: 90
+      line: 101
   - label: sec_fetch_user_value_valid (3)
     section: § 2.4
     snippet: It is a Structured Field whose value is a boolean.
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
-      line: 120
+      line: 131
 - label: Resource Timing
   url: https://www.w3.org/TR/resource-timing/
   type: text/html
@@ -784,22 +784,22 @@ sources:
     snippet: Disables XSS filtering.
     cited_by:
     - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
-      line: 134
+      line: 145
   - label: x_xss_protection_value_valid (2)
     snippet: Enables XSS filtering. Rather than sanitizing the page, the browser will prevent rendering of the page if an attack is detected.
     cited_by:
     - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
-      line: 140
+      line: 151
   - label: x_xss_protection_value_valid (3)
     snippet: Even though this feature can protect users of older web browsers that don't support CSP, in some cases, X-XSS-Protection can create XSS vulnerabilities in otherwise safe websites.
     cited_by:
     - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
-      line: 133
+      line: 144
   - label: x_xss_protection_value_valid (4)
     snippet: response header was a feature of Internet Explorer, Chrome and Safari that stopped pages from loading when they detected reflected cross-site scripting
     cited_by:
     - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
-      line: 98
+      line: 109
 - label: RFC 1035
   url: https://www.rfc-editor.org/rfc/rfc1035.html
   fragments:
@@ -5341,7 +5341,7 @@ sources:
     - file: lint-http-rules/src/rules/cache_coherence.rs
       line: 131
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 33
+      line: 44
   - label: cache_control_directive_valid
     section: § 5.1
     snippet: A field name labels the corresponding field value as having the semantics defined by that name.
@@ -5517,7 +5517,7 @@ sources:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
       line: 218
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 38
+      line: 49
   - label: conditional_request_handling
     section: § 13.1.2
     snippet: An origin server that evaluates an If-None-Match condition MUST NOT perform the requested method if the condition evaluates to false; instead, the origin server MUST respond with either a) the 304 (Not Modified) status code if the request method is GET or HEAD or b) the 412 (Precondition Failed) status code for all other request methods.
@@ -5711,7 +5711,7 @@ sources:
     - file: lint-http-rules/src/rules/content_type_valid.rs
       line: 220
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 35
+      line: 46
   - label: content_type_present (4)
     section: § 8.3
     snippet: If a Content-Type header field is not present, the recipient MAY either assume a media type of "application/octet-stream" ([RFC2046], Section 4.5.1) or examine the data to determine its type.
@@ -5911,7 +5911,7 @@ sources:
     - file: lint-http-rules/src/rules/etag_syntax.rs
       line: 116
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 34
+      line: 45
   - label: expect_header_valid
     section: § 10.1.1
     snippet: A "100-continue" expectation informs recipients that the client is about to send (presumably large) content in this request
@@ -6207,7 +6207,7 @@ sources:
     - file: lint-http-rules/src/rules/if_modified_since_date_syntax.rs
       line: 138
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 39
+      line: 50
     - file: lint-http-rules/src/rules/vary_header_cache_valid.rs
       line: 132
   - label: if_modified_since_date_syntax (2)
@@ -6235,7 +6235,7 @@ sources:
     - file: lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
       line: 136
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 40
+      line: 51
   - label: keep_alive_header_valid
     section: § 7.6.1
     snippet: Keep-Alive (Section 19.7.1 of [RFC2068])
@@ -6837,7 +6837,7 @@ sources:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 236
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 36
+      line: 47
     - file: lint-http-rules/src/violations/content_range.rs
       line: 56
     - file: lint-http-rules/src/violations/content_range.rs
@@ -7015,21 +7015,23 @@ sources:
     - file: lint-http-rules/src/rules/retry_after_date_or_delay.rs
       line: 82
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 102
+      line: 113
     - file: lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
-      line: 94
+      line: 105
     - file: lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
-      line: 94
+      line: 105
     - file: lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
-      line: 99
+      line: 110
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 261
+      line: 268
     - file: lint-http-rules/src/rules/vary_header_cache_valid.rs
       line: 133
     - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
-      line: 106
+      line: 117
     - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
-      line: 109
+      line: 120
+    - file: lint-http-rules/src/violations/field.rs
+      line: 62
   - label: lint-http-rules/src/helpers/headers.rs (5)
     section: § 5.5
     snippet: A recipient SHOULD treat other allowed octets in field content (i.e., obs-text) as opaque data.
@@ -7069,7 +7071,7 @@ sources:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
       line: 256
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 263
+      line: 270
   - label: lint-http-rules/src/helpers/headers.rs (7)
     section: § 5.5
     snippet: This is true for both list-based and singleton fields, since a singleton field might be erroneously sent with multiple members and detecting such errors improves interoperability.
@@ -7077,7 +7079,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 411
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 264
+      line: 271
   - label: lint-http-rules/src/helpers/headers.rs (8)
     section: § 5.5
     snippet: field-content  = field-vchar [ 1*( SP / HTAB / field-vchar ) field-vchar ]
@@ -8267,7 +8269,7 @@ sources:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 220
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 37
+      line: 48
   - label: range_request_and_caching
     section: § 13.1.5
     snippet: Note that the If-Range comparison is by exact match, including when the validator is an HTTP-date, and so it differs from the "earlier than or equal to" comparison used when evaluating an If-Unmodified-Since conditional.
@@ -8609,7 +8611,7 @@ sources:
     - file: lint-http-rules/src/rules/retry_after_date_or_delay.rs
       line: 88
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 43
+      line: 54
   - label: retry_after_status_valid
     section: § 10.2.3
     snippet: When sent with a 503 (Service Unavailable) response, Retry-After indicates how long the service is expected to be unavailable to the client.
@@ -8659,37 +8661,37 @@ sources:
     snippet: User-Agent = product *( RWS ( product / comment ) )
     cited_by:
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 31
+      line: 42
   - label: singleton_fields_not_repeated (2)
     section: § 10.2.4
     snippet: Server = product *( RWS ( product / comment ) )
     cited_by:
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 30
+      line: 41
   - label: singleton_fields_not_repeated (3)
     section: § 11.6.2
     snippet: Authorization = credentials
     cited_by:
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 41
+      line: 52
   - label: singleton_fields_not_repeated (4)
     section: § 11.7.2
     snippet: Proxy-Authorization = credentials
     cited_by:
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 42
+      line: 53
   - label: the exception's shape
     section: § 5.3
     snippet: 'such as an ABNF rule of #(values) defined in Section 5.6.1'
     cited_by:
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 262
+      line: 269
   - label: singleton_fields_not_repeated (5)
     section: § 6.6.1
     snippet: The "Date" header field represents the date and time at which the message was originated, having the same semantics as the Origination Date Field (orig-date) defined in Section 3.6.1 of [RFC5322].
     cited_by:
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 32
+      line: 43
   - label: status_101_switching_protocols
     section: § 15.2.2
     snippet: The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field (Section 7.8), for a change in the application protocol being used on this connection.
@@ -9300,7 +9302,7 @@ sources:
     - file: lint-http-rules/src/rules/age_header_numeric.rs
       line: 108
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 45
+      line: 56
   - label: age_header_numeric (2)
     section: § 5.1
     snippet: The Age field value is a non-negative integer, representing time in seconds
@@ -9674,13 +9676,13 @@ sources:
     snippet: The "Age" response header field conveys the sender's estimate of the time since the response was generated or successfully validated at the origin server.
     cited_by:
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 44
+      line: 55
   - label: singleton_fields_not_repeated (2)
     section: § 5.3
     snippet: The "Expires" response header field gives the date/time after which the response is considered stale.
     cited_by:
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 46
+      line: 57
     - file: lint-http-rules/src/rules/status_and_caching_semantics.rs
       line: 120
   - label: status_and_caching_semantics


### PR DESCRIPTION
The first subject that is not a production: RFC 9110 section 5.3 forbids a second field line of a name whose definition has no list form, and thirty-six rules were each wording that one sentence about their own field while the rule counting sixteen more fields worded it again. Thirteen of them take the id here, and the sixteen-field table stays where it is, because which definitions have no list alternative is a reading of sixteen documents rather than of section 5.3.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
