### PR TITLE
Six more fields name the repetition once

### DIFF
--- a/docs/rules/conditional_headers_consistent.md
+++ b/docs/rules/conditional_headers_consistent.md
@@ -18,6 +18,7 @@ Validate consistency and mutual exclusivity of conditional request headers. When
 - [RFC 9110 §14.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-14.2): Range (the header If-Range depends on)
 - [RFC 9110 §8.8.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3): Entity Tags — `entity-tag = [ weak ] opaque-tag`, `weak = %s"W/"` (case-sensitive by the `%s` prefix), `opaque-tag = DQUOTE *etagc DQUOTE`, and `etagc` as VCHAR minus the DQUOTE plus obs-text
 - [RFC 9110 §5.6.7](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.7): Date/Time Formats — `HTTP-date = IMF-fixdate / obs-date`, the recipient's MUST to accept all three, and the sender's MUST to generate only the first
+- [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order — a sender MUST NOT write multiple field lines of one name, in the headers or the trailers, unless at least one alternative of the field's definition allows the lines to be recombined as a comma-separated list
 
 ## Configuration
 

--- a/docs/rules/content_disposition_token_valid.md
+++ b/docs/rules/content_disposition_token_valid.md
@@ -24,7 +24,7 @@ Since the grammar has no comma-separated-list alternative, a message section car
 - [RFC 6266 §4.2](https://www.rfc-editor.org/rfc/rfc6266.html#section-4.2): Disposition Type: an unknown type is conforming and has defined handling (treat as `attachment`), which is why this rule validates the value's shape and not its membership in any list
 - [RFC 6266 §4](https://www.rfc-editor.org/rfc/rfc6266.html#section-4): Defines Content-Disposition as a *response* header field — the request half of this rule is a deliberate extension beyond the document, since upload APIs do send one
 - [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
-- [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order: a sender MUST NOT emit multiple field lines for a field whose definition has no comma-separated-list alternative
+- [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order — a sender MUST NOT write multiple field lines of one name, in the headers or the trailers, unless at least one alternative of the field's definition allows the lines to be recombined as a comma-separated list
 
 ## Configuration
 

--- a/docs/rules/content_type_valid.md
+++ b/docs/rules/content_type_valid.md
@@ -26,7 +26,7 @@ Check that a `Content-Type` header — in a request or a response — reads as a
 - [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 - [RFC 9110 §5.6.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4): `quoted-string = DQUOTE *( qdtext / quoted-pair ) DQUOTE` — the two delimiters, the class between them, and the backslash escape
 - [RFC 9110 §12.5.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.1): Accept: where `*` belongs — `media-range`, which names a set of media types. Cited to explain why a wildcard is reported in Content-Type, which carries a `media-type`
-- [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order: a sender MUST NOT emit multiple field lines for a field with no comma-separated-list alternative
+- [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order — a sender MUST NOT write multiple field lines of one name, in the headers or the trailers, unless at least one alternative of the field's definition allows the lines to be recombined as a comma-separated list
 
 ## Configuration
 

--- a/docs/rules/deprecation_header_syntax.md
+++ b/docs/rules/deprecation_header_syntax.md
@@ -14,7 +14,7 @@ The `Deprecation` response header signals that a resource is deprecated. RFC 974
 
 - [RFC 9745 §2.1](https://www.rfc-editor.org/rfc/rfc9745.html#section-2.1): Syntax: `Deprecation` is an Item Structured Header Field whose value MUST be a `Date`
 - [RFC 9651 §3.3.7](https://www.rfc-editor.org/rfc/rfc9651.html#section-3.3.7): Structured Field `Date` item syntax (leading `@`)
-- [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order: an Item field (non-list) must not appear as multiple field lines
+- [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order — a sender MUST NOT write multiple field lines of one name, in the headers or the trailers, unless at least one alternative of the field's definition allows the lines to be recombined as a comma-separated list
 
 ## Configuration
 

--- a/docs/rules/etag_syntax.md
+++ b/docs/rules/etag_syntax.md
@@ -13,7 +13,7 @@ Validate that the `ETag` response header contains a single, syntactically valid 
 ## Specifications
 
 - [RFC 9110 §8.8.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3): Entity Tags — `entity-tag = [ weak ] opaque-tag`, `weak = %s"W/"` (case-sensitive by the `%s` prefix), `opaque-tag = DQUOTE *etagc DQUOTE`, and `etagc` as VCHAR minus the DQUOTE plus obs-text
-- [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order: a non-list field (such as `ETag = entity-tag`) must not appear as multiple field lines
+- [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order — a sender MUST NOT write multiple field lines of one name, in the headers or the trailers, unless at least one alternative of the field's definition allows the lines to be recombined as a comma-separated list
 
 ## Configuration
 

--- a/docs/rules/retry_after_date_or_delay.md
+++ b/docs/rules/retry_after_date_or_delay.md
@@ -13,6 +13,7 @@ The `Retry-After` header, when present in responses, MUST be either a non-negati
 ## Specifications
 
 - [RFC 9110 §10.2.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.3): Retry-After header
+- [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order — a sender MUST NOT write multiple field lines of one name, in the headers or the trailers, unless at least one alternative of the field's definition allows the lines to be recombined as a comma-separated list
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/conditional_headers_consistent.rs
+++ b/lint-http-rules/src/rules/conditional_headers_consistent.rs
@@ -8,6 +8,7 @@ use crate::violations::etag::{
     entity_tag_defect, ETAG_CHARACTER_FORBIDDEN, ETAG_DELIMITER_MISSING,
     ETAG_WEAK_INDICATOR_INVALID, RFC_9110_8_8_3,
 };
+use crate::violations::field::{FIELD_LINE_DUPLICATED, RFC_9110_5_3};
 use crate::violations::http_date::{
     http_date_defect, HTTP_DATE_MALFORMED, HTTP_DATE_OBSOLETE, HTTP_DATE_WHITESPACE_FORBIDDEN,
     RFC_9110_5_6_7,
@@ -32,6 +33,7 @@ use crate::violations::ViolationDef;
 /// stand, a date conditional beside an entity-tag one, and a second field line
 /// where the grammar admits one.
 static DECLARED: &[&ViolationDef] = &[
+    &FIELD_LINE_DUPLICATED,
     &ETAG_WEAK_INDICATOR_INVALID,
     &ETAG_DELIMITER_MISSING,
     &ETAG_CHARACTER_FORBIDDEN,
@@ -104,6 +106,7 @@ severity = "warn"
             RFC_9110_14_2,
             RFC_9110_8_8_3,
             RFC_9110_5_6_7,
+            RFC_9110_5_3,
         ]
     }
 
@@ -258,7 +261,7 @@ impl Rule for ConditionalHeadersConsistent {
                 ("if-unmodified-since", "If-Unmodified-Since"),
             ] {
                 if req.headers.get_all(name).iter().count() > 1 {
-                    return Some(self.violation(ctx.severity, format!(
+                    return Some(ctx.report_with(&FIELD_LINE_DUPLICATED, format!(
                             "Multiple {} header fields present; the combined value is a list of dates, which the recipient MUST ignore",
                             label
                         )));

--- a/lint-http-rules/src/rules/content_disposition_token_valid.rs
+++ b/lint-http-rules/src/rules/content_disposition_token_valid.rs
@@ -4,6 +4,7 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::field::{FIELD_LINE_DUPLICATED, RFC_9110_5_3};
 use crate::violations::token::{
     token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN, TOKEN_EMPTY,
     TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
@@ -33,6 +34,7 @@ pub struct ContentDispositionTokenValid;
 /// octet the grammar does not admit, whose right conversion is an octet-wise
 /// reader first.
 static DECLARED: &[&ViolationDef] = &[
+    &FIELD_LINE_DUPLICATED,
     &TOKEN_EMPTY,
     &TOKEN_CHARACTER_FORBIDDEN,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
@@ -58,12 +60,6 @@ const RFC_6266_4: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("4"),
     url: "https://www.rfc-editor.org/rfc/rfc6266.html#section-4",
     note: "Defines Content-Disposition as a *response* header field — the request half of this rule is a deliberate extension beyond the document, since upload APIs do send one",
-};
-const RFC_9110_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("5.3"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
-    note: "Field Order: a sender MUST NOT emit multiple field lines for a field whose definition has no comma-separated-list alternative",
 };
 
 impl RuleMeta for ContentDispositionTokenValid {
@@ -265,8 +261,8 @@ impl Rule for ContentDispositionTokenValid {
                     } else {
                         "no definition of this field gives it a comma-separated-list form, so at most one field line may be sent (RFC 9110 §5.3)"
                     };
-                    return Some(self.violation(
-                        ctx.severity,
+                    return Some(ctx.report_with(
+                        &FIELD_LINE_DUPLICATED,
                         format!(
                             "Multiple Content-Disposition header fields in the {}; {}",
                             kind, basis

--- a/lint-http-rules/src/rules/content_type_valid.rs
+++ b/lint-http-rules/src/rules/content_type_valid.rs
@@ -4,6 +4,7 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::field::{FIELD_LINE_DUPLICATED, RFC_9110_5_3};
 use crate::violations::parameter::{
     PARAMETER_EQUALS_MISSING, PARAMETER_VALUE_EMPTY, RFC_9110_5_6_6,
 };
@@ -40,6 +41,7 @@ pub struct ContentTypeValid;
 /// declaring that subject, and the reachability question belongs to the
 /// reading of every body rather than to this list.
 static DECLARED: &[&ViolationDef] = &[
+    &FIELD_LINE_DUPLICATED,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
     &TOKEN_CHARACTER_FORBIDDEN,
     &TOKEN_EMPTY,
@@ -71,12 +73,6 @@ const RFC_9110_12_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("12.5.1"),
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.1",
     note: "Accept: where `*` belongs — `media-range`, which names a set of media types. Cited to explain why a wildcard is reported in Content-Type, which carries a `media-type`",
-};
-const RFC_9110_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("5.3"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
-    note: "Field Order: a sender MUST NOT emit multiple field lines for a field with no comma-separated-list alternative",
 };
 
 impl RuleMeta for ContentTypeValid {
@@ -228,7 +224,7 @@ impl Rule for ContentTypeValid {
                 // one would imply the recipient reads it, which is the thing §8.3
                 // says cannot be assumed.
                 if vals.len() > 1 {
-                    return Some(self.violation(ctx.severity, format!(
+                    return Some(ctx.report_with(&FIELD_LINE_DUPLICATED, format!(
                             "Multiple Content-Type field lines in the {}; Content-Type is a singleton field (RFC 9110 §8.3) and recipients differ over which member wins, so the media type the peer acts on is not the one this message states. Individual values are not validated while more than one is present",
                             which
                         )));

--- a/lint-http-rules/src/rules/deprecation_header_syntax.rs
+++ b/lint-http-rules/src/rules/deprecation_header_syntax.rs
@@ -4,6 +4,13 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::field::{FIELD_LINE_DUPLICATED, RFC_9110_5_3};
+use crate::violations::ViolationDef;
+
+/// § 5.3's repeated field line, which this rule reports for its own field.
+/// The sentence is the catalogue's; what stays here is the reading that says
+/// this field's definition has no comma-separated-list alternative.
+static DECLARED: &[&ViolationDef] = &[&FIELD_LINE_DUPLICATED];
 
 pub struct DeprecationHeaderSyntax;
 
@@ -21,12 +28,6 @@ const RFC_9651_3_3_7: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("3.3.7"),
     url: "https://www.rfc-editor.org/rfc/rfc9651.html#section-3.3.7",
     note: "Structured Field `Date` item syntax (leading `@`)",
-};
-const RFC_9110_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("5.3"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
-    note: "Field Order: an Item field (non-list) must not appear as multiple field lines",
 };
 
 impl RuleMeta for DeprecationHeaderSyntax {
@@ -46,6 +47,10 @@ severity = "warn"
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[RFC_9745_2_1, RFC_9651_3_3_7, RFC_9110_5_3]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -95,7 +100,7 @@ impl Rule for DeprecationHeaderSyntax {
             // cite(RFC 9745 § 2.1): "Deprecation is an Item Structured Header Field; its value MUST be a Date as per Section 3.3.7 of [RFC9651]."
             // cite(RFC 9110 § 5.3): "a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list"
             if vals.len() > 1 {
-                return Some(self.violation(ctx.severity, "Multiple Deprecation header fields present; Deprecation is a single Structured Field Item (RFC 9745 §2.1), so a response carries at most one Deprecation field line (RFC 9110 §5.3)".into()));
+                return Some(ctx.report_with(&FIELD_LINE_DUPLICATED, "Multiple Deprecation header fields present; Deprecation is a single Structured Field Item (RFC 9745 §2.1), so a response carries at most one Deprecation field line (RFC 9110 §5.3)".into()));
             }
 
             let hv = vals.into_iter().next()?;

--- a/lint-http-rules/src/rules/etag_syntax.rs
+++ b/lint-http-rules/src/rules/etag_syntax.rs
@@ -8,6 +8,7 @@ use crate::violations::etag::{
     entity_tag_defect, ETAG_CHARACTER_FORBIDDEN, ETAG_DELIMITER_MISSING,
     ETAG_WEAK_INDICATOR_INVALID, RFC_9110_8_8_3,
 };
+use crate::violations::field::{FIELD_LINE_DUPLICATED, RFC_9110_5_3};
 use crate::violations::ViolationDef;
 
 /// The production's three defects, which is everything this rule says about a
@@ -19,24 +20,20 @@ use crate::violations::ViolationDef;
 /// `*` is not a tag but is the shape a server copies from the conditional
 /// fields, and more than one field line is a statement about the message.
 static DECLARED: &[&ViolationDef] = &[
+    &FIELD_LINE_DUPLICATED,
     &ETAG_WEAK_INDICATOR_INVALID,
     &ETAG_DELIMITER_MISSING,
     &ETAG_CHARACTER_FORBIDDEN,
 ];
 
-/// Validate `ETag` header values: must be a single entity-tag (strong or weak quoted-string)
-/// per RFC 9110 §8.8.3. Also flags invalid UTF-8 and multiple header fields.
+/// Validate `ETag` header values: must be a single entity-tag (strong or weak
+/// quoted-string) per RFC 9110 §8.8.3. Also flags a repeated field line.
+///
+/// Both specification references this rule declares now live beside the defs
+/// they answer for — the entity-tag grammar in `violations/etag.rs` and § 5.3's
+/// field order in `violations/field.rs` — which is why no `SpecRef` is written
+/// here.
 pub struct EtagSyntax;
-
-/// The specification references this rule declares, each named so a finding
-/// site can cite the one it enforces. `specifications()` below is built from
-/// exactly these, so the docs and the citations cannot name different text.
-const RFC_9110_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("5.3"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
-    note: "Field Order: a non-list field (such as `ETag = entity-tag`) must not appear as multiple field lines",
-};
 
 impl RuleMeta for EtagSyntax {
     fn id(&self) -> &'static str {
@@ -158,7 +155,7 @@ impl Rule for EtagSyntax {
             // exception does not apply, and a sender must emit at most one ETag field line.
             // cite(RFC 9110 § 5.3): "a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list"
             if count > 1 {
-                return Some(self.cited(&RFC_9110_5_3, ctx.severity, format!(
+                return Some(ctx.report_with(&FIELD_LINE_DUPLICATED, format!(
                         "Multiple ETag header fields present ({}); ETag must be a single entity-tag",
                         count
                     )));

--- a/lint-http-rules/src/rules/retry_after_date_or_delay.rs
+++ b/lint-http-rules/src/rules/retry_after_date_or_delay.rs
@@ -4,6 +4,13 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::field::{FIELD_LINE_DUPLICATED, RFC_9110_5_3};
+use crate::violations::ViolationDef;
+
+/// § 5.3's repeated field line, which this rule reports for its own field.
+/// The sentence is the catalogue's; what stays here is the reading that says
+/// this field's definition has no comma-separated-list alternative.
+static DECLARED: &[&ViolationDef] = &[&FIELD_LINE_DUPLICATED];
 
 pub struct RetryAfterDateOrDelay;
 
@@ -37,7 +44,11 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[RFC_9110_10_2_3]
+        &[RFC_9110_10_2_3, RFC_9110_5_3]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -81,7 +92,7 @@ impl Rule for RetryAfterDateOrDelay {
             // comma of its own, so a comma-joined value is ambiguous rather than merely long.
             // cite(RFC 9110 § 5.3): "a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list"
             if resp.headers.get_all("retry-after").iter().count() > 1 {
-                return Some(self.violation(ctx.severity, "Multiple Retry-After header fields present; Retry-After takes a single value and cannot be combined into a list".into()));
+                return Some(ctx.report_with(&FIELD_LINE_DUPLICATED, "Multiple Retry-After header fields present; Retry-After takes a single value and cannot be combined into a list".into()));
             }
 
             // Each value is either a delay-seconds count or an HTTP-date.

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -2358,45 +2358,45 @@ sources:
     - file: lint-http-rules/src/rules/content_disposition_parameter_valid.rs
       line: 145
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 172
+      line: 168
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 255
+      line: 251
   - label: content_disposition_token_valid
     section: § 1
     snippet: This document does not apply to Content-Disposition header fields appearing in payload bodies transmitted over HTTP, such as when using the media type "multipart/form-data" ([RFC2388]).
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 153
+      line: 149
   - label: content_disposition_token_valid (2)
     section: § 4
     snippet: The Content-Disposition response header field is used to convey additional information about how to process the response payload, and also can be used to attach additional metadata, such as the filename to use when saving the response payload locally.
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 152
+      line: 148
   - label: content_disposition_token_valid (3)
     section: § 4.1
     snippet: Note that due to the rules for implied linear whitespace (Section 2.1 of [RFC2616]), OPTIONAL whitespace can appear between words (token or quoted-string) and separator characters.
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 184
+      line: 180
   - label: content_disposition_token_valid (4)
     section: § 4.1
     snippet: disp-ext-type       = token
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 204
+      line: 200
   - label: content_disposition_token_valid (5)
     section: § 4.1
     snippet: disposition-type = "inline" | "attachment" | disp-ext-type
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 186
+      line: 182
   - label: content_disposition_token_valid (6)
     section: § 4.2
     snippet: Unknown or unhandled disposition types SHOULD be handled by recipients the same way as "attachment" (see also [RFC2183], Section 2.8).
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 205
+      line: 201
 - label: RFC 6335
   url: https://www.rfc-editor.org/rfc/rfc6335.html
   fragments:
@@ -4709,7 +4709,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 252
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 310
+      line: 306
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 277
   - label: accept_and_content_type_negotiation (11)
@@ -4739,7 +4739,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
       line: 161
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 222
+      line: 218
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 226
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
@@ -5381,7 +5381,7 @@ sources:
     - file: lint-http-rules/src/rules/charset_registered.rs
       line: 150
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 181
+      line: 177
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
       line: 142
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
@@ -5469,45 +5469,45 @@ sources:
     snippet: A recipient MUST ignore If-Modified-Since if the request contains an If-None-Match header field
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 170
+      line: 173
   - label: conditional_headers_consistent (2)
     section: § 13.1.3
     snippet: A recipient MUST ignore the If-Modified-Since header field if the received field value is not a valid HTTP-date, the field value has more than one member, or if the request method is neither GET nor HEAD.
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 254
+      line: 257
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 272
+      line: 275
   - label: conditional_headers_consistent (3)
     section: § 13.1.4
     snippet: A recipient MUST ignore If-Unmodified-Since if the request contains an If-Match header field
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 177
+      line: 180
   - label: conditional_headers_consistent (4)
     section: § 13.1.4
     snippet: A recipient MUST ignore the If-Unmodified-Since header field if the received field value is not a valid HTTP-date (including when the field value appears to be a list of dates).
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 255
+      line: 258
   - label: conditional_headers_consistent (5)
     section: § 13.1.5
     snippet: A client MUST NOT generate an If-Range header field containing an entity tag that is marked as weak.
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 203
+      line: 206
   - label: conditional_headers_consistent (6)
     section: § 13.1.5
     snippet: A client MUST NOT generate an If-Range header field in a request that does not contain a Range header field.
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 189
+      line: 192
   - label: conditional_headers_consistent (7)
     section: § 13.1.5
     snippet: A valid entity-tag can be distinguished from a valid HTTP-date by examining the first three characters for a DQUOTE.
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 219
+      line: 222
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
       line: 278
   - label: If-Range grammar
@@ -5515,7 +5515,7 @@ sources:
     snippet: If-Range = entity-tag / HTTP-date
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 218
+      line: 221
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 49
   - label: conditional_request_handling
@@ -5579,7 +5579,7 @@ sources:
     snippet: Field values are usually constrained to the range of US-ASCII characters [USASCII].
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 282
+      line: 278
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
       line: 251
   - label: content_encoding_and_type_consistent
@@ -5709,7 +5709,7 @@ sources:
     - file: lint-http-rules/src/rules/content_type_present.rs
       line: 179
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 220
+      line: 216
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 46
   - label: content_type_present (4)
@@ -5749,7 +5749,7 @@ sources:
     snippet: Although Content-Type is defined as a singleton field, it is sometimes incorrectly generated multiple times, resulting in a combined field value that appears to be a list.
     cited_by:
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 221
+      line: 217
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 225
   - label: context_fields_direction
@@ -5829,7 +5829,7 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 48
     - file: lint-http-rules/src/rules/retry_after_date_or_delay.rs
-      line: 75
+      line: 86
     - file: lint-http-rules/src/rules/retry_after_status_valid.rs
       line: 165
     - file: lint-http-rules/src/rules/retry_after_status_valid.rs
@@ -5909,7 +5909,7 @@ sources:
     snippet: The "ETag" field in a response provides the current entity tag for the selected representation, as determined at the conclusion of handling the request.
     cited_by:
     - file: lint-http-rules/src/rules/etag_syntax.rs
-      line: 116
+      line: 113
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 45
   - label: expect_header_valid
@@ -6999,21 +6999,21 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 28
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 251
+      line: 254
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 257
+      line: 253
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 223
+      line: 219
     - file: lint-http-rules/src/rules/deprecation_header_syntax.rs
-      line: 96
+      line: 101
     - file: lint-http-rules/src/rules/etag_syntax.rs
-      line: 159
+      line: 156
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 369
     - file: lint-http-rules/src/rules/host_header.rs
       line: 199
     - file: lint-http-rules/src/rules/retry_after_date_or_delay.rs
-      line: 82
+      line: 93
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
       line: 113
     - file: lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
@@ -7047,7 +7047,7 @@ sources:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
       line: 252
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 244
+      line: 240
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
       line: 260
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
@@ -7069,7 +7069,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 410
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 256
+      line: 252
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 270
   - label: lint-http-rules/src/helpers/headers.rs (7)
@@ -7577,7 +7577,7 @@ sources:
     - file: lint-http-rules/src/helpers/validator.rs
       line: 140
     - file: lint-http-rules/src/rules/etag_syntax.rs
-      line: 141
+      line: 138
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
       line: 145
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
@@ -8603,13 +8603,13 @@ sources:
     snippet: A delay-seconds value is a non-negative decimal integer, representing time in seconds.
     cited_by:
     - file: lint-http-rules/src/rules/retry_after_date_or_delay.rs
-      line: 101
+      line: 112
   - label: retry_after_date_or_delay (2)
     section: § 10.2.3
     snippet: Retry-After = HTTP-date / delay-seconds
     cited_by:
     - file: lint-http-rules/src/rules/retry_after_date_or_delay.rs
-      line: 88
+      line: 99
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 54
   - label: retry_after_status_valid
@@ -11071,7 +11071,7 @@ sources:
     snippet: their serialization in textual HTTP fields is similar to that of Integers, distinguished from them with a leading "@".
     cited_by:
     - file: lint-http-rules/src/rules/deprecation_header_syntax.rs
-      line: 116
+      line: 121
     - file: lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
       line: 161
   - label: lint-http-rules/src/helpers/structured_fields.rs
@@ -11533,15 +11533,15 @@ sources:
     snippet: The Deprecation HTTP response header field allows a server to communicate to a client application that the resource in the context of the message will be or has been deprecated.
     cited_by:
     - file: lint-http-rules/src/rules/deprecation_header_syntax.rs
-      line: 83
+      line: 88
   - label: deprecation_header_syntax (2)
     section: § 2.1
     snippet: Deprecation is an Item Structured Header Field; its value MUST be a Date as per Section 3.3.7 of [RFC9651].
     cited_by:
     - file: lint-http-rules/src/rules/deprecation_header_syntax.rs
-      line: 95
+      line: 100
     - file: lint-http-rules/src/rules/deprecation_header_syntax.rs
-      line: 115
+      line: 120
     - file: lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
       line: 160
   - label: sunset_and_deprecation_consistent


### PR DESCRIPTION
Content-Type, Content-Disposition, ETag, Retry-After, Deprecation and the two date conditionals report a second field line under the shared id instead of wording section 5.3 six more ways. Three of them had written their own SpecRef for a section the subject already carries, which is the convention this catalogue keeps: a rule declaring a section the violations catalogue declares has not finished converting.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
