### PR TITLE
A subject's doc counts its declarers correctly

### DIFF
--- a/lint-http-rules/src/violations/field.rs
+++ b/lint-http-rules/src/violations/field.rs
@@ -13,9 +13,9 @@
 //! a comma-separated-list alternative, and a message breaking it carries values
 //! that are each perfectly well formed.
 //!
-//! That is why it is shared as widely as it is. **Thirty-six rules in this tree
-//! report a repeated field line today**, one field apiece, in thirty-six
-//! wordings of one sentence — and `singleton_fields_not_repeated` reports it for
+//! That is why it is shared as widely as it is. **Nineteen rules in this tree
+//! report a repeated field line**, one field apiece, in nineteen wordings of one
+//! sentence — and `singleton_fields_not_repeated` reports it for
 //! sixteen more fields that have no rule of their own. The spread is
 //! deliberate: that rule's own prose says eight singleton fields are left to the
 //! rules that read their values, "with the joined value in the finding". So the


### PR DESCRIPTION
The count in the field subject's prose came from a file-level grep that matched test assertions and rule descriptions as well as finding sites. Nineteen rules report a repeated field line, not thirty-six.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
