### PR TITLE
A header names its defects after the field

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1447,6 +1447,18 @@ severity = "warn"
 # Node identifier holds something that is not a node-port
 severity = "warn"
 
+[violations.origin_agent_cluster_empty]
+# Origin-Agent-Cluster is written with no boolean on it
+severity = "warn"
+
+[violations.origin_agent_cluster_invalid]
+# Origin-Agent-Cluster states a value that is not `?1`
+severity = "warn"
+
+[violations.origin_agent_cluster_malformed]
+# Origin-Agent-Cluster carries a list where a boolean is due
+severity = "warn"
+
 [violations.parameter_equals_missing]
 # Parameter is written without its '='
 severity = "warn"

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1312,7 +1312,7 @@ severity = "warn"
         /// directive list, and neither says anything about an encoding. Each
         /// field's octet is now `token`'s, under an id the rule already
         /// declared.
-        const FLOOR: usize = 140;
+        const FLOOR: usize = 138;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/rules/origin_isolated_header_valid.rs
+++ b/lint-http-rules/src/rules/origin_isolated_header_valid.rs
@@ -5,24 +5,30 @@
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
 use crate::violations::field::{FIELD_LINE_DUPLICATED, RFC_9110_5_3};
+use crate::violations::origin_agent_cluster::{
+    HTML_7_1_2, ORIGIN_AGENT_CLUSTER_EMPTY, ORIGIN_AGENT_CLUSTER_INVALID,
+    ORIGIN_AGENT_CLUSTER_MALFORMED,
+};
 use crate::violations::ViolationDef;
 
-/// The one entry a field with no list form always has available: its own
-/// repetition. The value on each line here is measured by the checks below;
-/// what § 5.3 forbids is there being two lines at all.
-static DECLARED: &[&ViolationDef] = &[&FIELD_LINE_DUPLICATED];
+/// One entry every field has available — its own repetition, which § 5.3
+/// forbids a field with no list form — and the three the value itself can
+/// reach: nothing written, more than one thing written, and one thing written
+/// that is not the boolean the header exists to carry.
+static DECLARED: &[&ViolationDef] = &[
+    &FIELD_LINE_DUPLICATED,
+    &ORIGIN_AGENT_CLUSTER_EMPTY,
+    &ORIGIN_AGENT_CLUSTER_MALFORMED,
+    &ORIGIN_AGENT_CLUSTER_INVALID,
+];
 
 pub struct OriginIsolatedHeaderValid;
 
-/// The specification references this rule declares, each named so a finding
-/// site can cite the one it enforces. `specifications()` below is built from
-/// exactly these, so the docs and the citations cannot name different text.
-const HTML_7_1_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "HTML",
-    section: Some("7.1.2"),
-    url: "https://html.spec.whatwg.org/multipage/browsers.html#origin-keyed-agent-clusters",
-    note: "`Origin-Agent-Cluster` — a structured-header boolean; only the `?1` true value requests an origin-keyed agent cluster",
-};
+/// The one reference this rule still owns, and it is the further reading
+/// `specifications()` is deliberately wider by: it defines the boolean the
+/// header's value is, and no finding is measured against it directly. The two
+/// that a finding does enforce belong to the catalogue — `HTML § 7.1.2` beside
+/// the defects it condemns, RFC 9110 § 5.3 beside the repeated line.
 const RFC_9651_3: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9651",
     section: Some("3"),
@@ -100,6 +106,10 @@ impl Rule for OriginIsolatedHeaderValid {
                 return None;
             };
 
+            // The response is where this header is read, and the field name is
+            // the shipped one: `Origin-Isolation`, which this rule is named
+            // after, was the proposal and never arrived.
+            // cite(HTML § 7.1.2): "A Document delivered over a secure context can request that it be placed in an origin-keyed agent cluster, by using the `Origin-Agent-Cluster` HTTP response header."
             let count = resp.headers.get_all("origin-agent-cluster").iter().count();
             if count == 0 {
                 return None;
@@ -125,26 +135,28 @@ impl Rule for OriginIsolatedHeaderValid {
             let line = crate::helpers::headers::field_line_as_written(hv);
             let val = crate::helpers::headers::trim_ows(&line);
 
-            // Must not be a comma-separated list
-            // cite(HTML § 7.1.2): "This header is a structured header whose value must be a boolean."
-            if crate::helpers::list::list_members(val).count() != 1 {
-                return Some(self.cited(
-                    &HTML_7_1_2,
-                    ctx.severity,
-                    "Origin-Agent-Cluster must be a single value".into(),
-                ));
+            // How many things the sender wrote, which is the question the
+            // field's value being a single Item asks. None and several are
+            // separate defects: a line with nothing on it states no
+            // preference, a line with two states one the recipient may not
+            // resolve.
+            let members = crate::helpers::list::list_members(val).count();
+            if members == 0 {
+                return Some(ctx.report(&ORIGIN_AGENT_CLUSTER_EMPTY));
+            }
+            if members > 1 {
+                return Some(ctx.report(&ORIGIN_AGENT_CLUSTER_MALFORMED));
             }
 
             // `?1` is the structured-header boolean true value that requests an
             // origin-keyed agent cluster. The spec *ignores* any other value; this
             // rule is deliberately stricter and reports it, since a non-`?1` value
             // (`?0`, `unsafe-none`, …) is almost always a server misconfiguration.
-            // cite(HTML § 7.1.2): "values that are not the structured header boolean true value (i.e., `?1`) will be ignored."
             if val.eq("?1") {
                 return None;
             }
 
-            Some(self.cited(&HTML_7_1_2, ctx.severity, format!("Origin-Agent-Cluster header value '{}' is invalid: expected '?1' to request an origin-keyed agent cluster", crate::helpers::shown::shown_in_finding(val))))
+            Some(ctx.report_with(&ORIGIN_AGENT_CLUSTER_INVALID, format!("Origin-Agent-Cluster header value '{}' is invalid: expected '?1' to request an origin-keyed agent cluster", crate::helpers::shown::shown_in_finding(val))))
         };
         Vec::from_iter(finding())
     }
@@ -194,6 +206,37 @@ mod tests {
                 val,
                 v
             );
+        }
+    }
+
+    /// Three ways to write a value that is not the boolean, and each answers
+    /// under its own id — a line with nothing on it is a different defect from
+    /// a line with two things on it, and both are different from a `?0`. The
+    /// commas-only value is the one worth pinning: it holds octets and no
+    /// member, which is the same reading `Content-Length` makes of `,,`.
+    #[test]
+    fn each_shape_of_wrong_value_reports_its_own_id() {
+        for (value, id) in [
+            ("", "origin_agent_cluster_empty"),
+            (",,", "origin_agent_cluster_empty"),
+            ("?1, ?1", "origin_agent_cluster_malformed"),
+            ("?0", "origin_agent_cluster_invalid"),
+            ("unsafe-none", "origin_agent_cluster_invalid"),
+        ] {
+            let tx = crate::test_helpers::make_test_transaction_with_response(
+                200,
+                &[("origin-agent-cluster", value)],
+            );
+            let found = crate::test_helpers::run_rule(
+                &OriginIsolatedHeaderValid,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "origin_isolated_header_valid",
+                ]),
+            )
+            .expect("a finding");
+            assert_eq!(found.violation, id, "{value}");
         }
     }
 

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -48,6 +48,7 @@ pub mod language;
 pub mod list;
 pub mod mailbox;
 pub mod node;
+pub mod origin_agent_cluster;
 pub mod parameter;
 pub mod quoted_pair;
 pub mod quoted_string;
@@ -364,7 +365,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 121;
+        const FLOOR: usize = 124;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/origin_agent_cluster.rs
+++ b/lint-http-rules/src/violations/origin_agent_cluster.rs
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `Origin-Agent-Cluster` defects — a response header whose whole value is one
+//! structured-field boolean, and the three ways a sender writes something else.
+//!
+//! **The first subject here that exists for a single rule.** Every other one is
+//! shared: a production several fields write their values in, a field two
+//! mirrored rules read from opposite ends of the exchange, a sentence nineteen
+//! rules word nineteen ways. This one is read by
+//! `origin_isolated_header_valid` and by nothing else, and it is written down
+//! anyway — because a violation id is what an operator configures, and an
+//! operator configures a *defect in the traffic*, not the internal arrangement
+//! of the crate that noticed it.
+//!
+//! **The subject is the field, and this field is the argument for that.** The
+//! rule is named `origin_isolated_header_valid`, after the `Origin-Isolation`
+//! proposal that never shipped; the header browsers honour is
+//! `Origin-Agent-Cluster`. An id built from the rule would make an operator
+//! silence a defect under the name of a header that does not exist, and would
+//! move the day the rule is renamed or absorbed — neither of which is a fact
+//! about the traffic. So the ids here name the field, exactly as
+//! `docs/development.md` says and for the reason it gives, and the long tail of
+//! rules whose findings are their own document's statements needs no new kind
+//! of subject: it needs the field spelled out.
+//!
+//! **What HTML asks of the value, in one sentence and one consequence.** The
+//! value must be a boolean, which is an Item and not a List; and any value that
+//! is not the true value `?1` is ignored. The first is a grammar, so writing a
+//! list or writing nothing breaks it. The second is not — `?0` is a perfectly
+//! well-formed boolean — which is why the entry for it is `_invalid` rather
+//! than `_malformed`, and why this crate reports something the specification
+//! is content to drop on the floor: a server that wrote `?0` or `unsafe-none`
+//! meant to ask for something, and is not getting it.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// Where the header is defined, what it requests, and the two sentences the
+/// entries below enforce.
+pub const HTML_7_1_2: SpecRef = SpecRef {
+    spec: "HTML",
+    section: Some("7.1.2"),
+    url: "https://html.spec.whatwg.org/multipage/browsers.html#origin-keyed-agent-clusters",
+    note: "`Origin-Agent-Cluster` — a structured-header boolean; only the `?1` true value requests an origin-keyed agent cluster",
+};
+
+defects! {
+    /// The header is written and no boolean is written on it: an empty value,
+    /// or one made of nothing but the commas of a list.
+    ///
+    /// Separated from the value that is merely not `?1` because the senders
+    /// differ and so does the fix. A `?0` is a server stating a preference this
+    /// crate disagrees with; an empty value is a server that meant to state one
+    /// and emitted nothing — a template that expanded to nothing, or a proxy
+    /// that dropped the value and kept the line.
+    ///
+    // cite(HTML § 7.1.2, label: Origin-Agent-Cluster is a boolean): "This header is a structured header whose value must be a boolean."
+    ORIGIN_AGENT_CLUSTER_EMPTY = {
+        id: "origin_agent_cluster_empty",
+        title: "Origin-Agent-Cluster is written with no boolean on it",
+        message: "Origin-Agent-Cluster is written with no value",
+        default_severity: Severity::Warn,
+        spec: Some(HTML_7_1_2),
+    }
+
+    /// More than one member on the line, where the field's value is a single
+    /// Item. `?1, ?1` is a List, and a List is not a boolean however true each
+    /// of its members is — so this is the grammar being broken rather than a
+    /// preference being refused, and a recipient has no sentence telling it
+    /// which member to read.
+    ///
+    // cite(HTML § 7.1.2, label: Origin-Agent-Cluster is a boolean): "This header is a structured header whose value must be a boolean."
+    ORIGIN_AGENT_CLUSTER_MALFORMED = {
+        id: "origin_agent_cluster_malformed",
+        title: "Origin-Agent-Cluster carries a list where a boolean is due",
+        message: "Origin-Agent-Cluster must be a single value",
+        default_severity: Severity::Warn,
+        spec: Some(HTML_7_1_2),
+    }
+
+    /// One value, and it is not the true value. `?1` is what requests an
+    /// origin-keyed agent cluster; `?0`, `1`, `true` and `unsafe-none` are each
+    /// a value the processing model ignores.
+    ///
+    /// **The document ignores it and this catalogue reports it**, which is a
+    /// deliberate step past what is quoted below: nothing is broken for the
+    /// recipient, since ignoring is exactly what it is told to do. What is
+    /// broken is the sender's intent — the header has one use, and a value that
+    /// is not `?1` puts it to none.
+    ///
+    // cite(HTML § 7.1.2): "values that are not the structured header boolean true value (i.e., `?1`) will be ignored."
+    ORIGIN_AGENT_CLUSTER_INVALID = {
+        id: "origin_agent_cluster_invalid",
+        title: "Origin-Agent-Cluster states a value that is not `?1`",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(HTML_7_1_2),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The subject is the field and not the rule, and the ids say so — a rule
+    /// named for a proposal that never shipped reports defects named for the
+    /// header that did.
+    #[test]
+    fn every_id_names_the_field_rather_than_the_rule_that_reads_it() {
+        for def in [
+            &ORIGIN_AGENT_CLUSTER_EMPTY,
+            &ORIGIN_AGENT_CLUSTER_MALFORMED,
+            &ORIGIN_AGENT_CLUSTER_INVALID,
+        ] {
+            assert!(
+                def.id.starts_with("origin_agent_cluster_"),
+                "{} is not spelled for the field",
+                def.id,
+            );
+            assert!(
+                !def.id.contains("isolated"),
+                "{} is spelled for the rule",
+                def.id,
+            );
+        }
+    }
+
+    /// The grammar half carries its whole message and the preference half does
+    /// not: `?0` is reported with the value in hand, because the operator's
+    /// next question is which value arrived.
+    #[test]
+    fn only_the_entry_naming_a_value_leaves_its_message_to_the_site() {
+        assert!(!ORIGIN_AGENT_CLUSTER_EMPTY.message.is_empty());
+        assert!(!ORIGIN_AGENT_CLUSTER_MALFORMED.message.is_empty());
+        assert!(ORIGIN_AGENT_CLUSTER_INVALID.message.is_empty());
+    }
+}

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -137,18 +137,26 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/cross_origin_opener_policy_valid.rs
       line: 164
-  - label: origin_isolated_header_valid
+  - label: Origin-Agent-Cluster is a boolean
     section: § 7.1.2
     snippet: This header is a structured header whose value must be a boolean.
     cited_by:
-    - file: lint-http-rules/src/rules/origin_isolated_header_valid.rs
-      line: 129
-  - label: origin_isolated_header_valid (2)
+    - file: lint-http-rules/src/violations/origin_agent_cluster.rs
+      line: 60
+    - file: lint-http-rules/src/violations/origin_agent_cluster.rs
+      line: 75
+  - label: origin_agent_cluster
     section: § 7.1.2
     snippet: values that are not the structured header boolean true value (i.e., `?1`) will be ignored.
     cited_by:
+    - file: lint-http-rules/src/violations/origin_agent_cluster.rs
+      line: 94
+  - label: origin_isolated_header_valid
+    section: § 7.1.2
+    snippet: A Document delivered over a secure context can request that it be placed in an origin-keyed agent cluster, by using the `Origin-Agent-Cluster` HTTP response header.
+    cited_by:
     - file: lint-http-rules/src/rules/origin_isolated_header_valid.rs
-      line: 142
+      line: 112
 - label: HTML Links
   url: https://html.spec.whatwg.org/multipage/links.html
   type: text/html


### PR DESCRIPTION
The Origin-Agent-Cluster rule reports three defects of its own document's making, and they get ids for the first time: nothing written on the line, more than one thing written, and one thing that is not the boolean the header exists to carry. The empty value used to be reported as a value that is not single, which is a different sender and a different fix.

The ids name the field rather than the rule, which this header argues for better than most: the rule is named after Origin-Isolation, a proposal that never shipped, and an operator silencing a defect should not have to spell a header that does not exist.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
