### PR TITLE
Chunked framing names three defects

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1527,6 +1527,18 @@ severity = "warn"
 # Token holds whitespace or a control character
 severity = "error"
 
+[violations.transfer_encoding_chunked_duplicated]
+# The chunked transfer coding is applied more than once
+severity = "warn"
+
+[violations.transfer_encoding_chunked_missing]
+# A coding is applied and chunked never is
+severity = "warn"
+
+[violations.transfer_encoding_chunked_position_invalid]
+# The chunked transfer coding is not the final one
+severity = "warn"
+
 [violations.uri_character_forbidden]
 # Value holds a character no URI is written with
 severity = "warn"

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1312,7 +1312,7 @@ severity = "warn"
         /// directive list, and neither says anything about an encoding. Each
         /// field's octet is now `token`'s, under an id the rule already
         /// declared.
-        const FLOOR: usize = 138;
+        const FLOOR: usize = 136;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
+++ b/lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
@@ -4,18 +4,28 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::transfer_encoding::{
+    RFC_9112_6_1, TRANSFER_ENCODING_CHUNKED_DUPLICATED, TRANSFER_ENCODING_CHUNKED_MISSING,
+    TRANSFER_ENCODING_CHUNKED_POSITION_INVALID,
+};
+use crate::violations::ViolationDef;
+
+/// § 6.1's paragraph, one entry per way of getting the sequence wrong: the
+/// coding applied twice, the coding applied and not last, and the coding never
+/// applied where something else was. The section itself is the catalogue's, so
+/// the quotes sit on the defs and this rule cites the readings it makes.
+static DECLARED: &[&ViolationDef] = &[
+    &TRANSFER_ENCODING_CHUNKED_DUPLICATED,
+    &TRANSFER_ENCODING_CHUNKED_POSITION_INVALID,
+    &TRANSFER_ENCODING_CHUNKED_MISSING,
+];
 
 pub struct TransferEncodingChunkedFinal;
 
-/// The specification references this rule declares, each named so a finding
-/// site can cite the one it enforces. `specifications()` below is built from
-/// exactly these, so the docs and the citations cannot name different text.
-const RFC_9112_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9112",
-    section: Some("6.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.1",
-    note: "Transfer-Encoding — every requirement this rule enforces is here: chunked at most once, and chunked last (unconditionally for requests, or the connection closes for responses)",
-};
+/// The specification references this rule declares beyond the catalogue's
+/// § 6.1, each named so a finding site can cite the one it enforces.
+/// `specifications()` below is built from exactly these, so the docs and the
+/// citations cannot name different text.
 const RFC_9112_9_6: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9112",
     section: Some("9.6"),
@@ -56,6 +66,10 @@ severity = "warn"
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[RFC_9112_6_1, RFC_9112_9_6, RFC_9112_7_1, RFC_9110_10_1_4]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -194,12 +208,10 @@ impl Rule for TransferEncodingChunkedFinal {
             // specific defect wins -- and ahead of the response's close
             // exemption, because this sentence offers no alternative. Nothing
             // in § 6.1 lets a closed connection excuse chunking twice.
-            // cite(RFC 9112 § 6.1): "A sender MUST NOT apply the chunked transfer coding more than once to a message body (i.e., chunking an already chunked message is not allowed)."
             let chunked_count = codings.iter().filter(|c| *c == "chunked").count();
             if chunked_count > 1 {
-                return Some(self.cited(
-                    &RFC_9112_6_1,
-                    ctx.severity,
+                return Some(ctx.report_with(
+                    &TRANSFER_ENCODING_CHUNKED_DUPLICATED,
                     format!(
                         "The chunked transfer coding must not be applied more than once: \
                              codings found '{}'",
@@ -209,8 +221,9 @@ impl Rule for TransferEncodingChunkedFinal {
             }
 
             // § 6.1 gives a response two ways to satisfy the same requirement,
-            // and the rule knew only one of them:
-            // cite(RFC 9112 § 6.1): "If any transfer coding other than chunked is applied to a response's content, the sender MUST either apply chunked as the final transfer coding or terminate the message by closing the connection."
+            // and the rule knew only one of them — the sentence is quoted on
+            // `transfer_encoding_chunked_position_invalid`, which is the defect
+            // this exemption stands in front of.
             //
             // So `Transfer-Encoding: chunked, gzip` on a response was reported
             // as a violation of a requirement the sender may have met the other
@@ -238,7 +251,7 @@ impl Rule for TransferEncodingChunkedFinal {
             // If 'chunked' appears anywhere other than the final coding it's a violation
             if let Some(pos) = codings.iter().position(|c| c == "chunked") {
                 if pos != codings.len() - 1 {
-                    return Some(self.violation(ctx.severity, format!(
+                    return Some(ctx.report_with(&TRANSFER_ENCODING_CHUNKED_POSITION_INVALID, format!(
                             "Transfer-Encoding 'chunked' must be the final coding: codings found '{}'",
                             codings.join(", ")
                         )));
@@ -253,19 +266,19 @@ impl Rule for TransferEncodingChunkedFinal {
             //     Transfer-Encoding: gzip
             //
             // passed. It applies a transfer coding other than chunked and never
-            // frames the result, which is the case the sentence exists for.
+            // frames the result, which is the case the sentence exists for —
+            // and the sentence is quoted on
+            // `transfer_encoding_chunked_missing`, which is what this reports.
             // (A test asserted this was fine.)
-            // cite(RFC 9112 § 6.1): "If any transfer coding other than chunked is applied to a request's content, the sender MUST apply chunked as the final transfer coding to ensure that the message is properly framed."
             //
             // Requests only. The response form of the sentence offers a second
-            // way to satisfy it, handled below.
+            // way to satisfy it, handled above.
             if is_request
                 && codings.iter().any(|c| c != "chunked")
                 && codings.last().map(String::as_str) != Some("chunked")
             {
-                return Some(self.cited(
-                    &RFC_9112_6_1,
-                    ctx.severity,
+                return Some(ctx.report_with(
+                    &TRANSFER_ENCODING_CHUNKED_MISSING,
                     format!(
                         "A request that applies any transfer coding other than chunked must apply \
                              chunked as the final coding: codings found '{}'",
@@ -354,6 +367,31 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    /// One paragraph, three ids, and the sequence decides which — not the
+    /// message direction. `chunked, gzip` answers the same way whether a
+    /// request or a response wrote it, which is the whole argument for the
+    /// entries being named after the sequence.
+    #[rstest]
+    #[case("chunked, chunked", "transfer_encoding_chunked_duplicated")]
+    #[case("chunked, gzip", "transfer_encoding_chunked_position_invalid")]
+    #[case("gzip", "transfer_encoding_chunked_missing")]
+    fn each_sequence_reports_its_own_id(#[case] value: &str, #[case] id: &str) {
+        let tx = crate::test_helpers::make_test_transaction_with_headers(&[(
+            "transfer-encoding",
+            value,
+        )]);
+        let found = crate::test_helpers::run_rule(
+            &TransferEncodingChunkedFinal,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "transfer_encoding_chunked_final",
+            ]),
+        )
+        .expect("a finding");
+        assert_eq!(found.violation, id, "{value}");
     }
 
     #[test]

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -55,6 +55,7 @@ pub mod quoted_string;
 pub mod qvalue;
 pub mod token;
 pub mod token68;
+pub mod transfer_encoding;
 pub mod uri;
 
 /// One reportable defect.
@@ -365,7 +366,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 124;
+        const FLOOR: usize = 127;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/transfer_encoding.rs
+++ b/lint-http-rules/src/violations/transfer_encoding.rs
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `Transfer-Encoding` defects — the sequence of codings a sender applied, and
+//! the one coding that has to be last.
+//!
+//! The field is framing, the way `Content-Length` is: the codings are applied
+//! in the order written and undone in reverse, and `chunked` is the one that
+//! delimits the result. So a sequence is not a description that happens to be
+//! in an awkward order — it is where the message ends, stated wrongly.
+//!
+//! **Three entries out of one paragraph.** RFC 9112 § 6.1 says `chunked` may be
+//! applied at most once, and that a sender applying any other coding must apply
+//! `chunked` last. The first is a sentence of its own and gets an entry of its
+//! own. The second is written twice, once per direction — unconditionally for a
+//! request, and for a response with the alternative of closing the connection —
+//! and the two directions are *not* what the ids split on. **What splits them is
+//! what the sender wrote**: `chunked` applied and something applied after it, or
+//! `chunked` never applied at all. Those are two different messages to a
+//! sender, two different fixes, and one shared requirement — so each entry
+//! quotes the direction of § 6.1 that states it most plainly and the other
+//! direction is the sibling entry's quote.
+//!
+//! **What is deliberately not here.** Whether a coding name is registered, and
+//! whether a member parses at all, are `transfer_coding_registered`'s findings
+//! and the `token` subject's ids; a value whose quoting never closes is declined
+//! by the ordering rule rather than reported by it, because members that cannot
+//! be delimited have no order to judge.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// The whole of the ordering requirement: `chunked` at most once, and
+/// `chunked` last — unconditionally for a request, or the connection closes for
+/// a response.
+pub const RFC_9112_6_1: SpecRef = SpecRef {
+    spec: "RFC 9112",
+    section: Some("6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.1",
+    note: "Transfer-Encoding — every requirement this rule enforces is here: chunked at most once, and chunked last (unconditionally for requests, or the connection closes for responses)",
+};
+
+defects! {
+    /// `chunked` applied twice to one body. Chunking an already chunked message
+    /// frames it twice, and a recipient undoing one layer finds chunk headers
+    /// where the content should be.
+    ///
+    /// **The one entry in this subject a closed connection cannot excuse.** The
+    /// sentence below offers no alternative — unlike the ordering requirement,
+    /// where a response may frame by closing instead — so it is answered before
+    /// the message direction is even considered.
+    ///
+    // cite(RFC 9112 § 6.1): "A sender MUST NOT apply the chunked transfer coding more than once to a message body (i.e., chunking an already chunked message is not allowed)."
+    TRANSFER_ENCODING_CHUNKED_DUPLICATED = {
+        id: "transfer_encoding_chunked_duplicated",
+        title: "The chunked transfer coding is applied more than once",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9112_6_1),
+    }
+
+    /// `chunked` is in the sequence and something is applied after it, so the
+    /// message is not chunk-framed on the wire — whatever the later coding
+    /// produced is, and the chunk boundaries are inside it.
+    ///
+    /// Quoted from the response's half of § 6.1 because that is the half a
+    /// response reaches this entry under, once it has been found not to
+    /// announce a close. A request reaches it under the stricter half, which is
+    /// quoted on [`TRANSFER_ENCODING_CHUNKED_MISSING`] — one requirement, two
+    /// directions, and the entry names the sequence rather than the direction.
+    ///
+    // cite(RFC 9112 § 6.1, label: chunked last or the connection closes): "If any transfer coding other than chunked is applied to a response's content, the sender MUST either apply chunked as the final transfer coding or terminate the message by closing the connection."
+    TRANSFER_ENCODING_CHUNKED_POSITION_INVALID = {
+        id: "transfer_encoding_chunked_position_invalid",
+        title: "The chunked transfer coding is not the final one",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9112_6_1),
+    }
+
+    /// A coding was applied and `chunked` was not, so nothing frames the
+    /// result. `Transfer-Encoding: gzip` on a request states that the content
+    /// is compressed and says nothing about where it ends.
+    ///
+    /// The sentence quoted here is unconditional, which is why the site
+    /// reporting it reads requests only: a response has the second alternative
+    /// of closing the connection, and this crate reads that from
+    /// `Connection: close` — an announcement RFC 9112 § 9.6 makes a SHOULD, so
+    /// a response that closes silently is left alone rather than reported here
+    /// on an inference.
+    ///
+    // cite(RFC 9112 § 6.1, label: chunked last, unconditionally): "If any transfer coding other than chunked is applied to a request's content, the sender MUST apply chunked as the final transfer coding to ensure that the message is properly framed."
+    TRANSFER_ENCODING_CHUNKED_MISSING = {
+        id: "transfer_encoding_chunked_missing",
+        title: "A coding is applied and chunked never is",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9112_6_1),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every entry names the sequence a sender wrote, and none of them names a
+    /// message direction — the requirement is written twice in § 6.1 and is one
+    /// requirement, so `transfer_encoding_request_*` would split the catalogue
+    /// where the document does not.
+    #[test]
+    fn no_entry_is_spelled_for_a_message_direction() {
+        for def in [
+            &TRANSFER_ENCODING_CHUNKED_DUPLICATED,
+            &TRANSFER_ENCODING_CHUNKED_POSITION_INVALID,
+            &TRANSFER_ENCODING_CHUNKED_MISSING,
+        ] {
+            assert!(
+                def.id.starts_with("transfer_encoding_chunked_"),
+                "{}",
+                def.id
+            );
+            assert!(!def.id.contains("request"), "{}", def.id);
+            assert!(!def.id.contains("response"), "{}", def.id);
+            assert_eq!(def.spec, Some(RFC_9112_6_1), "{}", def.id);
+        }
+    }
+
+    /// Each message names the codings that were found, so none of the entries
+    /// carries a whole message of its own.
+    #[test]
+    fn every_message_is_formatted_where_the_codings_are() {
+        for def in [
+            &TRANSFER_ENCODING_CHUNKED_DUPLICATED,
+            &TRANSFER_ENCODING_CHUNKED_POSITION_INVALID,
+            &TRANSFER_ENCODING_CHUNKED_MISSING,
+        ] {
+            assert!(def.message.is_empty(), "{}", def.id);
+        }
+    }
+}

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -5419,7 +5419,7 @@ sources:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 260
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 152
+      line: 166
   - label: compression_and_transfer_encoding_consistent (2)
     section: § 10.1.4
     snippet: transfer-parameter = token BWS "=" BWS ( token / quoted-string )
@@ -5429,7 +5429,7 @@ sources:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 241
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 134
+      line: 148
   - label: compression_and_transfer_encoding_consistent (3)
     section: § 8.4
     snippet: An origin server MAY respond with a status code of 415 (Unsupported Media Type) if a representation in the request message has a content coding that is not acceptable.
@@ -5563,7 +5563,7 @@ sources:
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
       line: 46
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 166
+      line: 180
   - label: connection_header_tokens_valid (2)
     section: § 7.6.1
     snippet: The "Connection" header field allows the sender to list desired control options for the current connection.
@@ -6549,7 +6549,7 @@ sources:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 246
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 136
+      line: 150
   - label: lint-http-rules/src/helpers/accept_ranges.rs (5)
     section: § 5.6.1.2
     snippet: In contrast, the following values would be invalid, since at least one non-empty element is required by the example-list production
@@ -7139,7 +7139,7 @@ sources:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 261
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 153
+      line: 167
     - file: lint-http-rules/src/rules/x_forwarded_consistent.rs
       line: 80
   - label: lint-http-rules/src/helpers/headers.rs (9)
@@ -7245,7 +7245,7 @@ sources:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 443
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 116
+      line: 130
     - file: lint-http-rules/src/violations/quoted_string.rs
       line: 43
   - label: lint-http-rules/src/helpers/mailbox.rs
@@ -9714,21 +9714,21 @@ sources:
 - label: RFC 9112
   url: https://www.rfc-editor.org/rfc/rfc9112.html
   fragments:
-  - label: compression_and_transfer_encoding_consistent
+  - label: chunked last, unconditionally
     section: § 6.1
     snippet: If any transfer coding other than chunked is applied to a request's content, the sender MUST apply chunked as the final transfer coding to ensure that the message is properly framed.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 115
-    - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 258
-  - label: compression_and_transfer_encoding_consistent (2)
+    - file: lint-http-rules/src/violations/transfer_encoding.rs
+      line: 94
+  - label: compression_and_transfer_encoding_consistent
     section: § 6.1
     snippet: Unlike Content-Encoding (Section 8.4.1 of [HTTP]), Transfer-Encoding is a property of the message, not of the representation.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 213
-  - label: compression_and_transfer_encoding_consistent (3)
+  - label: compression_and_transfer_encoding_consistent (2)
     section: § 7
     snippet: All transfer-coding names are case-insensitive and ought to be registered within the HTTP Transfer Coding registry, as defined in Section 7.3.
     cited_by:
@@ -9741,14 +9741,14 @@ sources:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 404
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 158
-  - label: compression_and_transfer_encoding_consistent (4)
+      line: 172
+  - label: compression_and_transfer_encoding_consistent (3)
     section: § 7.2
     snippet: 'The following transfer coding names for compression are defined by the same algorithm as their corresponding content coding:'
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 223
-  - label: compression_and_transfer_encoding_consistent (5)
+  - label: compression_and_transfer_encoding_consistent (4)
     section: § 7.3
     snippet: Names of transfer codings MUST NOT overlap with names of content codings (Section 8.4.1 of [HTTP]) unless the encoding transformation is identical, as is the case for the compression codings defined in Section 7.2.
     cited_by:
@@ -9837,7 +9837,7 @@ sources:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
       line: 298
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 298
+      line: 311
   - label: host_and_authority_consistent
     section: § 3.2.2
     snippet: When an origin server receives a request with an absolute-form of request-target, the origin server MUST ignore the received Host header field (if any) and instead use the host information of the request-target.
@@ -10278,30 +10278,30 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 270
-  - label: transfer_encoding_chunked_final
+  - label: transfer_encoding
     section: § 6.1
     snippet: A sender MUST NOT apply the chunked transfer coding more than once to a message body (i.e., chunking an already chunked message is not allowed).
     cited_by:
-    - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 197
-  - label: transfer_encoding_chunked_final (2)
+    - file: lint-http-rules/src/violations/transfer_encoding.rs
+      line: 55
+  - label: chunked last or the connection closes
     section: § 6.1
     snippet: If any transfer coding other than chunked is applied to a response's content, the sender MUST either apply chunked as the final transfer coding or terminate the message by closing the connection.
     cited_by:
-    - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 213
-  - label: transfer_encoding_chunked_final (3)
+    - file: lint-http-rules/src/violations/transfer_encoding.rs
+      line: 74
+  - label: transfer_encoding_chunked_final
     section: § 9.6
     snippet: A sender SHOULD send a Connection header field (Section 7.6.1 of [HTTP]) containing the "close" connection option when it intends to close a connection.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 233
-  - label: transfer_encoding_chunked_final (4)
+      line: 246
+  - label: transfer_encoding_chunked_final (2)
     section: § 9.6
     snippet: The "close" connection option is defined as a signal that the sender will close this connection after completion of the response.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 167
+      line: 181
 - label: RFC 9113
   url: https://www.rfc-editor.org/rfc/rfc9113.html
   fragments:


### PR DESCRIPTION
Transfer-Encoding gets a subject, and section 6.1's paragraph becomes three ids: chunked applied twice, chunked applied and not last, and chunked never applied where another coding was. The split is by what the sender wrote, not by which message wrote it — the requirement is written once per direction and is one requirement, so a request and a response that both put gzip after chunked answer under the same id.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
