### PR TITLE
A message may not frame itself twice

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1143,6 +1143,10 @@ severity = "error"
 # Content-Length declares no length
 severity = "error"
 
+[violations.content_length_forbidden]
+# Content-Length is sent in a message that is transfer-coded
+severity = "error"
+
 [violations.content_length_members_conflicting]
 # Content-Length is declared twice with different numbers
 severity = "error"

--- a/docs/rules/content_length_vs_transfer_encoding.md
+++ b/docs/rules/content_length_vs_transfer_encoding.md
@@ -14,7 +14,7 @@ Recipients are told to let `Transfer-Encoding` win and an intermediary that forw
 
 ## Specifications
 
-- [RFC 9112 §6.2](https://www.rfc-editor.org/rfc/rfc9112.html#section-6.2): The sender-side prohibition this rule enforces: Content-Length MUST NOT be sent in any message that contains Transfer-Encoding
+- [RFC 9112 §6.2](https://www.rfc-editor.org/rfc/rfc9112.html#section-6.2): Content-Length as framing — the declared length is how a recipient determines where the data and the message end, and the sender-side prohibition on sending it in a message that carries a Transfer-Encoding
 - [RFC 9112 §6.3](https://www.rfc-editor.org/rfc/rfc9112.html#section-6.3): The recipient side and the stakes: Transfer-Encoding overrides, a forwarding intermediary must strip the Content-Length, and such a message may be an attempt at request smuggling or response splitting
 
 ## Configuration

--- a/docs/rules/request_body_length_accuracy.md
+++ b/docs/rules/request_body_length_accuracy.md
@@ -19,7 +19,7 @@ Checks that a request's `Content-Length` matches the number of body octets actua
 ## Specifications
 
 - [RFC 9112 §6.3](https://www.rfc-editor.org/rfc/rfc9112.html#section-6.3): Message body length — item 6 is what licenses this rule at all, and its condition is 'without Transfer-Encoding'; item 3 is why a message carrying both is measured by neither
-- [RFC 9112 §6.2](https://www.rfc-editor.org/rfc/rfc9112.html#section-6.2): Content-Length as framing — the declared length is how a recipient determines where the data and the message end
+- [RFC 9112 §6.2](https://www.rfc-editor.org/rfc/rfc9112.html#section-6.2): Content-Length as framing — the declared length is how a recipient determines where the data and the message end, and the sender-side prohibition on sending it in a message that carries a Transfer-Encoding
 - [RFC 9110 §8.6](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6): Where the field and its `1*DIGIT` grammar are actually defined — the syntax itself is `content_length_valid`'s subject, not this rule's
 
 ## Configuration

--- a/docs/rules/response_body_length_accuracy.md
+++ b/docs/rules/response_body_length_accuracy.md
@@ -25,7 +25,7 @@ Checks that a response's `Content-Length` matches the number of body octets actu
 
 - [RFC 9112 §6.3](https://www.rfc-editor.org/rfc/rfc9112.html#section-6.3): Message body length, in precedence order — this rule is item 6, and items 1, 2 and 3 are why most responses are exempt rather than checked
 - [RFC 9110 §8.6](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6): Content-Length: the field, its grammar, the MUSTs that make a HEAD or 304 response's value describe a body it did not send, and the MUST NOT against forwarding a value known to be incorrect — this rule's reason to exist
-- [RFC 9112 §6.2](https://www.rfc-editor.org/rfc/rfc9112.html#section-6.2): Content-Length as framing — the declared length is how a recipient determines where the data and the message end
+- [RFC 9112 §6.2](https://www.rfc-editor.org/rfc/rfc9112.html#section-6.2): Content-Length as framing — the declared length is how a recipient determines where the data and the message end, and the sender-side prohibition on sending it in a message that carries a Transfer-Encoding
 - [RFC 9110 §9.3.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.2): HEAD — servers SHOULD answer it with the fields they would have sent for GET, which is what made the exemption the common case rather than a corner
 
 ## Configuration

--- a/lint-http-rules/src/rules/content_length_vs_transfer_encoding.rs
+++ b/lint-http-rules/src/rules/content_length_vs_transfer_encoding.rs
@@ -4,18 +4,19 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::content_length::{CONTENT_LENGTH_FORBIDDEN, RFC_9112_6_2};
+use crate::violations::ViolationDef;
+
+/// One defect, and it is the `Content-Length`'s: § 6.2 forbids sending that
+/// field in a transfer-coded message, so the field that may not be there is the
+/// one the id names. The direction is not part of it — a request and a response
+/// that each frame themselves twice are the same defect.
+static DECLARED: &[&ViolationDef] = &[&CONTENT_LENGTH_FORBIDDEN];
 
 pub struct ContentLengthVsTransferEncoding;
 
-/// The specification references this rule declares, each named so a finding
-/// site can cite the one it enforces. `specifications()` below is built from
-/// exactly these, so the docs and the citations cannot name different text.
-const RFC_9112_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9112",
-    section: Some("6.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.2",
-    note: "The sender-side prohibition this rule enforces: Content-Length MUST NOT be sent in any message that contains Transfer-Encoding",
-};
+/// The reference this rule owns beyond the catalogue's § 6.2: the recipient
+/// side, which is why the pairing is worth reporting rather than tidying.
 const RFC_9112_6_3: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9112",
     section: Some("6.3"),
@@ -44,6 +45,10 @@ severity = "warn"
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[RFC_9112_6_2, RFC_9112_6_3]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -78,8 +83,8 @@ impl Rule for ContentLengthVsTransferEncoding {
         // one finding (or none) becomes the vector.
         let finding = || -> Option<Violation> {
             // "in any message" is what puts both directions in scope; the same check runs
-            // over the response below.
-            // cite(RFC 9112 § 6.2): "A sender MUST NOT send a Content-Length header field in any message that contains a Transfer-Encoding header field."
+            // over the response below, and both report the one id — the
+            // prohibition is quoted on `content_length_forbidden`.
             //
             // The recipient side is why this is worth more than a style note. The two
             // fields give conflicting framing, recipients are told to resolve the
@@ -93,10 +98,7 @@ impl Rule for ContentLengthVsTransferEncoding {
             if tx.request.headers.contains_key("content-length")
                 && tx.request.headers.contains_key("transfer-encoding")
             {
-                return Some(self.violation(
-                    ctx.severity,
-                    "Both Content-Length and Transfer-Encoding present".into(),
-                ));
+                return Some(ctx.report(&CONTENT_LENGTH_FORBIDDEN));
             }
 
             // Check response headers if present
@@ -104,10 +106,7 @@ impl Rule for ContentLengthVsTransferEncoding {
                 if resp.headers.contains_key("content-length")
                     && resp.headers.contains_key("transfer-encoding")
                 {
-                    return Some(self.violation(
-                        ctx.severity,
-                        "Both Content-Length and Transfer-Encoding present".into(),
-                    ));
+                    return Some(ctx.report(&CONTENT_LENGTH_FORBIDDEN));
                 }
             }
 
@@ -154,6 +153,31 @@ mod tests {
             assert!(violation.is_none());
         }
         Ok(())
+    }
+
+    /// Both directions report the one id, and it arrives as an `error`: the
+    /// framing entries of the `Content-Length` subject are ranked together,
+    /// and this is the one with request smuggling behind it.
+    #[test]
+    fn either_direction_reports_the_framing_id_as_an_error() {
+        let both = &[("content-length", "10"), ("transfer-encoding", "chunked")];
+        let mut request = crate::test_helpers::make_test_transaction();
+        request.request.headers = crate::test_helpers::make_headers_from_pairs(both);
+        let response = crate::test_helpers::make_test_transaction_with_response(200, both);
+
+        for tx in [request, response] {
+            let found = crate::test_helpers::run_rule(
+                &ContentLengthVsTransferEncoding,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "content_length_vs_transfer_encoding",
+                ]),
+            )
+            .expect("a finding");
+            assert_eq!(found.violation, "content_length_forbidden");
+            assert_eq!(found.severity, crate::lint::Severity::Error);
+        }
     }
 
     #[rstest]

--- a/lint-http-rules/src/violations/content_length.rs
+++ b/lint-http-rules/src/violations/content_length.rs
@@ -34,12 +34,13 @@ use crate::rules::SpecRef;
 use crate::violations::{defects, ViolationDef};
 
 /// Why a mismatch matters rather than merely differing: the value is what a
-/// recipient frames the message with.
+/// recipient frames the message with — and, in the same section, why the field
+/// may not be written at all where a transfer coding is already framing.
 pub const RFC_9112_6_2: SpecRef = SpecRef {
     spec: "RFC 9112",
     section: Some("6.2"),
     url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.2",
-    note: "Content-Length as framing — the declared length is how a recipient determines where the data and the message end",
+    note: "Content-Length as framing — the declared length is how a recipient determines where the data and the message end, and the sender-side prohibition on sending it in a message that carries a Transfer-Encoding",
 };
 
 /// Where `Content-Length = 1*DIGIT` is defined — the grammar every value is
@@ -76,6 +77,33 @@ defects! {
         id: "content_length_conflicting",
         title: "Content-Length disagrees with the octets received",
         message: "",
+        default_severity: Severity::Error,
+        spec: Some(RFC_9112_6_2),
+    }
+
+    /// The field written at all, in a message a transfer coding is already
+    /// framing. Nothing is wrong with the number; what is wrong is that it is
+    /// there, because the message now states where it ends twice and the two
+    /// statements are resolved by different recipients at different times.
+    ///
+    /// **This is the entry with an attack behind it.** § 6.3 tells a recipient
+    /// to let the `Transfer-Encoding` win and an intermediary to strip the
+    /// `Content-Length` before forwarding; where that does not happen
+    /// consistently along a chain, two recipients disagree about where the
+    /// message ends, which is the whole of request smuggling and response
+    /// splitting. Both of those sentences are the reading
+    /// `content_length_vs_transfer_encoding` cites at its own site — what is
+    /// quoted here is the sender's prohibition, which is the defect.
+    ///
+    /// One id for both directions, like the mismatch above: a request that
+    /// frames itself twice and a response that does are the same message
+    /// written at opposite ends of the exchange.
+    ///
+    // cite(RFC 9112 § 6.2, label: Content-Length not in a transfer-coded message): "A sender MUST NOT send a Content-Length header field in any message that contains a Transfer-Encoding header field."
+    CONTENT_LENGTH_FORBIDDEN = {
+        id: "content_length_forbidden",
+        title: "Content-Length is sent in a message that is transfer-coded",
+        message: "Both Content-Length and Transfer-Encoding present",
         default_severity: Severity::Error,
         spec: Some(RFC_9112_6_2),
     }
@@ -166,6 +194,7 @@ mod tests {
     fn every_framing_defect_defaults_above_a_grammar_defect() {
         for def in [
             &CONTENT_LENGTH_CONFLICTING,
+            &CONTENT_LENGTH_FORBIDDEN,
             &CONTENT_LENGTH_EMPTY,
             &CONTENT_LENGTH_CHARACTER_FORBIDDEN,
             &CONTENT_LENGTH_MEMBERS_CONFLICTING,

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -366,7 +366,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 127;
+        const FLOOR: usize = 128;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -6783,9 +6783,9 @@ sources:
     - file: lint-http-rules/src/helpers/content_length.rs
       line: 86
     - file: lint-http-rules/src/violations/content_length.rs
-      line: 88
+      line: 116
     - file: lint-http-rules/src/violations/content_length.rs
-      line: 105
+      line: 133
   - label: lint-http-rules/src/helpers/content_length.rs (3)
     section: § 8.6
     snippet: When transferring a representation as content, Content-Length refers specifically to the amount of data enclosed so that it can be used to delimit framing
@@ -9755,27 +9755,17 @@ sources:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 222
   - label: content_length_vs_transfer_encoding
-    section: § 6.2
-    snippet: A sender MUST NOT send a Content-Length header field in any message that contains a Transfer-Encoding header field.
-    cited_by:
-    - file: lint-http-rules/src/rules/content_length_vs_transfer_encoding.rs
-      line: 82
-    - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 158
-    - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 216
-  - label: content_length_vs_transfer_encoding (2)
     section: § 6.3
     snippet: An intermediary that chooses to forward the message MUST first remove the received Content-Length field and process the Transfer-Encoding
     cited_by:
     - file: lint-http-rules/src/rules/content_length_vs_transfer_encoding.rs
-      line: 91
-  - label: content_length_vs_transfer_encoding (3)
+      line: 96
+  - label: content_length_vs_transfer_encoding (2)
     section: § 6.3
     snippet: If a message is received with both a Transfer-Encoding and a Content-Length header field, the Transfer-Encoding overrides the Content-Length.
     cited_by:
     - file: lint-http-rules/src/rules/content_length_vs_transfer_encoding.rs
-      line: 90
+      line: 95
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
       line: 254
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
@@ -9947,7 +9937,7 @@ sources:
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
       line: 123
     - file: lint-http-rules/src/violations/content_length.rs
-      line: 134
+      line: 162
   - label: lint-http-rules/src/helpers/uri.rs
     section: § 3.2
     snippet: A server MUST respond with a 400 (Bad Request) status code to any HTTP/1.1 request message that lacks a Host header field and to any request message that contains more than one Host header field line or a Host header field with an invalid field value.
@@ -10032,6 +10022,16 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
       line: 331
+  - label: Content-Length not in a transfer-coded message
+    section: § 6.2
+    snippet: A sender MUST NOT send a Content-Length header field in any message that contains a Transfer-Encoding header field.
+    cited_by:
+    - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
+      line: 158
+    - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
+      line: 216
+    - file: lint-http-rules/src/violations/content_length.rs
+      line: 102
   - label: request_body_length_accuracy
     section: § 6.2
     snippet: For messages that do include content, the Content-Length field value provides the framing information necessary for determining where the data (and message) ends.
@@ -10041,7 +10041,7 @@ sources:
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
       line: 226
     - file: lint-http-rules/src/violations/content_length.rs
-      line: 74
+      line: 75
   - label: request_body_length_accuracy (2)
     section: § 6.2
     snippet: When a message does not have a Transfer-Encoding header field, a Content-Length header field (Section 8.6 of [HTTP]) can provide the anticipated size, as a decimal number of octets, for potential content.


### PR DESCRIPTION
The Content-Length subject takes the field's other framing defect: being written at all in a message that carries a Transfer-Encoding. Both directions report the one id, and it defaults to error like the rest of the subject's framing entries, which is what the rule's own prose already said about a pairing that is the request-smuggling primitive.

Section 6.2's note is widened to hold both readings, since the section is the catalogue's and two rules now read it for different sentences.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
