### PR TITLE
Presence on a connectionless version is one id

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1299,6 +1299,10 @@ severity = "warn"
 # Weakness indicator is not written W/
 severity = "warn"
 
+[violations.field_connection_specific_forbidden]
+# A connection-specific field is written on a version that has none
+severity = "error"
+
 [violations.field_line_duplicated]
 # A field is written on more lines than its definition allows
 severity = "warn"

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1312,7 +1312,7 @@ severity = "warn"
         /// directive list, and neither says anything about an encoding. Each
         /// field's octet is now `token`'s, under an id the rule already
         /// declared.
-        const FLOOR: usize = 136;
+        const FLOOR: usize = 135;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/rules/no_connection_specific_fields.rs
+++ b/lint-http-rules/src/rules/no_connection_specific_fields.rs
@@ -5,6 +5,13 @@
 use crate::helpers::headers::combined_field_value_as_written;
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::field::FIELD_CONNECTION_SPECIFIC_FORBIDDEN;
+use crate::violations::ViolationDef;
+
+/// Presence, and nothing else: every field this rule reports is reported for
+/// being written at all. The `TE` a request may carry is the one field whose
+/// *value* is measured, and that half is not this entry's — see `check_te`.
+static DECLARED: &[&ViolationDef] = &[&FIELD_CONNECTION_SPECIFIC_FORBIDDEN];
 
 /// The connection-specific field names, as the two governing documents reach
 /// them.
@@ -139,7 +146,7 @@ impl NoConnectionSpecificFields {
         governing: ConnectionlessVersion,
         direction: Direction,
         headers: &hyper::HeaderMap,
-        severity: crate::lint::Severity,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // Presence is the whole defect, so the value is never read: what both
         // documents forbid is generating a message that *contains* the field.
@@ -152,8 +159,8 @@ impl NoConnectionSpecificFields {
         // cite(RFC 9114 § 4.2): "An endpoint MUST NOT generate an HTTP/3 field section containing connection-specific fields; any message containing connection-specific fields MUST be treated as malformed."
         for &name in CONNECTION_SPECIFIC_FIELDS {
             if headers.contains_key(name) {
-                return Some(self.violation(
-                    severity,
+                return Some(ctx.report_with(
+                    &FIELD_CONNECTION_SPECIFIC_FORBIDDEN,
                     format!(
                         "{} {} carries the connection-specific header field '{}'; \
                          {} makes such a message malformed",
@@ -166,7 +173,7 @@ impl NoConnectionSpecificFields {
             }
         }
 
-        self.check_te(governing, direction, headers, severity)
+        self.check_te(governing, direction, headers, ctx)
     }
 
     /// The one field both documents take back out of the set, and only for one
@@ -179,7 +186,7 @@ impl NoConnectionSpecificFields {
         governing: ConnectionlessVersion,
         direction: Direction,
         headers: &hyper::HeaderMap,
-        severity: crate::lint::Severity,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // A response is not the request the exception is written for, so the
         // field is connection-specific there like the five above it and the
@@ -191,9 +198,8 @@ impl NoConnectionSpecificFields {
         // cite(RFC 9110 § 10.1.4): "The "TE" header field describes capabilities of the client with regard to transfer codings and trailer sections."
         if direction == Direction::Response {
             if headers.contains_key("te") {
-                return Some(self.cited(
-                    &RFC_9110_10_1_4,
-                    severity,
+                return Some(ctx.report_with(
+                    &FIELD_CONNECTION_SPECIFIC_FORBIDDEN,
                     format!(
                         "{} response carries a TE header field; the exception {} makes is \
                          for a request, so in a response TE is a connection-specific field \
@@ -246,7 +252,7 @@ impl NoConnectionSpecificFields {
             .find(|member| !member.eq_ignore_ascii_case("trailers"))?;
 
         Some(self.violation(
-            severity,
+            ctx.severity,
             format!(
                 "{} request's TE header field holds '{}'; the only value {} permits it \
                  to contain is 'trailers'",
@@ -320,6 +326,10 @@ severity = "error"
             RFC_9110_10_1_4,
             RFC_5234_2_3,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -399,19 +409,16 @@ impl Rule for NoConnectionSpecificFields {
                     governing,
                     Direction::Request,
                     &tx.request.headers,
-                    ctx.severity,
+                    ctx,
                 ) {
                     return Some(violation);
                 }
             }
 
             if let Some((governing, resp)) = response {
-                if let Some(violation) = self.check_field_section(
-                    governing,
-                    Direction::Response,
-                    &resp.headers,
-                    ctx.severity,
-                ) {
+                if let Some(violation) =
+                    self.check_field_section(governing, Direction::Response, &resp.headers, ctx)
+                {
                     return Some(violation);
                 }
             }
@@ -739,6 +746,23 @@ mod tests {
                  connection-specific field like any other and the message is malformed"
             )
         );
+    }
+
+    /// One id for both shapes of presence, because both are one defect: a
+    /// field the version has no use for, written anyway. The `TE` of a response
+    /// joins the five names rather than getting an entry of its own — what
+    /// separates it in the *message* is which sentence explains it, not what is
+    /// wrong.
+    #[test]
+    fn presence_is_one_id_however_the_field_reached_the_section() {
+        for v in [
+            request("HTTP/2.0", &[("connection", "keep-alive")]).expect("violation"),
+            exchange("HTTP/3.0", "HTTP/3.0", &[("te", "trailers")]).expect("violation"),
+        ] {
+            assert_eq!(v.violation, "field_connection_specific_forbidden");
+            assert_eq!(v.severity, crate::lint::Severity::Error);
+            assert!(v.cite.is_none(), "the governing section is per version");
+        }
     }
 
     // --- Order, scope, config ---

--- a/lint-http-rules/src/violations/field.rs
+++ b/lint-http-rules/src/violations/field.rs
@@ -27,6 +27,11 @@
 //! own exception says so. The defect is a repetition the field's definition does
 //! not admit, so every declarer is a rule that has read that definition — which
 //! is also why no gate can find the next declarer for you.
+//!
+//! The second entry is the same kind of claim about the same object: a field
+//! line that is there and should not be, because the version carrying it has no
+//! use for the hop-by-hop control the field states. Neither entry ever reads a
+//! value.
 
 use crate::lint::Severity;
 use crate::rules::SpecRef;
@@ -67,6 +72,39 @@ defects! {
         default_severity: Severity::Warn,
         spec: Some(RFC_9110_5_3),
     }
+
+    /// A field stating hop-by-hop control — `Connection` and the fields it
+    /// governs, `TE` among them where no exception restores it — written into a
+    /// field section carried by a version that conveys such metadata by other
+    /// means. Presence is the whole defect: both documents call the message
+    /// malformed without anyone reading the value.
+    ///
+    /// `error`, because malformed is the word the documents use and a recipient
+    /// is entitled to reject the message rather than repair it.
+    ///
+    /// **This is the first entry in the catalogue with no `spec`, whose
+    /// sentence exists.** The requirement is stated once per version — RFC 9113
+    /// § 8.2.2 for HTTP/2, RFC 9114 § 4.2 for HTTP/3 — and the two are not
+    /// copies of one another: HTTP/2 closes the list of names in the sentence
+    /// after its MUST NOT, HTTP/3 enumerates nothing and defers to RFC 9110
+    /// § 7.6.1, whose own list is open. A `ViolationDef` carries one `SpecRef`,
+    /// so naming either document here would put an HTTP/2 citation on an HTTP/3
+    /// finding half the time — the wrong-document trap, arrived at from the
+    /// other side. **The defect is one and the sentence is two**, so the
+    /// citation stays where the version is known: at the rule's sites, and in
+    /// the finding's own message, which names the governing section.
+    ///
+    /// Splitting the entry per version was the alternative and it is refused:
+    /// an operator silencing this is silencing a defect, not a document, and
+    /// two ids for one defect is the duplication this whole campaign exists to
+    /// remove.
+    FIELD_CONNECTION_SPECIFIC_FORBIDDEN = {
+        id: "field_connection_specific_forbidden",
+        title: "A connection-specific field is written on a version that has none",
+        message: "",
+        default_severity: Severity::Error,
+        spec: None,
+    }
 }
 
 #[cfg(test)]
@@ -82,5 +120,22 @@ mod tests {
         assert_eq!(FIELD_LINE_DUPLICATED.id, "field_line_duplicated");
         assert_eq!(FIELD_LINE_DUPLICATED.default_severity, Severity::Warn);
         assert_eq!(FIELD_LINE_DUPLICATED.spec, Some(RFC_9110_5_3));
+    }
+
+    /// The entry with no sentence of its own, and the reason is that it has
+    /// two: one per version document. Pinned so that a later commit adding a
+    /// citation here has to answer which version's finding it would be wrong
+    /// for.
+    #[test]
+    fn the_requirement_written_once_per_version_carries_no_single_spec() {
+        assert_eq!(
+            FIELD_CONNECTION_SPECIFIC_FORBIDDEN.id,
+            "field_connection_specific_forbidden"
+        );
+        assert_eq!(FIELD_CONNECTION_SPECIFIC_FORBIDDEN.spec, None);
+        assert_eq!(
+            FIELD_CONNECTION_SPECIFIC_FORBIDDEN.default_severity,
+            Severity::Error
+        );
     }
 }

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1731,7 +1731,7 @@ sources:
     - file: lint-http-rules/src/helpers/validator.rs
       line: 153
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 242
+      line: 248
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
       line: 119
   - label: lint-http-rules/src/helpers/mailbox.rs
@@ -5805,7 +5805,7 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 18
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 191
+      line: 198
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 521
     - file: lint-http-rules/src/rules/te_header_valid.rs
@@ -6383,7 +6383,7 @@ sources:
     - file: lint-http-core/src/http_version.rs
       line: 155
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 77
+      line: 84
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 230
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
@@ -6451,7 +6451,7 @@ sources:
     - file: lint-http-rules/src/helpers/field_placement.rs
       line: 142
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 40
+      line: 47
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
       line: 61
   - label: lint-http-proxy/src/proxy/hop_by_hop.rs (8)
@@ -6715,7 +6715,7 @@ sources:
     - file: lint-http-rules/src/rules/max_forwards_numeric.rs
       line: 153
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 216
+      line: 222
     - file: lint-http-rules/src/rules/proxy_connection_discouraged.rs
       line: 134
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
@@ -7039,7 +7039,7 @@ sources:
     - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
       line: 120
     - file: lint-http-rules/src/violations/field.rs
-      line: 62
+      line: 67
   - label: lint-http-rules/src/helpers/headers.rs (5)
     section: § 5.5
     snippet: A recipient SHOULD treat other allowed octets in field content (i.e., obs-text) as opaque data.
@@ -7895,13 +7895,13 @@ sources:
     snippet: 'This includes but is not limited to:'
     cited_by:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 41
+      line: 48
   - label: t-codings
     section: § A
     snippet: t-codings = "trailers" / ( transfer-coding [ weight ] )
     cited_by:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 240
+      line: 246
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 117
   - label: no_connection_specific_fields (2)
@@ -7909,7 +7909,7 @@ sources:
     snippet: transfer-parameter = token BWS "=" BWS ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 241
+      line: 247
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 77
     - file: lint-http-rules/src/rules/te_header_valid.rs
@@ -10474,7 +10474,7 @@ sources:
     - file: lint-http-rules/src/helpers/field_placement.rs
       line: 100
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 39
+      line: 46
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
       line: 63
   - label: no_body_for_1xx_204_304
@@ -10484,9 +10484,9 @@ sources:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
       line: 307
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 150
+      line: 157
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 371
+      line: 381
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
       line: 168
     - file: lint-http-rules/src/rules/te_header_valid.rs
@@ -10498,25 +10498,25 @@ sources:
     snippet: An intermediary transforming an HTTP/1.x message to HTTP/2 MUST remove connection-specific header fields as discussed in Section 7.6.1 of [HTTP], or their messages will be treated by other HTTP/2 endpoints as malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 135
+      line: 142
   - label: no_connection_specific_fields (2)
     section: § 8.2.2
     snippet: Any message containing connection-specific header fields MUST be treated as malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 151
+      line: 158
   - label: no_connection_specific_fields (3)
     section: § 8.2.2
     snippet: HTTP/2 does not use the Connection header field (Section 7.6.1 of [HTTP]) to indicate connection-specific header fields; in this protocol, connection-specific metadata is conveyed by other means.
     cited_by:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 58
+      line: 65
   - label: no_connection_specific_fields (4)
     section: § 8.2.2
     snippet: The only exception to this is the TE header field, which MAY be present in an HTTP/2 request; when it is, it MUST NOT contain any value other than "trailers".
     cited_by:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 175
+      line: 182
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 173
   - label: request_target_form_valid
@@ -10801,7 +10801,7 @@ sources:
     snippet: An endpoint MUST NOT generate an HTTP/3 field section containing connection-specific fields; any message containing connection-specific fields MUST be treated as malformed.
     cited_by:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 152
+      line: 159
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 174
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
@@ -10811,19 +10811,19 @@ sources:
     snippet: An intermediary transforming an HTTP/1.x message to HTTP/3 MUST remove connection-specific header fields as discussed in Section 7.6.1 of [HTTP], or their messages will be treated by other HTTP/3 endpoints as malformed.
     cited_by:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 136
+      line: 143
   - label: no_connection_specific_fields (3)
     section: § 4.2
     snippet: HTTP/3 does not use the Connection header field to indicate connection-specific fields; in this protocol, connection-specific metadata is conveyed by other means.
     cited_by:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 59
+      line: 66
   - label: no_connection_specific_fields (4)
     section: § 4.2
     snippet: The only exception to this is the TE header field, which MAY be present in an HTTP/3 request header; when it is, it MUST NOT contain any value other than "trailers".
     cited_by:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 176
+      line: 183
   - label: quic_transport_parameters_valid
     section: § 6.1
     snippet: HTTP/3 does not use server-initiated bidirectional streams


### PR DESCRIPTION
The five connection-specific field names and the TE of a response report one defect: a field written into a section whose version conveys that metadata by other means. Presence is the whole finding either way, so the message explains which sentence governs and the id does not.

The entry carries no specification reference, and that is the reading rather than an omission: the requirement is written once per version by two documents that are not copies, an entry holds one reference, and naming either would cite the wrong document half the time.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
