### PR TITLE
The permitted TE says one thing only

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1507,6 +1507,10 @@ severity = "warn"
 # Weight is not a qvalue
 severity = "warn"
 
+[violations.te_member_forbidden]
+# A request's TE holds a member other than trailers
+severity = "error"
+
 [violations.token68_body_empty]
 # token68 is padding with no body
 severity = "warn"

--- a/lint-http-rules/src/rules/no_connection_specific_fields.rs
+++ b/lint-http-rules/src/rules/no_connection_specific_fields.rs
@@ -6,12 +6,14 @@ use crate::helpers::headers::combined_field_value_as_written;
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
 use crate::violations::field::FIELD_CONNECTION_SPECIFIC_FORBIDDEN;
+use crate::violations::te::TE_MEMBER_FORBIDDEN;
 use crate::violations::ViolationDef;
 
-/// Presence, and nothing else: every field this rule reports is reported for
-/// being written at all. The `TE` a request may carry is the one field whose
-/// *value* is measured, and that half is not this entry's — see `check_te`.
-static DECLARED: &[&ViolationDef] = &[&FIELD_CONNECTION_SPECIFIC_FORBIDDEN];
+/// Presence, and then the one value the exception leaves to be measured: every
+/// field this rule reports is reported for being written at all, except the
+/// `TE` a request is permitted to carry, whose members are read against the
+/// keyword the same sentence limits it to.
+static DECLARED: &[&ViolationDef] = &[&FIELD_CONNECTION_SPECIFIC_FORBIDDEN, &TE_MEMBER_FORBIDDEN];
 
 /// The connection-specific field names, as the two governing documents reach
 /// them.
@@ -179,8 +181,13 @@ impl NoConnectionSpecificFields {
     /// The one field both documents take back out of the set, and only for one
     /// direction.
     ///
-    /// cite(RFC 9113 § 8.2.2): "The only exception to this is the TE header field, which MAY be present in an HTTP/2 request; when it is, it MUST NOT contain any value other than "trailers"."
-    /// cite(RFC 9114 § 4.2): "The only exception to this is the TE header field, which MAY be present in an HTTP/3 request header; when it is, it MUST NOT contain any value other than "trailers"."
+    /// Each document writes the exception and its limit in one sentence, and
+    /// both sentences are quoted on
+    /// [`te_member_forbidden`](crate::violations::te::TE_MEMBER_FORBIDDEN),
+    /// which is what the limit half reports as. What this function decides is
+    /// the direction: a section that is not a request gets none of the
+    /// exception, and the field is connection-specific there like the five
+    /// names above.
     fn check_te(
         &self,
         governing: ConnectionlessVersion,
@@ -251,8 +258,8 @@ impl NoConnectionSpecificFields {
             .filter(|member| !member.is_empty())
             .find(|member| !member.eq_ignore_ascii_case("trailers"))?;
 
-        Some(self.violation(
-            ctx.severity,
+        Some(ctx.report_with(
+            &TE_MEMBER_FORBIDDEN,
             format!(
                 "{} request's TE header field holds '{}'; the only value {} permits it \
                  to contain is 'trailers'",
@@ -746,6 +753,16 @@ mod tests {
                  connection-specific field like any other and the message is malformed"
             )
         );
+    }
+
+    /// The exception's two halves answer under two ids: a `TE` that should not
+    /// be there at all is presence, and a `TE` that may be there and says the
+    /// wrong thing is the member's own defect.
+    #[test]
+    fn the_permitted_field_saying_the_wrong_thing_is_its_own_id() {
+        let v = request("HTTP/2.0", &[("te", "gzip")]).expect("violation");
+        assert_eq!(v.violation, "te_member_forbidden");
+        assert_eq!(v.severity, crate::lint::Severity::Error);
     }
 
     /// One id for both shapes of presence, because both are one defect: a

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -53,6 +53,7 @@ pub mod parameter;
 pub mod quoted_pair;
 pub mod quoted_string;
 pub mod qvalue;
+pub mod te;
 pub mod token;
 pub mod token68;
 pub mod transfer_encoding;

--- a/lint-http-rules/src/violations/te.rs
+++ b/lint-http-rules/src/violations/te.rs
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `TE` defects — the one member the versions that have no connection-specific
+//! fields still let a request write.
+//!
+//! `TE` states what transfer codings a client will accept, which is hop-by-hop
+//! control and is therefore a connection-specific field: over HTTP/2 and HTTP/3
+//! its presence would be
+//! [`field_connection_specific_forbidden`](crate::violations::field::FIELD_CONNECTION_SPECIFIC_FORBIDDEN)
+//! like `Connection`'s. Both version documents then take it back out, for one
+//! direction and one value — a *request* may carry it, and when it does it may
+//! hold nothing but `trailers`. That narrowing is what the entry below is for,
+//! and it exists only on those versions: over HTTP/1.1 a `TE: gzip` is an
+//! ordinary well-formed value.
+//!
+//! **The subject is the field, and only the part of it those two documents
+//! narrow.** Whether a member derives from `t-codings` at all — its `token`, its
+//! `weight`, its `transfer-parameter` — is `te_header_valid`'s reading and is
+//! reported under the `token`, `qvalue` and `parameter` subjects, on every
+//! version. What is here is the value being *permitted and yet not `trailers`*,
+//! which no other rule asks.
+//!
+//! The exception, in the two documents that write it:
+//
+// cite(RFC 9113 § 8.2.2, label: the TE exception): "The only exception to this is the TE header field, which MAY be present in an HTTP/2 request; when it is, it MUST NOT contain any value other than "trailers"."
+// cite(RFC 9114 § 4.2, label: the TE exception): "The only exception to this is the TE header field, which MAY be present in an HTTP/3 request header; when it is, it MUST NOT contain any value other than "trailers"."
+
+use crate::lint::Severity;
+use crate::violations::defects;
+
+defects! {
+    /// A member of a request's `TE` that is not `trailers`, on a version whose
+    /// document permits the field for that one keyword and nothing else. The
+    /// member may be a perfectly good transfer coding — `gzip`, `deflate`,
+    /// `chunked;q=0` — and that is beside the point: the field is present by an
+    /// exception, and the exception is written with its own limit.
+    ///
+    /// `error`, with the rest of the connection-specific reading: both
+    /// documents put this sentence inside the paragraph whose MUST NOT makes
+    /// such a message malformed.
+    ///
+    /// **No `spec`, for the reason
+    /// [`field_connection_specific_forbidden`](crate::violations::field::FIELD_CONNECTION_SPECIFIC_FORBIDDEN)
+    /// carries none**: the sentence is written once per version, by two
+    /// documents in force at the same time, and an entry holds one reference.
+    /// Both are quoted above the entry instead, where neither is being claimed
+    /// as *the* sentence, and the finding names the governing section itself.
+    /// The comparison against the keyword folds case because `t-codings` writes
+    /// it as an ABNF string, which is RFC 5234 § 2.3's sentence and the rule's
+    /// own reading rather than this defect's.
+    TE_MEMBER_FORBIDDEN = {
+        id: "te_member_forbidden",
+        title: "A request's TE holds a member other than trailers",
+        message: "",
+        default_severity: Severity::Error,
+        spec: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The entry names the member, not the version — the same request written
+    /// over HTTP/2 and over HTTP/3 breaks the same narrowing, and the two
+    /// documents differ in nothing but which version they name.
+    #[test]
+    fn one_entry_serves_both_versions_and_neither_names_it() {
+        assert_eq!(TE_MEMBER_FORBIDDEN.id, "te_member_forbidden");
+        assert!(!TE_MEMBER_FORBIDDEN.id.contains("http"));
+        assert_eq!(TE_MEMBER_FORBIDDEN.spec, None);
+        assert_eq!(TE_MEMBER_FORBIDDEN.default_severity, Severity::Error);
+    }
+}

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1731,7 +1731,7 @@ sources:
     - file: lint-http-rules/src/helpers/validator.rs
       line: 153
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 248
+      line: 255
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
       line: 119
   - label: lint-http-rules/src/helpers/mailbox.rs
@@ -5805,7 +5805,7 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 18
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 198
+      line: 205
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 521
     - file: lint-http-rules/src/rules/te_header_valid.rs
@@ -6383,7 +6383,7 @@ sources:
     - file: lint-http-core/src/http_version.rs
       line: 155
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 84
+      line: 86
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 230
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
@@ -6451,7 +6451,7 @@ sources:
     - file: lint-http-rules/src/helpers/field_placement.rs
       line: 142
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 47
+      line: 49
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
       line: 61
   - label: lint-http-proxy/src/proxy/hop_by_hop.rs (8)
@@ -6715,7 +6715,7 @@ sources:
     - file: lint-http-rules/src/rules/max_forwards_numeric.rs
       line: 153
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 222
+      line: 229
     - file: lint-http-rules/src/rules/proxy_connection_discouraged.rs
       line: 134
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
@@ -7895,13 +7895,13 @@ sources:
     snippet: 'This includes but is not limited to:'
     cited_by:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 48
+      line: 50
   - label: t-codings
     section: § A
     snippet: t-codings = "trailers" / ( transfer-coding [ weight ] )
     cited_by:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 246
+      line: 253
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 117
   - label: no_connection_specific_fields (2)
@@ -7909,7 +7909,7 @@ sources:
     snippet: transfer-parameter = token BWS "=" BWS ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 247
+      line: 254
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 77
     - file: lint-http-rules/src/rules/te_header_valid.rs
@@ -10474,7 +10474,7 @@ sources:
     - file: lint-http-rules/src/helpers/field_placement.rs
       line: 100
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 46
+      line: 48
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
       line: 63
   - label: no_body_for_1xx_204_304
@@ -10484,9 +10484,9 @@ sources:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
       line: 307
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 157
+      line: 159
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 381
+      line: 388
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
       line: 168
     - file: lint-http-rules/src/rules/te_header_valid.rs
@@ -10498,27 +10498,19 @@ sources:
     snippet: An intermediary transforming an HTTP/1.x message to HTTP/2 MUST remove connection-specific header fields as discussed in Section 7.6.1 of [HTTP], or their messages will be treated by other HTTP/2 endpoints as malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 142
+      line: 144
   - label: no_connection_specific_fields (2)
     section: § 8.2.2
     snippet: Any message containing connection-specific header fields MUST be treated as malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 158
+      line: 160
   - label: no_connection_specific_fields (3)
     section: § 8.2.2
     snippet: HTTP/2 does not use the Connection header field (Section 7.6.1 of [HTTP]) to indicate connection-specific header fields; in this protocol, connection-specific metadata is conveyed by other means.
     cited_by:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 65
-  - label: no_connection_specific_fields (4)
-    section: § 8.2.2
-    snippet: The only exception to this is the TE header field, which MAY be present in an HTTP/2 request; when it is, it MUST NOT contain any value other than "trailers".
-    cited_by:
-    - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 182
-    - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 173
+      line: 67
   - label: request_target_form_valid
     section: § 8.3.1
     snippet: Note that request targets for CONNECT or asterisk-form OPTIONS requests never include authority information
@@ -10539,6 +10531,14 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
       line: 170
+  - label: the TE exception
+    section: § 8.2.2
+    snippet: The only exception to this is the TE header field, which MAY be present in an HTTP/2 request; when it is, it MUST NOT contain any value other than "trailers".
+    cited_by:
+    - file: lint-http-rules/src/rules/te_header_valid.rs
+      line: 173
+    - file: lint-http-rules/src/violations/te.rs
+      line: 27
 - label: RFC 9114
   url: https://www.rfc-editor.org/rfc/rfc9114.html
   fragments:
@@ -10801,7 +10801,7 @@ sources:
     snippet: An endpoint MUST NOT generate an HTTP/3 field section containing connection-specific fields; any message containing connection-specific fields MUST be treated as malformed.
     cited_by:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 159
+      line: 161
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 174
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
@@ -10811,19 +10811,13 @@ sources:
     snippet: An intermediary transforming an HTTP/1.x message to HTTP/3 MUST remove connection-specific header fields as discussed in Section 7.6.1 of [HTTP], or their messages will be treated by other HTTP/3 endpoints as malformed.
     cited_by:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 143
+      line: 145
   - label: no_connection_specific_fields (3)
     section: § 4.2
     snippet: HTTP/3 does not use the Connection header field to indicate connection-specific fields; in this protocol, connection-specific metadata is conveyed by other means.
     cited_by:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 66
-  - label: no_connection_specific_fields (4)
-    section: § 4.2
-    snippet: The only exception to this is the TE header field, which MAY be present in an HTTP/3 request header; when it is, it MUST NOT contain any value other than "trailers".
-    cited_by:
-    - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 183
+      line: 68
   - label: quic_transport_parameters_valid
     section: § 6.1
     snippet: HTTP/3 does not use server-initiated bidirectional streams
@@ -10864,6 +10858,12 @@ sources:
       line: 210
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
       line: 161
+  - label: the TE exception
+    section: § 4.2
+    snippet: The only exception to this is the TE header field, which MAY be present in an HTTP/3 request header; when it is, it MUST NOT contain any value other than "trailers".
+    cited_by:
+    - file: lint-http-rules/src/violations/te.rs
+      line: 28
 - label: RFC 9218
   url: https://www.rfc-editor.org/rfc/rfc9218.html
   fragments:


### PR DESCRIPTION
The exception that lets a request carry TE over HTTP/2 and HTTP/3 limits it to trailers in the same sentence, so a member that is anything else gets the field's own entry rather than the presence one. Both documents write that sentence and the subject quotes both, since neither is the one an entry could name.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
