### PR TITLE
Coding twice is named as work, not as error

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1551,6 +1551,10 @@ severity = "warn"
 # The chunked transfer coding is not the final one
 severity = "warn"
 
+[violations.transfer_encoding_coding_redundant]
+# A coding is applied in transit that the representation already carries
+severity = "info"
+
 [violations.uri_character_forbidden]
 # Value holds a character no URI is written with
 severity = "warn"

--- a/docs/development.md
+++ b/docs/development.md
@@ -123,7 +123,16 @@ member is malformed".
 | Written, and left with nothing in it | `_empty` | — |
 | Appears more times than the grammar allows | `_duplicated` | — |
 | Written where the specification prohibits it | `_forbidden` | — |
+| Permitted, and almost certainly not what was meant | `_redundant` | — |
 | Retired by a later specification | `_obsolete` | — |
+
+`_redundant` is the one ending that condemns nothing: it names work a message
+did twice where doing it once was the whole intent, and it exists because the
+alternatives lie. `transfer_encoding_coding_redundant` — the same compression
+applied to the representation and then again in transit — is not `_duplicated`,
+since no definition is being exceeded, and not `_invalid`, since the message is
+perfectly decodable. An entry ending this way defaults to `info` unless there is
+an argument on the page for more.
 
 `_missing` and `_empty` are not alternatives to pick between: `_missing` is a
 sender that never wrote the thing, `_empty` is a sender that wrote it and put

--- a/lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
+++ b/lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
@@ -4,6 +4,13 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::transfer_encoding::{RFC_9112_7_3, TRANSFER_ENCODING_CODING_REDUNDANT};
+use crate::violations::ViolationDef;
+
+/// One observation, and it is about the transit layer: a coding applied there
+/// that the representation already carries. The rule reports it once per
+/// message, and the message names which side and which codings.
+static DECLARED: &[&ViolationDef] = &[&TRANSFER_ENCODING_CODING_REDUNDANT];
 
 pub struct CompressionAndTransferEncodingConsistent;
 
@@ -33,12 +40,6 @@ const RFC_9112_7_2: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("7.2"),
     url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.2",
     note: "The compression transfer codings, defined by the same algorithm as the content coding of the same name",
-};
-const RFC_9112_7_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9112",
-    section: Some("7.3"),
-    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.3",
-    note: "Transfer and content coding names may only overlap where the transformation is identical — so a shared name is unambiguous, and coding twice is coherent rather than malformed",
 };
 const RFC_9110_10_1_4: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
@@ -71,6 +72,10 @@ severity = "warn"
             RFC_9112_7_3,
             RFC_9110_10_1_4,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -218,8 +223,9 @@ impl Rule for CompressionAndTransferEncodingConsistent {
             // transit, which is well defined rather than ambiguous: the two
             // namespaces may share a name only where the transformation is
             // identical, and the compression transfer codings are defined by
-            // the algorithm of the content coding they are named after.
-            // cite(RFC 9112 § 7.3): "Names of transfer codings MUST NOT overlap with names of content codings (Section 8.4.1 of [HTTP]) unless the encoding transformation is identical, as is the case for the compression codings defined in Section 7.2."
+            // the algorithm of the content coding they are named after. The
+            // overlap sentence is quoted on
+            // `transfer_encoding_coding_redundant`, which is what this reports.
             // cite(RFC 9112 § 7.2): "The following transfer coding names for compression are defined by the same algorithm as their corresponding content coding:"
             //
             // § 8.4 goes further and contemplates a coding applied twice,
@@ -242,7 +248,7 @@ impl Rule for CompressionAndTransferEncodingConsistent {
             overlap.sort();
 
             if !overlap.is_empty() {
-                return Some(self.violation(ctx.severity, format!(
+                return Some(ctx.report_with(&TRANSFER_ENCODING_CODING_REDUNDANT, format!(
                         "Compression coding(s) '{}' appear in both Content-Encoding and Transfer-Encoding of the {}; the representation is coded once and then coded again in transit, which is decodable but almost never intended",
                         overlap.join(", "),
                         side
@@ -298,6 +304,26 @@ mod tests {
             tx.response.as_mut().unwrap().headers = hm;
         }
         tx
+    }
+
+    /// The advisory reports as one, and the id says which layer is the
+    /// removable one. `info` is the entry's own ranking: nothing is broken, so
+    /// it sits below the framing entries of the same subject rather than beside
+    /// them.
+    #[test]
+    fn the_overlap_is_the_transit_layers_redundancy() {
+        let tx = make_tx_with_headers(Some("gzip"), Some("gzip, chunked"));
+        let v = crate::test_helpers::run_rule(
+            &CompressionAndTransferEncodingConsistent,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "compression_and_transfer_encoding_consistent",
+            ]),
+        )
+        .expect("a finding");
+        assert_eq!(v.violation, "transfer_encoding_coding_redundant");
+        assert_eq!(v.severity, crate::lint::Severity::Info);
     }
 
     #[rstest]

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -378,7 +378,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 128;
+        const FLOOR: usize = 129;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,
@@ -400,6 +400,7 @@ mod tests {
         "malformed",
         "missing",
         "obsolete",
+        "redundant",
         "unregistered",
     ];
 

--- a/lint-http-rules/src/violations/transfer_encoding.rs
+++ b/lint-http-rules/src/violations/transfer_encoding.rs
@@ -22,6 +22,13 @@
 //! quotes the direction of § 6.1 that states it most plainly and the other
 //! direction is the sibling entry's quote.
 //!
+//! **One entry here is not a defect of the sequence at all**, and it is the
+//! only advisory one: a coding written in this field that the representation
+//! already carries in its `Content-Encoding`. Nothing forbids it, and the
+//! reason it can be reported at all is that the two namespaces may share a name
+//! only where the transformation is identical — so `gzip` at both layers is the
+//! same algorithm run twice and not two things that happen to be spelled alike.
+//!
 //! **What is deliberately not here.** Whether a coding name is registered, and
 //! whether a member parses at all, are `transfer_coding_registered`'s findings
 //! and the `token` subject's ids; a value whose quoting never closes is declined
@@ -40,6 +47,15 @@ pub const RFC_9112_6_1: SpecRef = SpecRef {
     section: Some("6.1"),
     url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.1",
     note: "Transfer-Encoding — every requirement this rule enforces is here: chunked at most once, and chunked last (unconditionally for requests, or the connection closes for responses)",
+};
+
+/// Why a name in both fields is one algorithm applied twice rather than a
+/// collision between two registries.
+pub const RFC_9112_7_3: SpecRef = SpecRef {
+    spec: "RFC 9112",
+    section: Some("7.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.3",
+    note: "Transfer and content coding names may only overlap where the transformation is identical — so a shared name is unambiguous, and coding twice is coherent rather than malformed",
 };
 
 defects! {
@@ -98,6 +114,32 @@ defects! {
         message: "",
         default_severity: Severity::Warn,
         spec: Some(RFC_9112_6_1),
+    }
+
+    /// A coding applied in transit that the representation already carries:
+    /// `Content-Encoding: gzip` with `Transfer-Encoding: gzip, chunked`. The
+    /// bytes are compressed, compressed again, and decompressed twice by a
+    /// recipient that has been told exactly what to do — so nothing here is
+    /// broken, and nothing in either document forbids it.
+    ///
+    /// `info`, and it is the only entry in this subject below `warn`: the other
+    /// three are a message stating where it ends wrongly, and this one is a
+    /// message doing avoidable work. It is the transit layer that is named
+    /// because the transit layer is the removable one — the representation's
+    /// coding is what the resource *is*, and an intermediary re-coding it in
+    /// flight is the party with something to change.
+    ///
+    /// The quoted sentence is what licenses reading the two names as one
+    /// algorithm; without it a shared name could be two registries colliding,
+    /// and the finding would be a guess about a spelling.
+    ///
+    // cite(RFC 9112 § 7.3): "Names of transfer codings MUST NOT overlap with names of content codings (Section 8.4.1 of [HTTP]) unless the encoding transformation is identical, as is the case for the compression codings defined in Section 7.2."
+    TRANSFER_ENCODING_CODING_REDUNDANT = {
+        id: "transfer_encoding_coding_redundant",
+        title: "A coding is applied in transit that the representation already carries",
+        message: "",
+        default_severity: Severity::Info,
+        spec: Some(RFC_9112_7_3),
     }
 }
 

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -4839,7 +4839,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
       line: 220
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 142
+      line: 147
   - label: accept_encoding_present
     section: § 12.5.3
     snippet: 'Accept-Encoding = #( codings [ weight ] )'
@@ -5415,7 +5415,7 @@ sources:
     snippet: transfer-coding    = token *( OWS ";" OWS transfer-parameter )
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 182
+      line: 187
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 260
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
@@ -5425,7 +5425,7 @@ sources:
     snippet: transfer-parameter = token BWS "=" BWS ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 183
+      line: 188
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 241
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
@@ -5435,13 +5435,13 @@ sources:
     snippet: An origin server MAY respond with a status code of 415 (Unsupported Media Type) if a representation in the request message has a content coding that is not acceptable.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 114
+      line: 119
   - label: compression_and_transfer_encoding_consistent (4)
     section: § 8.4
     snippet: 'Content-Encoding = #content-coding'
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 141
+      line: 146
     - file: lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
       line: 117
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
@@ -5451,25 +5451,25 @@ sources:
     snippet: If one or more encodings have been applied to a representation, the sender that applied the encodings MUST generate a Content-Encoding header field that lists the content codings in the order in which they were applied.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 237
+      line: 243
   - label: compression_and_transfer_encoding_consistent (6)
     section: § 8.4
     snippet: Such a content coding would only be listed if, for some bizarre reason, it is applied a second time to form the representation.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 230
+      line: 236
   - label: compression_and_transfer_encoding_consistent (7)
     section: § 8.4
     snippet: Unlike Transfer-Encoding (Section 6.1 of [HTTP/1.1]), the codings listed in Content-Encoding are a characteristic of the representation; the representation is defined in terms of the coded form, and all other metadata about the representation is about the coded form unless otherwise noted in the metadata definition.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 214
+      line: 219
   - label: compression_and_transfer_encoding_consistent (8)
     section: § 8.4.1
     snippet: All content codings are case-insensitive and ought to be registered within the "HTTP Content Coding Registry",
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 161
+      line: 166
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
       line: 199
   - label: conditional_headers_consistent
@@ -7121,9 +7121,9 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 147
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 160
+      line: 165
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 191
+      line: 196
     - file: lint-http-rules/src/rules/host_header.rs
       line: 228
     - file: lint-http-rules/src/rules/if_modified_since_date_syntax.rs
@@ -9719,21 +9719,21 @@ sources:
     snippet: If any transfer coding other than chunked is applied to a request's content, the sender MUST apply chunked as the final transfer coding to ensure that the message is properly framed.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 115
+      line: 120
     - file: lint-http-rules/src/violations/transfer_encoding.rs
-      line: 94
+      line: 110
   - label: compression_and_transfer_encoding_consistent
     section: § 6.1
     snippet: Unlike Content-Encoding (Section 8.4.1 of [HTTP]), Transfer-Encoding is a property of the message, not of the representation.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 213
+      line: 218
   - label: compression_and_transfer_encoding_consistent (2)
     section: § 7
     snippet: All transfer-coding names are case-insensitive and ought to be registered within the HTTP Transfer Coding registry, as defined in Section 7.3.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 192
+      line: 197
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 115
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -9747,13 +9747,7 @@ sources:
     snippet: 'The following transfer coding names for compression are defined by the same algorithm as their corresponding content coding:'
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 223
-  - label: compression_and_transfer_encoding_consistent (4)
-    section: § 7.3
-    snippet: Names of transfer codings MUST NOT overlap with names of content codings (Section 8.4.1 of [HTTP]) unless the encoding transformation is identical, as is the case for the compression codings defined in Section 7.2.
-    cited_by:
-    - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 222
+      line: 229
   - label: content_length_vs_transfer_encoding
     section: § 6.3
     snippet: An intermediary that chooses to forward the message MUST first remove the received Content-Length field and process the Transfer-Encoding
@@ -10283,13 +10277,19 @@ sources:
     snippet: A sender MUST NOT apply the chunked transfer coding more than once to a message body (i.e., chunking an already chunked message is not allowed).
     cited_by:
     - file: lint-http-rules/src/violations/transfer_encoding.rs
-      line: 55
+      line: 71
   - label: chunked last or the connection closes
     section: § 6.1
     snippet: If any transfer coding other than chunked is applied to a response's content, the sender MUST either apply chunked as the final transfer coding or terminate the message by closing the connection.
     cited_by:
     - file: lint-http-rules/src/violations/transfer_encoding.rs
-      line: 74
+      line: 90
+  - label: transfer_encoding (2)
+    section: § 7.3
+    snippet: Names of transfer codings MUST NOT overlap with names of content codings (Section 8.4.1 of [HTTP]) unless the encoding transformation is identical, as is the case for the compression codings defined in Section 7.2.
+    cited_by:
+    - file: lint-http-rules/src/violations/transfer_encoding.rs
+      line: 136
   - label: transfer_encoding_chunked_final
     section: § 9.6
     snippet: A sender SHOULD send a Connection header field (Section 7.6.1 of [HTTP]) containing the "close" connection option when it intends to close a connection.


### PR DESCRIPTION
The compression overlap between Content-Encoding and Transfer-Encoding gets an entry in the transit field's subject, defaulting to info: nothing forbids coding a representation and coding it again on the wire, and the sentence the entry quotes is the one that makes a shared name the same algorithm rather than two registries colliding.

The closed vocabulary of id endings grows by one word for it. Duplicated would claim a definition was exceeded and invalid would claim the message cannot be read; both are false, and this is the ending for a message that did avoidable work.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
