### PR TITLE
An unknown scheme is the scheme's own entry

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1059,6 +1059,10 @@ severity = "warn"
 # Authentication scheme holds a character outside token
 severity = "warn"
 
+[violations.auth_scheme_unregistered]
+# Authentication scheme is not one the deployment recognises
+severity = "warn"
+
 [violations.base64_character_forbidden]
 # Value holds an octet outside the base64 alphabet
 severity = "warn"

--- a/lint-http-rules/src/rules/auth_scheme_registered.rs
+++ b/lint-http-rules/src/rules/auth_scheme_registered.rs
@@ -4,7 +4,9 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
-use crate::violations::auth_scheme::{AUTH_SCHEME_CHARACTER_FORBIDDEN, RFC_9110_11_2};
+use crate::violations::auth_scheme::{
+    AUTH_SCHEME_CHARACTER_FORBIDDEN, AUTH_SCHEME_UNREGISTERED, RFC_9110_11_1, RFC_9110_11_2,
+};
 use crate::violations::challenge::{
     challenge_defect, CHALLENGE_MEMBER_EMPTY, CHALLENGE_SCHEME_MISSING, RFC_9110_11_3,
     RFC_9110_11_6_1,
@@ -28,14 +30,17 @@ pub struct AuthSchemeRegistered;
 /// `credentials_*` entries are what an `Authorization` value fails to be before
 /// any scheme is looked up.
 ///
-/// **What stays this rule's own is the registry question**, which is the whole
-/// of what its name is about: a scheme spelled correctly and absent from the
-/// operator's `allowed` list is not a defect of any production, and no sentence
-/// in RFC 9110 makes it one — § 11.1 says schemes *ought to* be registered.
+/// **The registry question is the whole of what this rule is named for**, and
+/// it is now an entry of the scheme's own subject rather than a sentence this
+/// file words: a scheme spelled correctly and absent from the operator's
+/// `allowed` list is not a defect of any production, and no sentence in
+/// RFC 9110 makes it one — § 11.1 says schemes *ought to* be registered, which
+/// is exactly what the entry carries.
 static DECLARED: &[&ViolationDef] = &[
     &CHALLENGE_MEMBER_EMPTY,
     &CHALLENGE_SCHEME_MISSING,
     &AUTH_SCHEME_CHARACTER_FORBIDDEN,
+    &AUTH_SCHEME_UNREGISTERED,
     &CREDENTIALS_EMPTY,
     &CREDENTIALS_MISSING,
     &CREDENTIALS_CONTROL_CHARACTER_FORBIDDEN,
@@ -44,12 +49,6 @@ static DECLARED: &[&ViolationDef] = &[
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_9110_11_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("11.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.1",
-    note: "Authentication Scheme — `auth-scheme = token`, and where new schemes are registered",
-};
 const RFC_9110_16_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
     section: Some("16.4.1"),
@@ -170,11 +169,10 @@ impl Rule for AuthSchemeRegistered {
                     // list, not the live IANA registry — the allowlist is the operator's chosen
                     // subset of acceptable (typically registered) schemes, and §16.4.1 is where
                     // registered ones live.
-                    // cite(RFC 9110 § 11.1): "New and existing authentication schemes are specified independently and ought to be registered"
                     // cite(RFC 9110 § 16.4.1): "The "Hypertext Transfer Protocol (HTTP) Authentication Scheme Registry" defines the namespace for the authentication schemes in challenges and credentials."
                     if !allowed.contains(&scheme.to_ascii_lowercase()) {
-                        return Some(AuthSchemeRegistered.violation(
-                            ctx.severity,
+                        return Some(ctx.report_with(
+                            &AUTH_SCHEME_UNREGISTERED,
                             format!("Unrecognized auth-scheme '{}' in {}", scheme, hdr_name),
                         ));
                     }
@@ -270,6 +268,31 @@ mod tests {
             }),
         );
         cfg
+    }
+
+    /// The registry question and the grammar question are two entries, and a
+    /// well-formed unknown name reaches the first: `NewScheme` is a `token`, so
+    /// nothing is wrong with it except that this deployment has never heard of
+    /// it. Both directions of the framework answer the same way.
+    #[test]
+    fn a_well_formed_unknown_scheme_is_the_registry_entry() {
+        let mut response = crate::test_helpers::make_test_transaction_with_response(401, &[]);
+        response.response.as_mut().expect("a response").headers =
+            crate::test_helpers::make_headers_from_pairs(&[("www-authenticate", "NewScheme abc=")]);
+        let mut request = crate::test_helpers::make_test_transaction();
+        request.request.headers =
+            crate::test_helpers::make_headers_from_pairs(&[("authorization", "X-MyAuth abc")]);
+
+        for tx in [response, request] {
+            let found = crate::test_helpers::run_rule(
+                &AuthSchemeRegistered,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &make_cfg(),
+            )
+            .expect("a finding");
+            assert_eq!(found.violation, "auth_scheme_unregistered");
+        }
     }
 
     #[rstest]

--- a/lint-http-rules/src/violations/auth_scheme.rs
+++ b/lint-http-rules/src/violations/auth_scheme.rs
@@ -22,6 +22,15 @@ use crate::lint::Severity;
 use crate::rules::SpecRef;
 use crate::violations::defects;
 
+/// Where the scheme is defined and where the registry that ought to hold it
+/// is named.
+pub const RFC_9110_11_1: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("11.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.1",
+    note: "Authentication Scheme — `auth-scheme = token`, and where new schemes are registered",
+};
+
 /// The framework's vocabulary: the scheme's `token`, the `auth-param` pair
 /// built on it, and the `token68` alternative. One section behind all three,
 /// which is why `challenge` and `credentials` both point their parameter
@@ -46,5 +55,31 @@ defects! {
         message: "",
         default_severity: Severity::Warn,
         spec: Some(RFC_9110_11_2),
+    }
+
+    /// A scheme name that is a perfectly good `token` and is not one the
+    /// deployment expects. Nothing about the value is malformed: what is
+    /// reported is that a recipient meeting it has nothing to look it up in.
+    ///
+    /// **The comparison is against the operator's `allowed` list, not against
+    /// the registry itself**, and that is a deliberate stand-in rather than an
+    /// approximation of one: this crate ships no snapshot of IANA's table, a
+    /// snapshot would be stale the day it was written, and a deployment
+    /// generally accepts far fewer schemes than are registered. So the list is
+    /// the operator's answer to § 11.1's *ought to*, and the id names the
+    /// sentence rather than the list — an operator silencing this is saying
+    /// "unrecognised schemes are fine here", which is what they mean.
+    ///
+    /// `warn`, and the sentence quoted is why it is not an error: schemes ought
+    /// to be registered, and a private scheme between two parties that know
+    /// each other breaks nothing.
+    ///
+    // cite(RFC 9110 § 11.1): "New and existing authentication schemes are specified independently and ought to be registered"
+    AUTH_SCHEME_UNREGISTERED = {
+        id: "auth_scheme_unregistered",
+        title: "Authentication scheme is not one the deployment recognises",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_11_1),
     }
 }

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -378,7 +378,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 129;
+        const FLOOR: usize = 130;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -5276,18 +5276,18 @@ sources:
       line: 354
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
       line: 188
-  - label: auth_scheme_registered
+  - label: auth_scheme
     section: § 11.1
     snippet: New and existing authentication schemes are specified independently and ought to be registered
     cited_by:
-    - file: lint-http-rules/src/rules/auth_scheme_registered.rs
-      line: 173
-  - label: auth_scheme_registered (2)
+    - file: lint-http-rules/src/violations/auth_scheme.rs
+      line: 77
+  - label: auth_scheme_registered
     section: § 16.4.1
     snippet: The "Hypertext Transfer Protocol (HTTP) Authentication Scheme Registry" defines the namespace for the authentication schemes in challenges and credentials.
     cited_by:
     - file: lint-http-rules/src/rules/auth_scheme_registered.rs
-      line: 174
+      line: 172
   - label: authentication_challenge_valid
     section: § 11.5
     snippet: Note that a response can have multiple challenges with the same auth-scheme but with different realms.
@@ -6567,7 +6567,7 @@ sources:
     - file: lint-http-rules/src/helpers/auth.rs
       line: 434
     - file: lint-http-rules/src/rules/auth_scheme_registered.rs
-      line: 153
+      line: 152
     - file: lint-http-rules/src/rules/basic_auth_base64_valid.rs
       line: 108
     - file: lint-http-rules/src/rules/bearer_token_syntax.rs
@@ -6575,7 +6575,7 @@ sources:
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
       line: 154
     - file: lint-http-rules/src/violations/auth_scheme.rs
-      line: 42
+      line: 51
   - label: lint-http-rules/src/helpers/auth.rs (2)
     section: § 11.2
     snippet: auth-param     = token BWS "=" BWS ( token / quoted-string )


### PR DESCRIPTION
The last finding of the authentication cluster gets an id: a name that is a perfectly good token and that this deployment does not recognise. The allowed list is the operator's answer to the ought-to-be-registered sentence, so the entry names that sentence rather than the list, and the rule that is named for the registry now words none of it itself.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
