### PR TITLE
An unlisted media type cites registration

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1431,6 +1431,10 @@ severity = "warn"
 # Mailbox is followed by something else
 severity = "warn"
 
+[violations.media_type_unregistered]
+# Media type is not one the deployment recognises
+severity = "warn"
+
 [violations.node_ipv4_address_malformed]
 # Node identifier is digits and dots that are not an IPv4 address
 severity = "warn"

--- a/lint-http-rules/src/rules/content_type_registered.rs
+++ b/lint-http-rules/src/rules/content_type_registered.rs
@@ -4,18 +4,20 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::media_type::{MEDIA_TYPE_UNREGISTERED, RFC_9110_8_3_1};
+use crate::violations::ViolationDef;
+
+/// One entry, and it is the pair's own: everything this rule reports is a
+/// well-formed `media-type` that the operator's list does not hold. A value
+/// that does not parse is declined here and is the syntax rules' finding.
+static DECLARED: &[&ViolationDef] = &[&MEDIA_TYPE_UNREGISTERED];
 
 pub struct ContentTypeRegistered;
 
-/// The specification references this rule declares, each named so a finding
-/// site can cite the one it enforces. `specifications()` below is built from
-/// exactly these, so the docs and the citations cannot name different text.
-const RFC_9110_8_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("8.3.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1",
-    note: "`media-type` syntax, the case-insensitivity of its tokens, and the \"ought to be registered with IANA\" guidance that motivates this rule — guidance, not a requirement, and not something this rule verifies",
-};
+/// The specification references this rule declares beyond the catalogue's
+/// § 8.3.1, each named so a finding site can cite the one it enforces.
+/// `specifications()` below is built from exactly these, so the docs and the
+/// citations cannot name different text.
 const RFC_6838_4_2_8: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 6838",
     section: Some("4.2.8"),
@@ -104,6 +106,10 @@ allowed = [
         &[RFC_9110_8_3_1, RFC_6838_4_2_8, IANA_MEDIA_TYPES]
     }
 
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
+    }
+
     fn examples(&self) -> &'static [crate::rules::Example] {
         use crate::rules::{Compliance, Example};
         &[
@@ -162,8 +168,12 @@ impl Rule for ContentTypeRegistered {
                 // for it: entries can be exact (`text/plain`), a type wildcard
                 // (`image/*`), `*/*`, or a structured-syntax suffix (`+json`). The
                 // wildcard and suffix forms are configuration conveniences with no
-                // basis in any specification.
-                // cite(RFC 9110 § 8.3.1): "Media types ought to be registered with IANA according to the procedures defined in [BCP13]."
+                // basis in any specification. The sentence that motivates the
+                // whole check is quoted on `media_type_unregistered`, which is
+                // what a value reaching the end of this loop reports as — and
+                // it was RFC 6838 § 4.2.8's suffix sentence that sat on the
+                // finding before, a sentence about how one *allowlist entry*
+                // is matched rather than about registration at all.
 
                 for pat in allowed {
                     if pat == "*/*" || pat == &full {
@@ -194,9 +204,8 @@ impl Rule for ContentTypeRegistered {
                     }
                 }
 
-                Some(self.cited(
-                    &RFC_6838_4_2_8,
-                    ctx.severity,
+                Some(ctx.report_with(
+                    &MEDIA_TYPE_UNREGISTERED,
                     format!("Unrecognized media type '{}' in {} header", full, hdr_name),
                 ))
             };
@@ -257,6 +266,28 @@ mod tests {
             }),
         );
         cfg
+    }
+
+    /// The finding is the pair's registry entry, and it carries the
+    /// registration sentence. It used to carry RFC 6838 § 4.2.8's — the
+    /// definition of a structured syntax suffix, which is how a `+json`
+    /// allowlist entry is *matched* and is not what the finding claims.
+    #[test]
+    fn an_unlisted_type_reports_the_registry_entry_and_cites_registration() {
+        let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
+        tx.response.as_mut().expect("a response").headers =
+            crate::test_helpers::make_headers_from_pairs(&[("content-type", "text/x-custom")]);
+        let found = crate::test_helpers::run_rule(
+            &ContentTypeRegistered,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &make_cfg(),
+        )
+        .expect("a finding");
+        assert_eq!(found.violation, "media_type_unregistered");
+        let cite = found.cite.expect("the entry's citation");
+        assert_eq!(cite.spec, "RFC 9110");
+        assert_eq!(cite.section.as_deref(), Some("8.3.1"));
     }
 
     #[rstest]

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1312,7 +1312,7 @@ severity = "warn"
         /// directive list, and neither says anything about an encoding. Each
         /// field's octet is now `token`'s, under an id the rule already
         /// declared.
-        const FLOOR: usize = 135;
+        const FLOOR: usize = 134;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/violations/media_type.rs
+++ b/lint-http-rules/src/violations/media_type.rs
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `media-type` defects — what a type/subtype pair can be wrong about once it
+//! is well formed.
+//!
+//! The grammar half of this production is already spoken for and deliberately
+//! not here: a `media-type` is `type "/" subtype parameters`, all of it built
+//! from `token`, `parameter` and `quoted-string`, so a malformed one answers
+//! under those subjects wherever it is read — `Content-Type`, `Accept`,
+//! `Accept-Patch`, a multipart body's part. What is left over is the pair
+//! *itself*: two well-formed tokens naming something.
+//!
+//! Which is why the one entry below is a registry entry, and why it is the
+//! second of that shape after
+//! [`auth_scheme_unregistered`](crate::violations::auth_scheme::AUTH_SCHEME_UNREGISTERED).
+//! Both are an `ought to` addressed to whoever defines the name, measured
+//! against a list the operator wrote — and in both cases naming the id after
+//! the sentence rather than after the list is what keeps an operator's
+//! configuration meaningful when the list changes.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// The production, the case-insensitivity of its two tokens, and the
+/// registration guidance the entry below carries.
+pub const RFC_9110_8_3_1: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1",
+    note: "`media-type` syntax, the case-insensitivity of its tokens, and the \"ought to be registered with IANA\" guidance that motivates this rule — guidance, not a requirement, and not something this rule verifies",
+};
+
+defects! {
+    /// A well-formed `type/subtype` that the deployment does not expect. The
+    /// tokens parse, the pair is comparable, and a recipient still has nothing
+    /// telling it what the bytes are.
+    ///
+    /// **Measured against the operator's `allowed` list rather than against
+    /// IANA's table**, which this crate does not carry — the same stand-in
+    /// `auth_scheme_unregistered` makes, and worth the same caution: an entry
+    /// may be an exact pair, a `type/*`, `*/*`, or a `+suffix`, and those three
+    /// wildcard forms are configuration conveniences with no basis in any
+    /// document. So a finding here means "not on the list", and the list is the
+    /// operator's answer to the sentence quoted below.
+    ///
+    /// `warn`: registration is an *ought to* addressed to whoever defines the
+    /// type, and an unregistered type between two parties that agree on it
+    /// breaks nothing on the wire.
+    ///
+    // cite(RFC 9110 § 8.3.1): "Media types ought to be registered with IANA according to the procedures defined in [BCP13]."
+    MEDIA_TYPE_UNREGISTERED = {
+        id: "media_type_unregistered",
+        title: "Media type is not one the deployment recognises",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_8_3_1),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The entry carries the registration sentence and not the suffix one.
+    /// Before it existed, the finding cited RFC 6838 § 4.2.8 — the sentence
+    /// defining `+json` as a structured syntax suffix, which is how one
+    /// *allowlist entry* is matched and says nothing about whether a type is
+    /// registered.
+    #[test]
+    fn the_entry_quotes_the_registration_sentence() {
+        assert_eq!(MEDIA_TYPE_UNREGISTERED.spec, Some(RFC_9110_8_3_1));
+        assert_eq!(
+            MEDIA_TYPE_UNREGISTERED.spec.map(|s| s.spec),
+            Some("RFC 9110")
+        );
+    }
+}

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -47,6 +47,7 @@ pub mod http_date;
 pub mod language;
 pub mod list;
 pub mod mailbox;
+pub mod media_type;
 pub mod node;
 pub mod origin_agent_cluster;
 pub mod parameter;
@@ -378,7 +379,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 130;
+        const FLOOR: usize = 131;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -3150,7 +3150,7 @@ sources:
     snippet: it specified a suffix (in that case, "+xml") to be appended to the base subtype name.
     cited_by:
     - file: lint-http-rules/src/rules/content_type_registered.rs
-      line: 190
+      line: 200
   - label: link_header_valid
     section: § 4.2
     snippet: 'Type and subtype names MUST conform to the following ABNF:'
@@ -5746,12 +5746,6 @@ sources:
       line: 255
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
       line: 171
-  - label: content_type_registered
-    section: § 8.3.1
-    snippet: Media types ought to be registered with IANA according to the procedures defined in [BCP13].
-    cited_by:
-    - file: lint-http-rules/src/rules/content_type_registered.rs
-      line: 166
   - label: content_type_valid
     section: § 8.3
     snippet: Although Content-Type is defined as a singleton field, it is sometimes incorrectly generated multiple times, resulting in a combined field value that appears to be a list.
@@ -7355,7 +7349,7 @@ sources:
     - file: lint-http-rules/src/rules/charset_present.rs
       line: 97
     - file: lint-http-rules/src/rules/content_type_registered.rs
-      line: 152
+      line: 158
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
       line: 62
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
@@ -7808,6 +7802,12 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/max_forwards_numeric.rs
       line: 220
+  - label: media_type
+    section: § 8.3.1
+    snippet: Media types ought to be registered with IANA according to the procedures defined in [BCP13].
+    cited_by:
+    - file: lint-http-rules/src/violations/media_type.rs
+      line: 53
   - label: multipart_boundary_syntax
     section: § 5.6.6
     snippet: A parameter value that matches the token production can be transmitted either as a token or within a quoted-string.


### PR DESCRIPTION
The media-type pair gets a subject holding the one thing left to say about a well-formed type/subtype: that the deployment does not recognise it. The finding had been citing the sentence defining a structured syntax suffix, which is how one allowlist entry is matched and says nothing about registration; the entry carries the registration sentence instead.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
