### PR TITLE
A charset name answers for itself

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1127,6 +1127,14 @@ severity = "warn"
 # Authentication token68 is indistinguishable from a parameter
 severity = "info"
 
+[violations.charset_empty]
+# Charset parameter carries no name
+severity = "warn"
+
+[violations.charset_unregistered]
+# Charset name is not one the deployment recognises
+severity = "warn"
+
 [violations.comment_character_forbidden]
 # Comment holds a character ctext does not admit
 severity = "warn"

--- a/lint-http-rules/src/rules/charset_registered.rs
+++ b/lint-http-rules/src/rules/charset_registered.rs
@@ -4,6 +4,7 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::charset::{CHARSET_EMPTY, CHARSET_UNREGISTERED, RFC_9110_8_3_2};
 use crate::violations::parameter::{PARAMETER_VALUE_EMPTY, RFC_9110_5_6_6};
 use crate::violations::quoted_pair::QUOTED_PAIR_MALFORMED;
 use crate::violations::quoted_string::{
@@ -32,6 +33,8 @@ pub struct CharsetRegistered;
 /// charset name of nothing. One is § 5.6.6's defect and the other is § 8.3.2's,
 /// and the `charset` subject that owns the second is unwritten.
 static DECLARED: &[&ViolationDef] = &[
+    &CHARSET_EMPTY,
+    &CHARSET_UNREGISTERED,
     &PARAMETER_VALUE_EMPTY,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
     &TOKEN_CHARACTER_FORBIDDEN,
@@ -41,15 +44,10 @@ static DECLARED: &[&ViolationDef] = &[
     &QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
 ];
 
-/// The specification references this rule declares, each named so a finding
-/// site can cite the one it enforces. `specifications()` below is built from
-/// exactly these, so the docs and the citations cannot name different text.
-const RFC_9110_8_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("8.3.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.2",
-    note: "Charset: what the parameter means, that names are matched case-insensitively, and the \"ought to be registered\" guidance that motivates this rule — guidance, not a requirement, and not something this rule verifies",
-};
+/// The specification references this rule declares beyond the catalogue's
+/// § 8.3.2, each named so a finding site can cite the one it enforces.
+/// `specifications()` below is built from exactly these, so the docs and the
+/// citations cannot name different text.
 const RFC_2978_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 2978",
     section: Some("2.3"),
@@ -270,8 +268,8 @@ impl Rule for CharsetRegistered {
                             // waits for a `charset` subject — the two look like
                             // one finding and are two.
                             if value.is_empty() {
-                                return Some(CharsetRegistered.violation(
-                                    ctx.severity,
+                                return Some(ctx.report_with(
+                                    &CHARSET_EMPTY,
                                     format!(
                                         "Invalid Content-Type in {}: empty 'charset' parameter",
                                         which
@@ -281,15 +279,17 @@ impl Rule for CharsetRegistered {
 
                             // The rule's name says IANA; the code says the
                             // operator's `allowed` array. The registry is never
-                            // consulted — there is no lookup — so this cite is
-                            // the *motivation*, and "ought to" is why the whole
-                            // rule is a policy rather than a conformance check.
-                            // The fold is the matching rule, not a convenience.
-                            // cite(RFC 9110 § 8.3.2): "Charset names ought to be registered in the IANA "Character Sets" registry (<https://www.iana.org/assignments/character-sets>) according to the procedures defined in Section 2 of [RFC2978]."
+                            // consulted — there is no lookup — and the "ought
+                            // to" that motivates the whole rule is quoted on
+                            // `charset_unregistered`, which is what this
+                            // reports. The fold is the matching rule, not a
+                            // convenience, and that sentence stays here because
+                            // it is what this comparison does rather than what
+                            // the defect is.
                             // cite(RFC 9110 § 8.3.2): "In both cases, charset names are matched case-insensitively."
                             if !config.allowed.contains(&value.to_ascii_lowercase()) {
-                                return Some(CharsetRegistered.violation(
-                                    ctx.severity,
+                                return Some(ctx.report_with(
+                                    &CHARSET_UNREGISTERED,
                                     format!("Unrecognized charset '{}' in {} header", value, which),
                                 ));
                             }
@@ -430,9 +430,8 @@ mod tests {
 
     /// `charset=""` is the pair that must not collapse into the one above: the
     /// value is a `quoted-string` and derives exactly as § 5.6.6 says, so what
-    /// is empty is the charset name and the defect is this rule's own — still
-    /// on the older API, and reported at the rule's severity rather than the
-    /// parameter def's.
+    /// is empty is the charset name — a defect of the name and not of the
+    /// parameter carrying it, which is why the two answer under different ids.
     #[test]
     fn a_quoted_empty_charset_is_not_the_parameters_defect() {
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
@@ -448,10 +447,8 @@ mod tests {
             &make_cfg(),
         )
         .expect("a finding");
-        assert!(
-            found.violation.is_empty(),
-            "unconverted sites carry no defect id"
-        );
+        assert_eq!(found.violation, "charset_empty");
+        assert_ne!(found.violation, "parameter_value_empty");
     }
 
     #[rstest]

--- a/lint-http-rules/src/violations/charset.rs
+++ b/lint-http-rules/src/violations/charset.rs
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `charset` defects — the name that says which character encoding scheme a
+//! textual representation was written in.
+//!
+//! A charset name is not a production of its own in RFC 9110: § 8.3.2 says it
+//! appears *"either in parameters (Content-Type), or, for Accept-Encoding, in
+//! the form of a plain token"*, so the carrier's grammar has already been
+//! measured by the time these entries are reached — a `parameter` that is
+//! missing its `=`, a `quoted-string` that never closes, an octet no `token`
+//! admits, all answer under those subjects. **What is left is the name.**
+//!
+//! Which is exactly the distinction the empty entry below exists for, and it
+//! was written down in `charset_registered` before there was anywhere to put
+//! it: `charset=""` is a *well-formed* `parameter` whose value is a
+//! *well-formed* `quoted-string`, and the thing that is empty is the charset
+//! name inside it. Under § 5.6.6 nothing is wrong; under § 8.3.2 the
+//! representation states no encoding at all.
+//!
+//! The third registry entry of the catalogue, after
+//! [`auth_scheme_unregistered`](crate::violations::auth_scheme::AUTH_SCHEME_UNREGISTERED)
+//! and
+//! [`media_type_unregistered`](crate::violations::media_type::MEDIA_TYPE_UNREGISTERED),
+//! and the same shape as both: an *ought to* addressed to whoever defines the
+//! name, measured against a list the operator wrote.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// Where a charset name appears, how it is matched, and the registry it ought
+/// to be in.
+pub const RFC_9110_8_3_2: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.3.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.2",
+    note: "Charset: what the parameter means, that names are matched case-insensitively, and the \"ought to be registered\" guidance that motivates this rule — guidance, not a requirement, and not something this rule verifies",
+};
+
+defects! {
+    /// A charset parameter carrying no name: `charset=""`. The parameter is
+    /// there, the quoting is closed, and the representation still says nothing
+    /// about how its characters are encoded — which is worse than omitting the
+    /// parameter, because a recipient reading the field sees an answer.
+    ///
+    // cite(RFC 9110 § 8.3.2): "In the fields defined by this document, charset names appear either in parameters (Content-Type), or, for Accept-Encoding, in the form of a plain token."
+    CHARSET_EMPTY = {
+        id: "charset_empty",
+        title: "Charset parameter carries no name",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_8_3_2),
+    }
+
+    /// A charset name the deployment does not recognise. Matched
+    /// case-insensitively, because that is how § 8.3.2 says charset names are
+    /// matched, and against the operator's `allowed` list rather than IANA's
+    /// table — the stand-in the other two registry entries make, for the same
+    /// reason: this crate carries no snapshot of a registry it cannot keep
+    /// current.
+    ///
+    /// `warn`. The consequence of an unknown name is a recipient guessing at
+    /// the encoding, which is a decoding risk rather than a malformed message.
+    ///
+    // cite(RFC 9110 § 8.3.2): "Charset names ought to be registered in the IANA "Character Sets" registry (<https://www.iana.org/assignments/character-sets>) according to the procedures defined in Section 2 of [RFC2978]."
+    CHARSET_UNREGISTERED = {
+        id: "charset_unregistered",
+        title: "Charset name is not one the deployment recognises",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_8_3_2),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two entries that look like one finding. The empty name reaches its own
+    /// id rather than `parameter_value_empty`, because `charset=""` has a
+    /// perfectly good parameter value — the emptiness is one level in.
+    #[test]
+    fn the_empty_name_is_not_the_empty_parameter_value() {
+        assert_eq!(CHARSET_EMPTY.id, "charset_empty");
+        assert_ne!(CHARSET_EMPTY.id, "parameter_value_empty");
+        assert_eq!(CHARSET_EMPTY.spec, Some(RFC_9110_8_3_2));
+        assert_eq!(CHARSET_UNREGISTERED.spec, Some(RFC_9110_8_3_2));
+    }
+}

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -34,6 +34,7 @@ pub mod base64;
 pub mod basic_credentials;
 pub mod bws;
 pub mod challenge;
+pub mod charset;
 pub mod comment;
 pub mod content_length;
 pub mod content_range;
@@ -379,7 +380,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 131;
+        const FLOOR: usize = 133;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -5376,6 +5376,18 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/cached_validators_reused.rs
       line: 138
+  - label: charset
+    section: § 8.3.2
+    snippet: Charset names ought to be registered in the IANA "Character Sets" registry (<https://www.iana.org/assignments/character-sets>) according to the procedures defined in Section 2 of [RFC2978].
+    cited_by:
+    - file: lint-http-rules/src/violations/charset.rs
+      line: 67
+  - label: charset (2)
+    section: § 8.3.2
+    snippet: In the fields defined by this document, charset names appear either in parameters (Content-Type), or, for Accept-Encoding, in the form of a plain token.
+    cited_by:
+    - file: lint-http-rules/src/violations/charset.rs
+      line: 48
   - label: charset_present
     section: § 8.3.2
     snippet: HTTP uses "charset" names to indicate or negotiate the character encoding scheme
@@ -5387,7 +5399,7 @@ sources:
     snippet: 'The "Content-Type" header field indicates the media type of the associated representation: either the representation enclosed in the message content or the selected representation, as determined by the message semantics.'
     cited_by:
     - file: lint-http-rules/src/rules/charset_registered.rs
-      line: 150
+      line: 148
     - file: lint-http-rules/src/rules/content_type_valid.rs
       line: 177
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
@@ -5398,16 +5410,10 @@ sources:
       line: 98
   - label: charset_registered (2)
     section: § 8.3.2
-    snippet: Charset names ought to be registered in the IANA "Character Sets" registry (<https://www.iana.org/assignments/character-sets>) according to the procedures defined in Section 2 of [RFC2978].
-    cited_by:
-    - file: lint-http-rules/src/rules/charset_registered.rs
-      line: 288
-  - label: charset_registered (3)
-    section: § 8.3.2
     snippet: In both cases, charset names are matched case-insensitively.
     cited_by:
     - file: lint-http-rules/src/rules/charset_registered.rs
-      line: 83
+      line: 81
     - file: lint-http-rules/src/rules/charset_registered.rs
       line: 289
   - label: compression_and_transfer_encoding_consistent
@@ -7291,7 +7297,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
       line: 251
     - file: lint-http-rules/src/rules/charset_registered.rs
-      line: 195
+      line: 193
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
       line: 274
   - label: lint-http-rules/src/helpers/media_type.rs (3)


### PR DESCRIPTION
The charset subject the rule's comments had been waiting for: an empty name inside a perfectly well-formed quoted parameter value, and a name the deployment does not recognise. The first is one level in from the parameter defect it used to sit beside, and the second is the third registry entry of the same shape as the scheme's and the media type's.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
