### PR TITLE
Two fields do not share one vocabulary

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1143,6 +1143,18 @@ severity = "warn"
 # Comment is never closed
 severity = "warn"
 
+[violations.content_coding_identity_forbidden]
+# The identity coding is named where a coding belongs
+severity = "warn"
+
+[violations.content_coding_unregistered]
+# Content coding is not one the deployment recognises
+severity = "warn"
+
+[violations.content_coding_wildcard_forbidden]
+# The Accept-Encoding wildcard is written where a coding belongs
+severity = "warn"
+
 [violations.content_length_character_forbidden]
 # Content-Length value holds an octet DIGIT does not admit
 severity = "error"

--- a/lint-http-rules/src/rules/content_encoding_registered.rs
+++ b/lint-http-rules/src/rules/content_encoding_registered.rs
@@ -4,6 +4,10 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::content_coding::{
+    CONTENT_CODING_IDENTITY_FORBIDDEN, CONTENT_CODING_UNREGISTERED,
+    CONTENT_CODING_WILDCARD_FORBIDDEN, RFC_9110_12_5_3, RFC_9110_8_4, RFC_9110_8_4_1,
+};
 use crate::violations::token::{
     token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
     TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
@@ -27,29 +31,15 @@ pub struct ContentEncodingRegistered;
 static DECLARED: &[&ViolationDef] = &[
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
     &TOKEN_CHARACTER_FORBIDDEN,
+    &CONTENT_CODING_WILDCARD_FORBIDDEN,
+    &CONTENT_CODING_IDENTITY_FORBIDDEN,
+    &CONTENT_CODING_UNREGISTERED,
 ];
 
-/// The specification references this rule declares, each named so a finding
-/// site can cite the one it enforces. `specifications()` below is built from
+/// The registry this rule is named after, and the only reference here the
+/// catalogue does not hold: the three RFC 9110 sections a finding cites live
+/// on the `content_coding` defects. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_9110_8_4: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("8.4"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4",
-    note: "`Content-Encoding = #content-coding`, and the reservation of `identity` for Accept-Encoding — the reason it is flagged here",
-};
-const RFC_9110_8_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("8.4.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4.1",
-    note: "`content-coding = token`, case-insensitive, and the \"ought to be registered\" guidance that motivates the rule without being what it checks",
-};
-const RFC_9110_12_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("12.5.3"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.3",
-    note: "The wider Accept-Encoding grammar (`codings = content-coding / \"identity\" / \"*\"`), which is why the two headers are checked against different vocabularies",
-};
 const IANA_HTTP_PARAMETERS: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "IANA HTTP Parameters",
     section: None,
@@ -157,11 +147,10 @@ impl Rule for ContentEncodingRegistered {
                         // preferences are expressed. In Content-Encoding there is
                         // nothing for it to match: that field states what was actually
                         // applied.
-                        // cite(RFC 9110 § 12.5.3): "The asterisk "*" symbol in an Accept-Encoding field matches any available content coding not explicitly listed in the field."
                         if is_accept {
                             continue;
                         }
-                        return Some(ContentEncodingRegistered.violation(ctx.severity, format!(
+                        return Some(ctx.report_with(&CONTENT_CODING_WILDCARD_FORBIDDEN, format!(
                                     "'*' is not a content-coding and is only meaningful in Accept-Encoding, not in {}",
                                     hdr_name
                                 )));
@@ -169,9 +158,8 @@ impl Rule for ContentEncodingRegistered {
                     // `identity` is likewise Accept-Encoding vocabulary — the way to say
                     // "no encoding". Naming it in Content-Encoding claims a transformation
                     // that by definition does nothing, so the spec reserves it away.
-                    // cite(RFC 9110 § 8.4): "Note that the coding named "identity" is reserved for its special role in Accept-Encoding and thus SHOULD NOT be included."
                     if !is_accept && token.eq_ignore_ascii_case("identity") {
-                        return Some(ContentEncodingRegistered.violation(ctx.severity, format!(
+                        return Some(ctx.report_with(&CONTENT_CODING_IDENTITY_FORBIDDEN, format!(
                                     "'identity' is reserved for Accept-Encoding and SHOULD NOT be sent in {}",
                                     hdr_name
                                 )));
@@ -196,10 +184,9 @@ impl Rule for ContentEncodingRegistered {
                     // in the media-type sibling, "registered" here means "in the
                     // operator's list": nothing consults the registry the rule is named
                     // after, and the sentence below is an "ought to" in any case.
-                    // cite(RFC 9110 § 8.4.1): "All content codings are case-insensitive and ought to be registered within the "HTTP Content Coding Registry","
                     if !allowed.contains(&token.to_ascii_lowercase()) {
-                        return Some(ContentEncodingRegistered.violation(
-                            ctx.severity,
+                        return Some(ctx.report_with(
+                            &CONTENT_CODING_UNREGISTERED,
                             format!(
                                 "Unrecognized content-coding '{}' in {} header",
                                 token, hdr_name
@@ -916,13 +903,30 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
         );
-        assert!(v.is_some());
-        let v = v.unwrap();
-        assert_eq!(v.severity, crate::lint::Severity::Error);
+        let v = v.expect("a finding");
+        assert_eq!(v.violation, "content_coding_unregistered");
         assert_eq!(
             v.message,
             "Unrecognized content-coding 'x-foo' in Content-Encoding header"
         );
+        // The rule's own `severity = "error"` above is no longer what this
+        // finding reports at: a converted site takes the entry's default, and
+        // an operator who wants it louder says so under the id.
+        assert_eq!(v.severity, crate::lint::Severity::Warn);
+
+        crate::test_helpers::override_violation_severity(
+            &mut cfg,
+            "content_coding_unregistered",
+            "error",
+        );
+        let raised = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .expect("a finding");
+        assert_eq!(raised.severity, crate::lint::Severity::Error);
         Ok(())
     }
 

--- a/lint-http-rules/src/violations/content_coding.rs
+++ b/lint-http-rules/src/violations/content_coding.rs
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `content-coding` defects — the name of a transformation applied to a
+//! representation, and the two words that are not one.
+//!
+//! `content-coding = token`, so the production adds nothing to the alphabet and
+//! an octet no `token` admits answers under that subject rather than here. What
+//! this subject holds is what a *name* can be wrong about, and the interesting
+//! half of that is a distinction the grammar cannot make: **`Accept-Encoding`
+//! and `Content-Encoding` do not accept the same vocabulary.**
+//!
+//! § 12.5.3 gives the request field `codings = content-coding / "identity" /
+//! "*"` — three alternatives, of which only the first is a coding. The response
+//! field is `#content-coding` and nothing else, because it states what was
+//! actually applied rather than what would be welcome. So `*` and `identity`
+//! are perfectly good `token`s that name no transformation, and each gets an
+//! entry: a recipient meeting either in a `Content-Encoding` has been told the
+//! representation was transformed by something that does not exist.
+//!
+//! The registry entry beneath them is the fourth of its shape — see
+//! [`charset_unregistered`](crate::violations::charset::CHARSET_UNREGISTERED)
+//! for the reasoning all four share.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// The response field's grammar, and the sentence reserving `identity` away
+/// from it.
+pub const RFC_9110_8_4: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4",
+    note: "`Content-Encoding = #content-coding`, and the reservation of `identity` for Accept-Encoding — the reason it is flagged here",
+};
+
+/// The production itself, its case-insensitivity, and the registry a name
+/// ought to be in.
+pub const RFC_9110_8_4_1: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4.1",
+    note: "`content-coding = token`, case-insensitive, and the \"ought to be registered\" guidance that motivates the rule without being what it checks",
+};
+
+/// The request field's wider vocabulary, which is what makes the two entries
+/// below defects of the *response* field alone.
+pub const RFC_9110_12_5_3: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("12.5.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.3",
+    note: "The wider Accept-Encoding grammar (`codings = content-coding / \"identity\" / \"*\"`), which is why the two headers are checked against different vocabularies",
+};
+
+defects! {
+    /// `*` written where a coding that was actually applied belongs. The
+    /// asterisk is how a request says "anything else"; a response saying it has
+    /// named no transformation at all, and a recipient has nothing to undo.
+    ///
+    /// A `token` admits `*`, so nothing about the grammar refuses this — which
+    /// is why the sentence quoted is the one that gives the symbol its only
+    /// meaning, in the other field.
+    ///
+    // cite(RFC 9110 § 12.5.3): "The asterisk "*" symbol in an Accept-Encoding field matches any available content coding not explicitly listed in the field."
+    CONTENT_CODING_WILDCARD_FORBIDDEN = {
+        id: "content_coding_wildcard_forbidden",
+        title: "The Accept-Encoding wildcard is written where a coding belongs",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_12_5_3),
+    }
+
+    /// `identity` written where a coding that was actually applied belongs. It
+    /// is the request field's way of asking for *no* encoding, so a response
+    /// naming it claims a transformation defined to do nothing — and the
+    /// document reserves the name away from this field in as many words.
+    ///
+    // cite(RFC 9110 § 8.4): "Note that the coding named "identity" is reserved for its special role in Accept-Encoding and thus SHOULD NOT be included."
+    CONTENT_CODING_IDENTITY_FORBIDDEN = {
+        id: "content_coding_identity_forbidden",
+        title: "The identity coding is named where a coding belongs",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_8_4),
+    }
+
+    /// A coding name the deployment does not recognise, matched
+    /// case-insensitively because the names are. Measured against the
+    /// operator's `allowed` list and not against IANA's table, the stand-in
+    /// every registry entry in this catalogue makes.
+    ///
+    /// `warn`: registration is an *ought to*, and the consequence of an unknown
+    /// name is a recipient that cannot decode — which it discovers immediately
+    /// rather than silently.
+    ///
+    // cite(RFC 9110 § 8.4.1): "All content codings are case-insensitive and ought to be registered within the "HTTP Content Coding Registry","
+    CONTENT_CODING_UNREGISTERED = {
+        id: "content_coding_unregistered",
+        title: "Content coding is not one the deployment recognises",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_8_4_1),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The two vocabulary entries quote the field that *does* admit the word,
+    /// which is the only way to state what is wrong with writing it in the
+    /// field that does not. Nothing here quotes `content-coding = token`: the
+    /// grammar admits both words, and an entry citing it would be evidence
+    /// against itself.
+    #[test]
+    fn each_vocabulary_entry_quotes_the_field_that_admits_the_word() {
+        assert_eq!(
+            CONTENT_CODING_WILDCARD_FORBIDDEN.spec,
+            Some(RFC_9110_12_5_3)
+        );
+        assert_eq!(CONTENT_CODING_IDENTITY_FORBIDDEN.spec, Some(RFC_9110_8_4));
+        assert_eq!(CONTENT_CODING_UNREGISTERED.spec, Some(RFC_9110_8_4_1));
+    }
+}

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -36,6 +36,7 @@ pub mod bws;
 pub mod challenge;
 pub mod charset;
 pub mod comment;
+pub mod content_coding;
 pub mod content_length;
 pub mod content_range;
 pub mod cookie;
@@ -380,7 +381,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 133;
+        const FLOOR: usize = 136;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -4810,8 +4810,8 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
       line: 221
-    - file: lint-http-rules/src/rules/content_encoding_registered.rs
-      line: 160
+    - file: lint-http-rules/src/violations/content_coding.rs
+      line: 66
   - label: accept_encoding_parameter_valid (8)
     section: § 12.5.3
     snippet: The field value is evaluated the same way as in a request.
@@ -5451,7 +5451,7 @@ sources:
     - file: lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
       line: 117
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
-      line: 145
+      line: 135
   - label: compression_and_transfer_encoding_consistent (5)
     section: § 8.4
     snippet: If one or more encodings have been applied to a representation, the sender that applied the encodings MUST generate a Content-Encoding header field that lists the content codings in the order in which they were applied.
@@ -5476,8 +5476,8 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 166
-    - file: lint-http-rules/src/rules/content_encoding_registered.rs
-      line: 199
+    - file: lint-http-rules/src/violations/content_coding.rs
+      line: 98
   - label: conditional_headers_consistent
     section: § 13.1.3
     snippet: A recipient MUST ignore If-Modified-Since if the request contains an If-None-Match header field
@@ -5588,6 +5588,12 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
       line: 74
+  - label: content_coding
+    section: § 8.4
+    snippet: Note that the coding named "identity" is reserved for its special role in Accept-Encoding and thus SHOULD NOT be included.
+    cited_by:
+    - file: lint-http-rules/src/violations/content_coding.rs
+      line: 80
   - label: content_disposition_token_valid
     section: § 5.5
     snippet: Field values are usually constrained to the range of US-ASCII characters [USASCII].
@@ -5607,19 +5613,13 @@ sources:
     snippet: codings = content-coding / "identity" / "*"
     cited_by:
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
-      line: 146
+      line: 136
   - label: content_encoding_registered (2)
-    section: § 8.4
-    snippet: Note that the coding named "identity" is reserved for its special role in Accept-Encoding and thus SHOULD NOT be included.
-    cited_by:
-    - file: lint-http-rules/src/rules/content_encoding_registered.rs
-      line: 172
-  - label: content_encoding_registered (3)
     section: § 8.4.1
     snippet: content-coding = token
     cited_by:
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
-      line: 179
+      line: 167
   - label: content_length_valid
     section: § 8.6
     snippet: The "Content-Length" header field indicates the associated representation's data length as a decimal non-negative integer number of octets.


### PR DESCRIPTION
The content-coding production gets a subject, and the three findings of the Content-Encoding rule become entries: the wildcard and identity, each a perfectly good token that names no transformation in the field that states what was applied, and a name the deployment does not recognise. Both vocabulary entries quote the field that does admit the word, which is the only way to say what is wrong with writing it in the one that does not.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
