### PR TITLE
A coding name and the field naming it

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1535,6 +1535,10 @@ severity = "warn"
 # Weight is not a qvalue
 severity = "warn"
 
+[violations.te_chunked_forbidden]
+# TE names the chunked coding, which cannot be declined
+severity = "warn"
+
 [violations.te_member_forbidden]
 # A request's TE holds a member other than trailers
 severity = "error"
@@ -1566,6 +1570,14 @@ severity = "warn"
 [violations.token_whitespace_or_control_forbidden]
 # Token holds whitespace or a control character
 severity = "error"
+
+[violations.transfer_coding_parameter_forbidden]
+# A coding that defines no parameters carries one
+severity = "warn"
+
+[violations.transfer_coding_unregistered]
+# Transfer coding is not one the deployment recognises
+severity = "warn"
 
 [violations.transfer_encoding_chunked_duplicated]
 # The chunked transfer coding is applied more than once

--- a/docs/rules/transfer_coding_registered.md
+++ b/docs/rules/transfer_coding_registered.md
@@ -25,11 +25,12 @@ Validate `Transfer-Encoding` and `TE` header values: transfer-coding names must 
 ## Specifications
 
 - [RFC 9112 §6.1](https://www.rfc-editor.org/rfc/rfc9112.html#section-6.1): Transfer-Encoding = #transfer-coding, and the 501 a recipient owes a coding it does not understand
-- [RFC 9112 §7](https://www.rfc-editor.org/rfc/rfc9112.html#section-7): Transfer codings: the names are case-insensitive and 'ought to be' registered — the whole of this rule's strength
+- [RFC 9112 §7](https://www.rfc-editor.org/rfc/rfc9112.html#section-7): Transfer Codings — names are case-insensitive and ought to be registered; §7.3 puts registration behind IETF Review, which is why an unrecognised name is a configuration question
 - [RFC 9112 §7.1](https://www.rfc-editor.org/rfc/rfc9112.html#section-7.1): Chunked, which likewise defines no parameters
-- [RFC 9112 §7.2](https://www.rfc-editor.org/rfc/rfc9112.html#section-7.2): The five compression codings, which define no parameters — §7.1 says the same of chunked
-- [RFC 9112 §7.4](https://www.rfc-editor.org/rfc/rfc9112.html#section-7.4): Negotiating transfer codings: chunked is forbidden in TE, an empty TE is conforming, and the q is a rank
+- [RFC 9112 §7.2](https://www.rfc-editor.org/rfc/rfc9112.html#section-7.2): The compression transfer codings, and the sentence saying they define no parameters and that a parameter's presence SHOULD be treated as an error
+- [RFC 9112 §7.4](https://www.rfc-editor.org/rfc/rfc9112.html#section-7.4): TE — the codings a client will accept, the `q` pseudo-parameter that ranks them, and the MUST NOT on naming `chunked`
 - [RFC 9110 §10.1.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.4): TE, and the grammar both fields share — including the quoted-string a transfer-parameter may carry
+- [RFC 9110 §5.6.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4): `quoted-string = DQUOTE *( qdtext / quoted-pair ) DQUOTE` — the two delimiters, the class between them, and the backslash escape
 - [IANA HTTP Parameters](https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#transfer-coding): The registry this rule is named after and does not read: names are checked against the configured 'allowed' list instead
 - [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 

--- a/lint-http-rules/src/rules/transfer_coding_registered.rs
+++ b/lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -4,9 +4,14 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::quoted_string::{QUOTED_STRING_DELIMITER_MISSING, RFC_9110_5_6_4};
+use crate::violations::te::{RFC_9112_7_4, TE_CHUNKED_FORBIDDEN};
 use crate::violations::token::{
     token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN, TOKEN_EMPTY,
     TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+};
+use crate::violations::transfer_coding::{
+    RFC_9112_7, RFC_9112_7_2, TRANSFER_CODING_PARAMETER_FORBIDDEN, TRANSFER_CODING_UNREGISTERED,
 };
 use crate::violations::ViolationDef;
 
@@ -42,6 +47,10 @@ static DECLARED: &[&ViolationDef] = &[
     &TOKEN_EMPTY,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
     &TOKEN_CHARACTER_FORBIDDEN,
+    &QUOTED_STRING_DELIMITER_MISSING,
+    &TE_CHUNKED_FORBIDDEN,
+    &TRANSFER_CODING_PARAMETER_FORBIDDEN,
+    &TRANSFER_CODING_UNREGISTERED,
 ];
 
 /// The specification references this rule declares, each named so a finding
@@ -53,30 +62,11 @@ const RFC_9112_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
     url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.1",
     note: "Transfer-Encoding = #transfer-coding, and the 501 a recipient owes a coding it does not understand",
 };
-const RFC_9112_7: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9112",
-    section: Some("7"),
-    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7",
-    note: "Transfer codings: the names are case-insensitive and 'ought to be' registered — the whole of this rule's strength",
-};
 const RFC_9112_7_1: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9112",
     section: Some("7.1"),
     url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.1",
     note: "Chunked, which likewise defines no parameters",
-};
-const RFC_9112_7_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9112",
-    section: Some("7.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.2",
-    note:
-        "The five compression codings, which define no parameters — §7.1 says the same of chunked",
-};
-const RFC_9112_7_4: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9112",
-    section: Some("7.4"),
-    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.4",
-    note: "Negotiating transfer codings: chunked is forbidden in TE, an empty TE is conforming, and the q is a rank",
 };
 const RFC_9110_10_1_4: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
@@ -141,6 +131,7 @@ allowed = ["chunked", "compress", "gzip", "deflate"]
             RFC_9112_7_2,
             RFC_9112_7_4,
             RFC_9110_10_1_4,
+            RFC_9110_5_6_4,
             IANA_HTTP_PARAMETERS,
             RFC_9110_5_6_2,
         ]
@@ -220,10 +211,9 @@ impl Rule for TransferCodingRegistered {
                 // owns the field's syntax and will report it; for
                 // `Transfer-Encoding` no such rule exists, and silence here would
                 // be the whole of the answer.
-                // cite(RFC 9110 § 5.6.4): "quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE"
                 if !crate::helpers::list::quoting_is_balanced(val) {
-                    return Some(TransferCodingRegistered.violation(
-                        ctx.severity,
+                    return Some(ctx.report_with(
+                        &QUOTED_STRING_DELIMITER_MISSING,
                         format!(
                             "Unterminated quoted-string in {} header: '{}'",
                             hdr_name, val
@@ -312,28 +302,18 @@ impl Rule for TransferCodingRegistered {
                     // a reason the second half of the sentence gives: a client
                     // cannot decline it, so naming it says nothing. This is the one
                     // place where a name being *recognized* is not enough.
-                    // cite(RFC 9112 § 7.4): "A client MUST NOT send the chunked transfer coding name in TE; chunked is always acceptable for HTTP/1.1 recipients."
                     //
                     // Case-insensitively, like every other name comparison here.
                     // cite(RFC 9112 § 7): "All transfer-coding names are case-insensitive and ought to be registered within the HTTP Transfer Coding registry, as defined in Section 7.3."
                     if hdr_name.eq_ignore_ascii_case("TE") && token.eq_ignore_ascii_case("chunked")
                     {
-                        return Some(
-                            TransferCodingRegistered.violation(
-                                ctx.severity,
-                                "A client must not send the chunked transfer coding name in TE; \
-                                 chunked is always acceptable for HTTP/1.1 recipients"
-                                    .into(),
-                            ),
-                        );
+                        return Some(ctx.report(&TE_CHUNKED_FORBIDDEN));
                     }
                     // § 7.2 defines exactly these five names by reference to the
                     // content codings of the same name, and then says outright what
                     // follows for their parameters. The rule stripped everything
                     // from the first `;` onward and never looked, so
                     // `Transfer-Encoding: gzip;level=9` passed as an ordinary gzip.
-                    // cite(RFC 9112 § 7.2): "The compression codings do not define any parameters."
-                    // cite(RFC 9112 § 7.2): "The presence of parameters with any of these compression codings SHOULD be treated as an error."
                     //
                     // `chunked` says the same thing about itself, in its own
                     // section and in two sentences rather than one. An earlier pass
@@ -374,8 +354,8 @@ impl Rule for TransferCodingRegistered {
                             {
                                 continue;
                             }
-                            return Some(TransferCodingRegistered.violation(
-                                ctx.severity,
+                            return Some(ctx.report_with(
+                                &TRANSFER_CODING_PARAMETER_FORBIDDEN,
                                 format!(
                                     "Transfer-coding '{}' defines no parameters, but '{}' is \
                                      present in the {} header",
@@ -403,8 +383,8 @@ impl Rule for TransferCodingRegistered {
                     // is the same sentence the config parser folds by.
                     // cite(RFC 9112 § 7): "All transfer-coding names are case-insensitive and ought to be registered within the HTTP Transfer Coding registry, as defined in Section 7.3."
                     if !allowed.contains(&token.to_ascii_lowercase()) {
-                        return Some(TransferCodingRegistered.violation(
-                            ctx.severity,
+                        return Some(ctx.report_with(
+                            &TRANSFER_CODING_UNREGISTERED,
                             format!(
                                 "Unrecognized transfer-coding '{}' in {} header",
                                 token, hdr_name
@@ -1267,13 +1247,16 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
         );
-        assert!(v.is_some());
-        let v = v.unwrap();
-        assert_eq!(v.severity, crate::lint::Severity::Error);
+        let v = v.expect("a finding");
+        assert_eq!(v.violation, "transfer_coding_unregistered");
         assert_eq!(
             v.message,
             "Unrecognized transfer-coding 'x-foo' in Transfer-Encoding header"
         );
+        // The rule's `severity = "error"` above no longer reaches a converted
+        // finding: the entry's own default is what arrives, and an operator
+        // raising it says so under the violation id.
+        assert_eq!(v.severity, crate::lint::Severity::Warn);
         Ok(())
     }
 

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -59,6 +59,7 @@ pub mod qvalue;
 pub mod te;
 pub mod token;
 pub mod token68;
+pub mod transfer_coding;
 pub mod transfer_encoding;
 pub mod uri;
 
@@ -381,7 +382,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 136;
+        const FLOOR: usize = 139;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/te.rs
+++ b/lint-http-rules/src/violations/te.rs
@@ -15,6 +15,13 @@
 //! and it exists only on those versions: over HTTP/1.1 a `TE: gzip` is an
 //! ordinary well-formed value.
 //!
+//! **A second entry arrived from a different direction**: RFC 9112 § 7.4
+//! forbids a client from naming `chunked` here, on every version, because
+//! chunked is not something a recipient may decline. Both entries are about
+//! what this field may say rather than about the productions it says it in —
+//! which is what makes them the field's and not
+//! [`transfer_coding`](crate::violations::transfer_coding)'s.
+//!
 //! **The subject is the field, and only the part of it those two documents
 //! narrow.** Whether a member derives from `t-codings` at all — its `token`, its
 //! `weight`, its `transfer-parameter` — is `te_header_valid`'s reading and is
@@ -28,7 +35,17 @@
 // cite(RFC 9114 § 4.2, label: the TE exception): "The only exception to this is the TE header field, which MAY be present in an HTTP/3 request header; when it is, it MUST NOT contain any value other than "trailers"."
 
 use crate::lint::Severity;
+use crate::rules::SpecRef;
 use crate::violations::defects;
+
+/// The field's own section in RFC 9112: what it is for, the ranking `q` it
+/// admits, and the one coding name it may not carry.
+pub const RFC_9112_7_4: SpecRef = SpecRef {
+    spec: "RFC 9112",
+    section: Some("7.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.4",
+    note: "TE — the codings a client will accept, the `q` pseudo-parameter that ranks them, and the MUST NOT on naming `chunked`",
+};
 
 defects! {
     /// A member of a request's `TE` that is not `trailers`, on a version whose
@@ -56,6 +73,26 @@ defects! {
         message: "",
         default_severity: Severity::Error,
         spec: None,
+    }
+
+    /// `chunked` named in a `TE`. The name is a real transfer coding and is
+    /// ordinary in `Transfer-Encoding`; what makes it wrong here is that the
+    /// field states what a client is *willing* to accept, and chunked is not
+    /// something a client may decline — so naming it states nothing and
+    /// occupies a list a recipient reads for preferences.
+    ///
+    /// The entry is the field's rather than the coding's, which is the line
+    /// [`crate::violations::transfer_coding`] draws: a coding that defines no
+    /// parameters defines none in either field, but this word is admissible in
+    /// one field and forbidden in the other.
+    ///
+    // cite(RFC 9112 § 7.4): "A client MUST NOT send the chunked transfer coding name in TE; chunked is always acceptable for HTTP/1.1 recipients."
+    TE_CHUNKED_FORBIDDEN = {
+        id: "te_chunked_forbidden",
+        title: "TE names the chunked coding, which cannot be declined",
+        message: "A client must not send the chunked transfer coding name in TE; chunked is always acceptable for HTTP/1.1 recipients",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9112_7_4),
     }
 }
 

--- a/lint-http-rules/src/violations/transfer_coding.rs
+++ b/lint-http-rules/src/violations/transfer_coding.rs
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `transfer-coding` defects — the name of a transformation applied to a
+//! message, and what may be hung off it.
+//!
+//! The production is `token *( OWS ";" OWS transfer-parameter )`, read from two
+//! fields: `Transfer-Encoding`, which states what a sender applied, and `TE`,
+//! which states what a client will accept. Its name half is a `token` and its
+//! parameters are `parameter`s, so a mangled octet or a missing `=` answers
+//! under those subjects — what is left here is which names exist and which of
+//! them may carry anything at all.
+//!
+//! **The mirror of [`content_coding`](crate::violations::content_coding), with
+//! one asymmetry worth keeping in view.** There the two fields differ in
+//! *vocabulary* — `*` and `identity` are words one field has and the other does
+//! not — so the entries live on the production. Here the two fields differ in
+//! what they may say about a name they both have: `chunked` is a real transfer
+//! coding, perfectly ordinary in `Transfer-Encoding`, and forbidden in `TE`
+//! because a client cannot decline it. **That is a defect of the field and not
+//! of the coding**, so it lives in [`crate::violations::te`] and not here.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// Where the coding names are registered, and the sentence making them
+/// case-insensitive and asking that they be registered at all.
+pub const RFC_9112_7: SpecRef = SpecRef {
+    spec: "RFC 9112",
+    section: Some("7"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7",
+    note: "Transfer Codings — names are case-insensitive and ought to be registered; §7.3 puts registration behind IETF Review, which is why an unrecognised name is a configuration question",
+};
+
+/// The compression codings, defined by the algorithm of the content coding of
+/// the same name — and defining no parameters of their own.
+pub const RFC_9112_7_2: SpecRef = SpecRef {
+    spec: "RFC 9112",
+    section: Some("7.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.2",
+    note: "The compression transfer codings, and the sentence saying they define no parameters and that a parameter's presence SHOULD be treated as an error",
+};
+
+defects! {
+    /// A parameter hung off a coding that defines none. § 7.2 says so of the
+    /// five compression codings in one sentence and § 7.1 says it of `chunked`
+    /// in two, so the six that this crate can check are covered; a coding an
+    /// operator adds to the allowed list answers to whatever registered it.
+    ///
+    /// The exception is `TE`'s `q`, and it is an exception of the *grammar*
+    /// rather than a tolerance: § 10.1.4 puts the `weight` outside
+    /// `transfer-coding` and § 7.3 calls it a pseudo-parameter, so `q` there is
+    /// not a parameter of the coding at all. `Transfer-Encoding` has no weight
+    /// in its grammar, so a `q` written there is an ordinary parameter and is
+    /// reported like any other.
+    ///
+    // cite(RFC 9112 § 7.2): "The compression codings do not define any parameters."
+    // cite(RFC 9112 § 7.2): "The presence of parameters with any of these compression codings SHOULD be treated as an error."
+    TRANSFER_CODING_PARAMETER_FORBIDDEN = {
+        id: "transfer_coding_parameter_forbidden",
+        title: "A coding that defines no parameters carries one",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9112_7_2),
+    }
+
+    /// A coding name the deployment does not recognise — the fifth registry
+    /// entry of the catalogue, and the one whose sentence is weakest: § 7 says
+    /// names *ought to* be registered, which is neither a MUST nor a SHOULD.
+    ///
+    /// What gives the finding its point is not disobedience but consequence: a
+    /// recipient meeting a coding it does not understand cannot frame or decode
+    /// the message, and § 6.1 tells a server to answer `501 (Not Implemented)`.
+    /// The comparison is against the operator's `allowed` list, matched
+    /// case-insensitively, and never against the registry — § 7.3 puts
+    /// registration behind IETF Review, which no linter stands in for.
+    ///
+    // cite(RFC 9112 § 7, label: transfer-coding names): "All transfer-coding names are case-insensitive and ought to be registered within the HTTP Transfer Coding registry, as defined in Section 7.3."
+    TRANSFER_CODING_UNREGISTERED = {
+        id: "transfer_coding_unregistered",
+        title: "Transfer coding is not one the deployment recognises",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9112_7),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Neither entry is spelled for a field: both `Transfer-Encoding` and `TE`
+    /// carry this production, and a coding that defines no parameters defines
+    /// none in either of them. The entry that *is* field-specific is `TE`'s,
+    /// and it is deliberately in another file.
+    #[test]
+    fn no_entry_here_is_spelled_for_one_of_the_two_fields() {
+        for def in [
+            &TRANSFER_CODING_PARAMETER_FORBIDDEN,
+            &TRANSFER_CODING_UNREGISTERED,
+        ] {
+            assert!(def.id.starts_with("transfer_coding_"), "{}", def.id);
+            assert!(!def.id.contains("_te_"), "{}", def.id);
+            assert!(!def.id.contains("encoding"), "{}", def.id);
+        }
+    }
+}

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -5423,7 +5423,7 @@ sources:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 187
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 260
+      line: 250
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
       line: 166
   - label: compression_and_transfer_encoding_consistent (2)
@@ -5433,7 +5433,7 @@ sources:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 188
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 241
+      line: 231
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
       line: 148
   - label: compression_and_transfer_encoding_consistent (3)
@@ -6547,7 +6547,7 @@ sources:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
       line: 16
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 246
+      line: 236
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
       line: 150
   - label: lint-http-rules/src/helpers/accept_ranges.rs (5)
@@ -6991,7 +6991,7 @@ sources:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 210
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 431
+      line: 411
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 5.3
     snippet: Since it cannot be combined into a single field value, recipients ought to handle "Set-Cookie" as a special case while processing fields.
@@ -7137,7 +7137,7 @@ sources:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 609
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 261
+      line: 251
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
       line: 167
     - file: lint-http-rules/src/rules/x_forwarded_consistent.rs
@@ -7241,9 +7241,7 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 328
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 223
-    - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 443
+      line: 423
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
       line: 130
     - file: lint-http-rules/src/violations/quoted_string.rs
@@ -7477,7 +7475,7 @@ sources:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 102
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 444
+      line: 424
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
       line: 654
     - file: lint-http-rules/src/violations/quoted_string.rs
@@ -7525,7 +7523,7 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 254
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 286
+      line: 276
     - file: lint-http-rules/src/rules/via_header_syntax.rs
       line: 292
     - file: lint-http-rules/src/violations/token.rs
@@ -9001,7 +8999,7 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 43
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 479
+      line: 459
   - label: te_header_valid (3)
     section: § 5.6.3
     snippet: The BWS rule is used where the grammar allows optional whitespace only for historical reasons.  A sender MUST NOT generate BWS in messages.  A recipient MUST parse for such bad whitespace and remove it before interpreting the protocol element.
@@ -9117,7 +9115,7 @@ sources:
     snippet: 'TE                 = #t-codings t-codings          = "trailers" / ( transfer-coding [ weight ] ) transfer-coding    = token *( OWS ";" OWS transfer-parameter ) transfer-parameter = token BWS "=" BWS ( token / quoted-string )'
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 370
+      line: 350
   - label: upgrade_and_connection_consistent
     section: § 7.6.1
     snippet: In contrast, a connection-specific field received without a corresponding connection option usually indicates that the field has been improperly forwarded by an intermediary and ought to be ignored by the recipient.
@@ -9734,21 +9732,23 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 218
-  - label: compression_and_transfer_encoding_consistent (2)
+  - label: transfer-coding names
     section: § 7
     snippet: All transfer-coding names are case-insensitive and ought to be registered within the HTTP Transfer Coding registry, as defined in Section 7.3.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 197
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 115
+      line: 105
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 318
+      line: 307
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 404
+      line: 384
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
       line: 172
-  - label: compression_and_transfer_encoding_consistent (3)
+    - file: lint-http-rules/src/violations/transfer_coding.rs
+      line: 80
+  - label: compression_and_transfer_encoding_consistent (2)
     section: § 7.2
     snippet: 'The following transfer coding names for compression are defined by the same algorithm as their corresponding content coding:'
     cited_by:
@@ -10196,6 +10196,12 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
       line: 158
+  - label: te
+    section: § 7.4
+    snippet: A client MUST NOT send the chunked transfer coding name in TE; chunked is always acceptable for HTTP/1.1 recipients.
+    cited_by:
+    - file: lint-http-rules/src/violations/te.rs
+      line: 89
   - label: te_header_valid
     section: § 7.3
     snippet: The TE header field (Section 10.1.4 of [HTTP]) uses a pseudo-parameter named "q" as the rank value when multiple transfer codings are acceptable.
@@ -10209,7 +10215,7 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 60
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 478
+      line: 458
   - label: te_header_valid (3)
     section: § 7.4
     snippet: Since the TE header field only applies to the immediate connection, a sender of TE MUST also send a "TE" connection option within the Connection header field (Section 7.6.1 of [HTTP]) in order to prevent the TE header field from being forwarded by intermediaries that do not support its semantics.
@@ -10223,61 +10229,55 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 282
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 371
+      line: 351
+  - label: transfer_coding
+    section: § 7.2
+    snippet: The compression codings do not define any parameters.
+    cited_by:
+    - file: lint-http-rules/src/violations/transfer_coding.rs
+      line: 59
+  - label: transfer_coding (2)
+    section: § 7.2
+    snippet: The presence of parameters with any of these compression codings SHOULD be treated as an error.
+    cited_by:
+    - file: lint-http-rules/src/violations/transfer_coding.rs
+      line: 60
   - label: transfer_coding_registered
     section: § 6.1
     snippet: A server that receives a request message with a transfer coding it does not understand SHOULD respond with 501 (Not Implemented).
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 392
+      line: 372
   - label: transfer_coding_registered (2)
     section: § 6.1
     snippet: 'Transfer-Encoding = #transfer-coding'
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 454
+      line: 434
   - label: transfer_coding_registered (3)
     section: § 7.1
     snippet: The chunked coding does not define any parameters.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 344
+      line: 324
   - label: transfer_coding_registered (4)
     section: § 7.1
     snippet: Their presence SHOULD be treated as an error.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 345
+      line: 325
   - label: transfer_coding_registered (5)
-    section: § 7.2
-    snippet: The compression codings do not define any parameters.
-    cited_by:
-    - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 335
-  - label: transfer_coding_registered (6)
-    section: § 7.2
-    snippet: The presence of parameters with any of these compression codings SHOULD be treated as an error.
-    cited_by:
-    - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 336
-  - label: transfer_coding_registered (7)
     section: § 7.3
     snippet: The "HTTP Transfer Coding Registry" defines the namespace for transfer coding names.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 233
-  - label: transfer_coding_registered (8)
-    section: § 7.4
-    snippet: A client MUST NOT send the chunked transfer coding name in TE; chunked is always acceptable for HTTP/1.1 recipients.
-    cited_by:
-    - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 315
-  - label: transfer_coding_registered (9)
+      line: 223
+  - label: transfer_coding_registered (6)
     section: § 7.4
     snippet: The keyword "trailers" indicates that the sender will not discard trailer fields, as described in Section 6.5 of [HTTP].
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 270
+      line: 260
   - label: transfer_encoding
     section: § 6.1
     snippet: A sender MUST NOT apply the chunked transfer coding more than once to a message body (i.e., chunking an already chunked message is not allowed).
@@ -10544,7 +10544,7 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 173
     - file: lint-http-rules/src/violations/te.rs
-      line: 27
+      line: 34
 - label: RFC 9114
   url: https://www.rfc-editor.org/rfc/rfc9114.html
   fragments:
@@ -10869,7 +10869,7 @@ sources:
     snippet: The only exception to this is the TE header field, which MAY be present in an HTTP/3 request header; when it is, it MUST NOT contain any value other than "trailers".
     cited_by:
     - file: lint-http-rules/src/violations/te.rs
-      line: 28
+      line: 35
 - label: RFC 9218
   url: https://www.rfc-editor.org/rfc/rfc9218.html
   fragments:


### PR DESCRIPTION
The transfer-coding production gets its own subject for what is true in both fields that carry it — a parameter on a coding that defines none, and a name the deployment does not recognise — while chunked in TE stays with the field, since that word is ordinary in the sibling field and forbidden only here. The unterminated quoted-string borrows the id it always had.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
