### PR TITLE
An advertised protocol name gets two entries

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1055,6 +1055,14 @@ severity = "warn"
 enabled = true
 severity = "warn"
 
+[violations.alpn_protocol_name_length_invalid]
+# ALPN protocol name is longer than the vector that carries it
+severity = "warn"
+
+[violations.alpn_protocol_name_unregistered]
+# ALPN protocol name is not one this deployment serves
+severity = "warn"
+
 [violations.auth_scheme_character_forbidden]
 # Authentication scheme holds a character outside token
 severity = "warn"

--- a/lint-http-rules/src/rules/alt_svc_protocol_registered.rs
+++ b/lint-http-rules/src/rules/alt_svc_protocol_registered.rs
@@ -9,6 +9,18 @@ use crate::helpers::list::{
 use crate::helpers::shown::{describe_octet, shown_in_finding};
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::alpn::{
+    ALPN_PROTOCOL_NAME_LENGTH_INVALID, ALPN_PROTOCOL_NAME_UNREGISTERED, RFC_7301_3_1, RFC_7838_2,
+};
+use crate::violations::ViolationDef;
+
+/// Two entries, and the difference between them is whether the configuration
+/// is consulted: a name too long for its vector is named by nothing at all,
+/// and a name this deployment does not serve is named by nothing *here*.
+static DECLARED: &[&ViolationDef] = &[
+    &ALPN_PROTOCOL_NAME_LENGTH_INVALID,
+    &ALPN_PROTOCOL_NAME_UNREGISTERED,
+];
 
 /// The one alternative of the field's top production that names no alternative
 /// service, and so carries no protocol identifier for this rule to look up.
@@ -18,9 +30,9 @@ const CLEAR: &str = "clear";
 
 /// A `ProtocolName` is a TLS vector with a one-octet length prefix, so
 /// `2^8 - 1` is how many octets one can hold. A name longer than that is not
-/// one a ClientHello or a ServerHello can express, whatever else it is.
-// cite(RFC 7301 § 3.1): "opaque ProtocolName<1..2^8-1>;"
-// cite(RFC 7301 § 3.1): ""ProtocolNameList" contains the list of protocols advertised by the client, in descending order of preference."
+/// one a ClientHello or a ServerHello can express, whatever else it is — the
+/// vector is quoted on `alpn_protocol_name_length_invalid`, which is the
+/// finding this number produces.
 const MAX_ALPN_PROTOCOL_NAME_OCTETS: usize = 255;
 
 /// What the rule reads out of its configuration.
@@ -195,23 +207,11 @@ pub struct AltSvcProtocolRegistered;
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_7838_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 7838",
-    section: Some("2"),
-    url: "https://www.rfc-editor.org/rfc/rfc7838.html#section-2",
-    note: "Alternative Services Concepts: an alternative service is identified by an ALPN protocol name as per RFC 7301, a host and a port; §2.4 requires a client to treat a connection that does not negotiate the expected protocol as failed",
-};
 const RFC_7838_3: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 7838",
     section: Some("3"),
     url: "https://www.rfc-editor.org/rfc/rfc7838.html#section-3",
     note: "The Alt-Svc HTTP Header Field: `protocol-id = token ; percent-encoded ALPN protocol name`, the escaping table that is its round trip, and the `clear` keyword",
-};
-const RFC_7301_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 7301",
-    section: Some("3.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc7301.html#section-3.1",
-    note: "The Application-Layer Protocol Negotiation Extension: protocol names are IANA-registered opaque byte strings, carried in a `ProtocolName` vector of at most 255 octets; §3.2 is the fatal alert a server sends when nothing is in common",
 };
 const RFC_7301_6: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 7301",
@@ -303,6 +303,10 @@ allowed = ["h2", "h3", "h3-29", "h2c", "http/1.1"]
             RFC_9110_5_6_2,
             RFC_3986_2_1,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -424,8 +428,8 @@ impl Rule for AltSvcProtocolRegistered {
                 // on the wire, so no list has to be consulted to know it names
                 // nothing.
                 if name.len() > MAX_ALPN_PROTOCOL_NAME_OCTETS {
-                    return Some(self.violation(
-                        config.severity,
+                    return Some(ctx.report_with(
+                        &ALPN_PROTOCOL_NAME_LENGTH_INVALID,
                         format!(
                             "Alt-Svc protocol-id '{}' decodes to an ALPN protocol name of {} octets. A `ProtocolName` carries at most {}, so this alternative is named by something no ClientHello or ServerHello can express",
                             shown_in_finding(protocol_id),
@@ -444,7 +448,6 @@ impl Rule for AltSvcProtocolRegistered {
                 // deployment does not serve is an alternative every client will
                 // fail over to and away from.
                 // cite(RFC 7838 § 2): "An Application Layer Protocol Negotiation (ALPN) protocol name, as per [RFC7301]"
-                // cite(RFC 7838 § 2): "The ALPN protocol name is used to identify the application protocol or suite of protocols used by the alternative service."
                 // cite(RFC 7301 § 3.2): "In the event that the server supports no protocols that the client advertises, then the server SHALL respond with a fatal "no_application_protocol" alert."
                 // cite(RFC 7838 § 2.4): "If the connection to the alternative service does not negotiate the expected protocol (for example, ALPN fails to negotiate h2, or an Upgrade request to h2c is not accepted), the connection to the alternative service MUST be considered to have failed."
                 if !config
@@ -452,8 +455,8 @@ impl Rule for AltSvcProtocolRegistered {
                     .iter()
                     .any(|allowed| allowed.as_bytes() == name.as_slice())
                 {
-                    return Some(self.violation(
-                        config.severity,
+                    return Some(ctx.report_with(
+                        &ALPN_PROTOCOL_NAME_UNREGISTERED,
                         format!(
                             "Alt-Svc protocol-id '{}' names the ALPN protocol {}, which is not one this deployment lists as an alternative service it offers. A client taking this alternative negotiates that name in TLS and is required to treat the connection as failed when it is not the one selected",
                             shown_in_finding(protocol_id),

--- a/lint-http-rules/src/violations/alpn.rs
+++ b/lint-http-rules/src/violations/alpn.rs
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! ALPN protocol name defects — the octets that identify an application
+//! protocol during the TLS handshake, and what an HTTP field can say wrongly
+//! about them.
+//!
+//! The name is not an HTTP production at all: RFC 7301 defines it as a TLS
+//! vector of octets, and HTTP fields carry it in whatever spelling their own
+//! grammar allows — `Alt-Svc` writes a `protocol-id`, which is the name with
+//! every non-`tchar` octet percent-encoded, so `http/1.1` travels as
+//! `http%2F1.1`. **The entries here are about the name after that spelling is
+//! undone**; how it was spelled is the carrying field's grammar and answers
+//! under `token`, `uri` and the field's own rule.
+//!
+//! Which is why the length entry below can be stated at all: a limit measured
+//! in octets means nothing against an escaped form, where one octet may be
+//! three characters.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// Where the name is defined, and the vector that carries it.
+pub const RFC_7301_3_1: SpecRef = SpecRef {
+    spec: "RFC 7301",
+    section: Some("3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc7301.html#section-3.1",
+    note: "The Application-Layer Protocol Negotiation Extension: protocol names are IANA-registered opaque byte strings, carried in a `ProtocolName` vector of at most 255 octets; §3.2 is the fatal alert a server sends when nothing is in common",
+};
+
+/// What an alternative service's protocol identifier is *for*, and what a
+/// client does when the name it negotiated is not the one advertised.
+pub const RFC_7838_2: SpecRef = SpecRef {
+    spec: "RFC 7838",
+    section: Some("2"),
+    url: "https://www.rfc-editor.org/rfc/rfc7838.html#section-2",
+    note: "Alternative Services Concepts: an alternative service is identified by an ALPN protocol name as per RFC 7301, a host and a port; §2.4 requires a client to treat a connection that does not negotiate the expected protocol as failed",
+};
+
+defects! {
+    /// A name that cannot fit the vector carrying it. `ProtocolName` is length
+    /// prefixed with one octet, so 255 is the ceiling, and a longer name is not
+    /// something any ClientHello or ServerHello can express — the alternative
+    /// is identified by nothing.
+    ///
+    /// No list is consulted for this one, which makes it the only entry in the
+    /// subject that holds without configuration: it is arithmetic on the wire
+    /// format rather than a question about which names a deployment serves.
+    ///
+    // cite(RFC 7301 § 3.1): "opaque ProtocolName<1..2^8-1>;"
+    // cite(RFC 7301 § 3.1): ""ProtocolNameList" contains the list of protocols advertised by the client, in descending order of preference."
+    ALPN_PROTOCOL_NAME_LENGTH_INVALID = {
+        id: "alpn_protocol_name_length_invalid",
+        title: "ALPN protocol name is longer than the vector that carries it",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_7301_3_1),
+    }
+
+    /// A well-formed name that this deployment does not serve. The sixth
+    /// registry entry of the catalogue and the one whose list is *narrower*
+    /// than the registry on purpose: IANA's table is Expert Review and gains
+    /// entries between releases, while the useful question about an
+    /// advertisement is whether the alternative answers to that name here.
+    ///
+    /// The comparison is byte-exact, because an ALPN protocol name is its
+    /// precise octets — `H2` is not `h2` — which is the one place a registry
+    /// entry in this catalogue does *not* fold case.
+    ///
+    /// `warn`: an advertisement nobody can use costs a client one failed
+    /// connection and a fallback, which is a deployment defect rather than a
+    /// malformed message.
+    ///
+    // cite(RFC 7838 § 2): "The ALPN protocol name is used to identify the application protocol or suite of protocols used by the alternative service."
+    ALPN_PROTOCOL_NAME_UNREGISTERED = {
+        id: "alpn_protocol_name_unregistered",
+        title: "ALPN protocol name is not one this deployment serves",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_7838_2),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One entry needs configuration and the other does not, which is the whole
+    /// difference between them: 255 octets is a fact about the wire format, and
+    /// membership is a fact about a deployment.
+    #[test]
+    fn the_length_entry_is_the_one_that_needs_no_list() {
+        assert_eq!(ALPN_PROTOCOL_NAME_LENGTH_INVALID.spec, Some(RFC_7301_3_1));
+        assert_eq!(ALPN_PROTOCOL_NAME_UNREGISTERED.spec, Some(RFC_7838_2));
+        assert_eq!(
+            ALPN_PROTOCOL_NAME_LENGTH_INVALID.default_severity,
+            Severity::Warn
+        );
+    }
+}

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -29,6 +29,7 @@ use crate::rules::SpecRef;
 use linkme::distributed_slice;
 use std::sync::LazyLock;
 
+pub mod alpn;
 pub mod auth_scheme;
 pub mod base64;
 pub mod basic_credentials;
@@ -382,7 +383,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 139;
+        const FLOOR: usize = 141;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1242,7 +1242,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 171
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 138
+      line: 150
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
       line: 49
     - file: lint-http-rules/src/violations/uri.rs
@@ -3707,48 +3707,48 @@ sources:
 - label: RFC 7301
   url: https://www.rfc-editor.org/rfc/rfc7301.html
   fragments:
-  - label: alt_svc_protocol_registered
+  - label: alpn
     section: § 3.1
     snippet: '"ProtocolNameList" contains the list of protocols advertised by the client, in descending order of preference.'
     cited_by:
-    - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 23
-  - label: alt_svc_protocol_registered (2)
+    - file: lint-http-rules/src/violations/alpn.rs
+      line: 53
+  - label: alpn (2)
+    section: § 3.1
+    snippet: opaque ProtocolName<1..2^8-1>;
+    cited_by:
+    - file: lint-http-rules/src/violations/alpn.rs
+      line: 52
+  - label: alt_svc_protocol_registered
     section: § 3.1
     snippet: Protocols are named by IANA-registered, opaque, non-empty byte strings, as described further in Section 6 ("IANA Considerations") of this document.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 89
-  - label: alt_svc_protocol_registered (3)
-    section: § 3.1
-    snippet: opaque ProtocolName<1..2^8-1>;
-    cited_by:
-    - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 22
-  - label: alt_svc_protocol_registered (4)
+      line: 101
+  - label: alt_svc_protocol_registered (2)
     section: § 3.2
     snippet: In the event that the server supports no protocols that the client advertises, then the server SHALL respond with a fatal "no_application_protocol" alert.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 448
-  - label: alt_svc_protocol_registered (5)
+      line: 451
+  - label: alt_svc_protocol_registered (3)
     section: § 6
     snippet: 'Identification Sequence: The precise set of octet values that identifies the protocol.'
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 90
-  - label: alt_svc_protocol_registered (6)
+      line: 102
+  - label: alt_svc_protocol_registered (4)
     section: § 6
     snippet: This document establishes a registry for protocol identifiers entitled "Application-Layer Protocol Negotiation (ALPN) Protocol IDs" under the existing "Transport Layer Security (TLS) Extensions" heading.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 46
-  - label: alt_svc_protocol_registered (7)
+      line: 58
+  - label: alt_svc_protocol_registered (5)
     section: § 6
     snippet: This registry operates under the "Expert Review" policy as defined in [RFC5226].
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 47
+      line: 59
 - label: RFC 7303
   url: https://www.rfc-editor.org/rfc/rfc7303.html
   fragments:
@@ -3870,6 +3870,12 @@ sources:
 - label: RFC 7838
   url: https://www.rfc-editor.org/rfc/rfc7838.html
   fragments:
+  - label: alpn
+    section: § 2
+    snippet: The ALPN protocol name is used to identify the application protocol or suite of protocols used by the alternative service.
+    cited_by:
+    - file: lint-http-rules/src/violations/alpn.rs
+      line: 76
   - label: Alt-Svc grammar
     section: § 3
     snippet: Alt-Svc       = clear / 1#alt-value
@@ -3879,7 +3885,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 132
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 15
+      line: 27
   - label: alt_svc_h3_advertisement_valid
     section: § 3
     snippet: An HTTP(S) origin server can advertise the availability of alternative services to clients by adding an Alt-Svc header field to responses.
@@ -3889,7 +3895,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 667
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 328
+      line: 332
   - label: alt_svc_h3_advertisement_valid (2)
     section: § 3
     snippet: Each "alt-value" is followed by an OPTIONAL semicolon-separated list of additional parameters, each such "parameter" comprising a name and a value.
@@ -3917,7 +3923,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 505
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 368
+      line: 372
   - label: alt_svc_h3_advertisement_valid (5)
     section: § 3
     snippet: parameter     = token "=" ( token / quoted-string )
@@ -3959,7 +3965,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 684
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 349
+      line: 353
   - label: alt_svc_header_syntax (5)
     section: § 3
     snippet: Consequently, the octet representing the percent character "%" (hex 25) MUST be percent-encoded as well.
@@ -3991,7 +3997,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 165
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 137
+      line: 149
   - label: alt_svc_header_syntax (10)
     section: § 3
     snippet: The "alt-authority" component consists of an OPTIONAL uri-host ("host" in Section 3.2.2 of [RFC3986]), a colon (":"), and a port number.
@@ -4005,7 +4011,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 134
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 16
+      line: 28
   - label: alt_svc_header_syntax (12)
     section: § 3
     snippet: When using percent-encoding, uppercase hex digits MUST be used.
@@ -4031,7 +4037,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 146
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 389
+      line: 393
   - label: alt_svc_header_syntax (16)
     section: § 3
     snippet: alternative   = protocol-id "=" alt-authority
@@ -4039,7 +4045,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 498
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 400
+      line: 404
   - label: alt_svc_header_syntax (17)
     section: § 3
     snippet: protocol-id   = token ; percent-encoded ALPN protocol name
@@ -4047,7 +4053,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 499
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 135
+      line: 147
   - label: alt_svc_header_syntax (18)
     section: § 3.1
     snippet: Alternative services that are intended to be longer lived (such as those that are not specific to the client access network) can carry the "persist" parameter with a value "1" as a hint that the service is potentially useful beyond a network configuration change.
@@ -4077,25 +4083,19 @@ sources:
     snippet: An Application Layer Protocol Negotiation (ALPN) protocol name, as per [RFC7301]
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 446
+      line: 450
   - label: alt_svc_protocol_registered (2)
-    section: § 2
-    snippet: The ALPN protocol name is used to identify the application protocol or suite of protocols used by the alternative service.
-    cited_by:
-    - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 447
-  - label: alt_svc_protocol_registered (3)
     section: § 2.4
     snippet: If the connection to the alternative service does not negotiate the expected protocol (for example, ALPN fails to negotiate h2, or an Upgrade request to h2c is not accepted), the connection to the alternative service MUST be considered to have failed.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 449
-  - label: alt_svc_protocol_registered (4)
+      line: 452
+  - label: alt_svc_protocol_registered (3)
     section: § 3
     snippet: ALPN protocol names are octet sequences with no additional constraints on format.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 136
+      line: 148
 - label: RFC 8187
   url: https://www.rfc-editor.org/rfc/rfc8187.html
   fragments:
@@ -4440,7 +4440,7 @@ sources:
     snippet: 'For consistency amongst TLS registries, IANA has prepended "TLS" to the following registries:'
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 48
+      line: 60
 - label: RFC 8470
   url: https://www.rfc-editor.org/rfc/rfc8470.html
   fragments:
@@ -5271,7 +5271,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 668
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 329
+      line: 333
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 354
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
@@ -7513,7 +7513,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 500
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 407
+      line: 411
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
       line: 197
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
@@ -7631,7 +7631,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 701
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 359
+      line: 363
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 396
   - label: lint-http-rules/src/helpers/word.rs


### PR DESCRIPTION
The ALPN protocol name becomes a subject of its own, since it is not an HTTP production and the field carrying it spells it differently: a name longer than the vector that holds it, which needs no configuration to be wrong, and a name this deployment does not serve, which is the sixth registry entry and the one comparison in that family that keeps case.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
