### PR TITLE
A field name joins the line's own subject

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1339,6 +1339,10 @@ severity = "error"
 # A field is written on more lines than its definition allows
 severity = "warn"
 
+[violations.field_name_unregistered]
+# Field name is not one the deployment expects
+severity = "warn"
+
 [violations.http_date_malformed]
 # Timestamp derives from no HTTP-date format
 severity = "warn"

--- a/lint-http-rules/src/rules/extension_headers_registered.rs
+++ b/lint-http-rules/src/rules/extension_headers_registered.rs
@@ -4,18 +4,18 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::field::{FIELD_NAME_UNREGISTERED, RFC_9110_5_1};
+use crate::violations::ViolationDef;
+
+/// One entry, and it is the field line's own: the name on it is not one this
+/// deployment expects. Nothing about a value is read.
+static DECLARED: &[&ViolationDef] = &[&FIELD_NAME_UNREGISTERED];
 
 pub struct ExtensionHeadersRegistered;
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_9110_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("5.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.1",
-    note: "Field Names (case-insensitive, and registration is an \"ought to\"; the same paragraph makes a proxy forward what it does not recognize)",
-};
 const RFC_9110_6_5: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
     section: Some("6.5"),
@@ -87,6 +87,10 @@ allowed = ["host", "user-agent", "accept", "content-type", "acme-request-id"]
         "Reports field names this deployment has not listed in the rule's `allowed` array. All four field sections a transaction can carry are walked — the request and response header sections, and their trailer sections when the message framing carried one — and names are compared case-insensitively, which is what RFC 9110 §5.1 says a field name is.\n\n**The `allowed` array is the rule's only authority.** It does not consult the IANA HTTP Field Name Registry: a permanently registered field is reported exactly like a typo when the array omits it, and registering a name with IANA changes nothing about what this rule says. Neither is a finding a protocol error. RFC 9110 §5.1 asks only that field names \"ought to be\" registered — weaker than SHOULD — and the same paragraph requires a proxy to forward unrecognized header fields and tells other recipients they SHOULD ignore them. A finding means \"this deployment did not expect this field\", which is worth a look for typos, forgotten debug headers and injected fields, and is not a claim that the sender did anything wrong.\n\nBecause the array has to name every field the deployment sees, no useful list is deployment-independent and `config_example.toml` ships the rule disabled with an illustrative one. For a private field prefer a short name scoped to its use and no `X-` prefix: RFC 9110 §16.3.2.1 says field names ought not be prefixed with `X-`."
     }
 
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
+    }
+
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
             RFC_9110_5_1,
@@ -153,7 +157,7 @@ impl Rule for ExtensionHeadersRegistered {
             // which sections exist at all is the framing's answer, not this rule's.
             // cite(RFC 9110 § 6.5): "Fields (Section 5) that are located within a "trailer section" are referred to as "trailer fields""
             for (section, headers) in crate::helpers::headers::transaction_field_sections(tx) {
-                if let Some(v) = check_section(section, headers, config, ctx.severity) {
+                if let Some(v) = check_section(section, headers, config, ctx) {
                     return Some(v);
                 }
             }
@@ -179,7 +183,7 @@ fn check_section(
     section: &str,
     fields: &hyper::HeaderMap,
     config: &crate::helpers::rule_config::AllowedList,
-    severity: crate::lint::Severity,
+    ctx: &crate::rules::RuleContext<'_>,
 ) -> Option<Violation> {
     // `keys()` rather than `iter()`: what is being judged is the name, and a field
     // repeated across lines is one name that would otherwise be judged once per line.
@@ -196,9 +200,8 @@ fn check_section(
         {
             continue;
         }
-        // cite(RFC 9110 § 5.1): "Field names are case-insensitive and ought to be registered within the "Hypertext Transfer Protocol (HTTP) Field Name Registry""
-        return Some(ExtensionHeadersRegistered.violation(
-            severity,
+        return Some(ctx.report_with(
+            &FIELD_NAME_UNREGISTERED,
             format!(
                 "Field name '{}' in the {} is not in the 'allowed' list for '{}'. That list is the rule's only authority: add the name to it if this deployment expects the field",
                 name.as_str(),

--- a/lint-http-rules/src/violations/field.rs
+++ b/lint-http-rules/src/violations/field.rs
@@ -30,12 +30,22 @@
 //!
 //! The second entry is the same kind of claim about the same object: a field
 //! line that is there and should not be, because the version carrying it has no
-//! use for the hop-by-hop control the field states. Neither entry ever reads a
-//! value.
+//! use for the hop-by-hop control the field states. The third is the name on
+//! that line being one nobody here expects. **No entry in this subject ever
+//! reads a value** — which is what makes it a subject rather than a drawer.
 
 use crate::lint::Severity;
 use crate::rules::SpecRef;
 use crate::violations::defects;
+
+/// Where field names are defined: case-insensitive, and ought to be
+/// registered.
+pub const RFC_9110_5_1: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.1",
+    note: "Field Names (case-insensitive, and registration is an \"ought to\"; the same paragraph makes a proxy forward what it does not recognize)",
+};
 
 /// The MUST NOT, its exception, and the recombination that makes the exception
 /// the whole of the difference.
@@ -104,6 +114,32 @@ defects! {
         message: "",
         default_severity: Severity::Error,
         spec: None,
+    }
+
+    /// A field name the deployment does not expect. The seventh registry entry
+    /// of the catalogue and the widest: every other one asks about a name
+    /// inside a value, and this one asks about the name of the line itself.
+    ///
+    /// **The weakest reading in the family, and deliberately so.** § 5.1 says
+    /// names *ought to* be registered, and the same paragraph tells a proxy to
+    /// forward what it does not recognise and every other recipient to ignore
+    /// it — so an unknown field is the extension mechanism working, not a
+    /// message defect. What the finding buys is the inventory: a deployment
+    /// that has written down the fields it expects gets told when something
+    /// else appears, which is a question about that deployment and answerable
+    /// by nothing else here.
+    ///
+    /// `warn`, and the comparison folds no case at the reading end because it
+    /// cannot: every parser this crate reads through has already lowercased the
+    /// name, and HTTP/3 makes an uppercase one malformed outright.
+    ///
+    // cite(RFC 9110 § 5.1): "Field names are case-insensitive and ought to be registered within the "Hypertext Transfer Protocol (HTTP) Field Name Registry""
+    FIELD_NAME_UNREGISTERED = {
+        id: "field_name_unregistered",
+        title: "Field name is not one the deployment expects",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_5_1),
     }
 }
 

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -383,7 +383,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 141;
+        const FLOOR: usize = 142;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -6001,37 +6001,37 @@ sources:
     snippet: Most fields are designed with the expectation that a recipient can safely ignore (but forward downstream) any field not recognized
     cited_by:
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 177
+      line: 181
   - label: extension_headers_registered (2)
     section: § 16.3.2.1
     snippet: Field names ought not be prefixed with "X-"
     cited_by:
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 103
+      line: 107
   - label: extension_headers_registered (3)
     section: § 5.1
     snippet: A proxy MUST forward unrecognized header fields unless the field name is listed in the Connection header field
     cited_by:
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 175
+      line: 179
   - label: extension_headers_registered (4)
     section: § 5.1
     snippet: Field names are case-insensitive and ought to be registered within the "Hypertext Transfer Protocol (HTTP) Field Name Registry"
     cited_by:
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
       line: 69
-    - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 199
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
       line: 166
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
       line: 360
+    - file: lint-http-rules/src/violations/field.rs
+      line: 136
   - label: extension_headers_registered (5)
     section: § 5.1
     snippet: Other recipients SHOULD ignore unrecognized header and trailer fields
     cited_by:
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 176
+      line: 180
   - label: from_header_email_syntax
     section: § 10.1.2
     snippet: The address ought to be machine-usable, as defined by "mailbox" in Section 3.4 of [RFC5322]
@@ -6977,7 +6977,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 275
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 135
+      line: 139
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
       line: 116
   - label: lint-http-rules/src/helpers/headers.rs (2)
@@ -7039,7 +7039,7 @@ sources:
     - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
       line: 120
     - file: lint-http-rules/src/violations/field.rs
-      line: 67
+      line: 77
   - label: lint-http-rules/src/helpers/headers.rs (5)
     section: § 5.5
     snippet: A recipient SHOULD treat other allowed octets in field content (i.e., obs-text) as opaque data.
@@ -7157,7 +7157,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 276
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 154
+      line: 158
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
       line: 133
   - label: lint-http-rules/src/helpers/list.rs
@@ -10559,7 +10559,7 @@ sources:
     snippet: A request or response containing uppercase characters in field names MUST be treated as malformed
     cited_by:
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 191
+      line: 195
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
       line: 158
   - label: header_field_names_token_valid


### PR DESCRIPTION
An unexpected field name is a claim about the line rather than about any value, so it goes where the repeated line and the connection-specific one already live. It is the seventh registry entry and the weakest: the same paragraph that asks for registration tells every recipient to ignore what it does not know, so what the finding buys is the deployment's inventory.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
