### PR TITLE
A media type answers for its own shape

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1463,8 +1463,20 @@ severity = "warn"
 # Mailbox is followed by something else
 severity = "warn"
 
+[violations.media_type_empty]
+# Media type is written with nothing in it
+severity = "warn"
+
+[violations.media_type_malformed]
+# Media type is not a type/subtype pair
+severity = "warn"
+
 [violations.media_type_unregistered]
 # Media type is not one the deployment recognises
+severity = "warn"
+
+[violations.media_type_wildcard_forbidden]
+# A media range is written where one media type belongs
 severity = "warn"
 
 [violations.node_ipv4_address_malformed]

--- a/docs/rules/content_type_registered.md
+++ b/docs/rules/content_type_registered.md
@@ -16,7 +16,7 @@ Entries may be exact (`text/plain`), a type wildcard (`image/*`), `*/*`, or a st
 
 ## Specifications
 
-- [RFC 9110 §8.3.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1): `media-type` syntax, the case-insensitivity of its tokens, and the "ought to be registered with IANA" guidance that motivates this rule — guidance, not a requirement, and not something this rule verifies
+- [RFC 9110 §8.3.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1): Media Type: `media-type = type "/" subtype parameters`, both halves `token` and both case-insensitive, and the "ought to be registered with IANA" guidance — guidance rather than a requirement, and not something this crate verifies
 - [RFC 6838 §4.2.8](https://www.rfc-editor.org/rfc/rfc6838.html#section-4.2.8): Structured syntax suffixes — a suffix is appended to a base subtype after a `+`, which is what a `+json` allowlist entry matches
 - [IANA Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml): The registry this rule is named after but does not read; the configured `allowed` array stands in for it
 

--- a/docs/rules/content_type_valid.md
+++ b/docs/rules/content_type_valid.md
@@ -21,11 +21,11 @@ Check that a `Content-Type` header — in a request or a response — reads as a
 ## Specifications
 
 - [RFC 9110 §8.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3): Content-Type: `Content-Type = media-type`, and the paragraph naming duplicated field lines as an error whose recipient handling differs between implementations
-- [RFC 9110 §8.3.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1): Media Type: `media-type = type "/" subtype parameters`, both halves `token`, both case-insensitive
+- [RFC 9110 §8.3.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1): Media Type: `media-type = type "/" subtype parameters`, both halves `token` and both case-insensitive, and the "ought to be registered with IANA" guidance — guidance rather than a requirement, and not something this crate verifies
 - [RFC 9110 §5.6.6](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.6): Parameters — `parameters = *( OWS ";" OWS [ parameter ] )`, the `name=value` pair inside it with neither half optional, and the bracketing that leaves a trailing `;` conforming
 - [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 - [RFC 9110 §5.6.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4): `quoted-string = DQUOTE *( qdtext / quoted-pair ) DQUOTE` — the two delimiters, the class between them, and the backslash escape
-- [RFC 9110 §12.5.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.1): Accept: where `*` belongs — `media-range`, which names a set of media types. Cited to explain why a wildcard is reported in Content-Type, which carries a `media-type`
+- [RFC 9110 §12.5.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.1): Accept and its `media-range` — where the asterisk groups media types into ranges, which is the reason it names nothing in a Content-Type
 - [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): Field Order — a sender MUST NOT write multiple field lines of one name, in the headers or the trailers, unless at least one alternative of the field's definition allows the lines to be recombined as a comma-separated list
 
 ## Configuration

--- a/lint-http-rules/src/helpers/media_type.rs
+++ b/lint-http-rules/src/helpers/media_type.rs
@@ -29,6 +29,24 @@ pub struct ParsedMediaType<'a> {
     pub params: Option<&'a str>,
 }
 
+/// Why a value is not a `media-type` at all, as data rather than as prose.
+///
+/// Three shapes, and every caller but one treats all three the same way: the
+/// rules that *read* a media type use this reader as a gate and return `None`
+/// on any of them, because a value that is not a media type is
+/// `content_type_valid`'s finding and not theirs. That one caller is why the
+/// verdict is typed — the wording belongs where the field name is known, and
+/// the id belongs to the catalogue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MediaTypeError {
+    /// Nothing there once the field's own `OWS` comes off.
+    Empty,
+    /// No `/` at all, so there is no place where the type ends.
+    SlashMissing,
+    /// A `/` with nothing on one side of it.
+    PartEmpty,
+}
+
 /// Parse a Media Type string into type, subtype, and optional params.
 ///
 /// This does NOT fully validate the tokens (e.g. wildcards or invalid chars),
@@ -53,10 +71,10 @@ pub struct ParsedMediaType<'a> {
 ///
 // cite(RFC 9110 § 5.6.6): "parameters      = *( OWS ";" OWS [ parameter ] )"
 // cite(RFC 9110 § 5.5): "A field value does not include leading or trailing whitespace.  When a specific version of HTTP allows such whitespace to appear in a message, a field parsing implementation MUST exclude such whitespace prior to evaluating the field value."
-pub fn parse_media_type(val: &str) -> Result<ParsedMediaType<'_>, String> {
+pub fn parse_media_type(val: &str) -> Result<ParsedMediaType<'_>, MediaTypeError> {
     let trimmed = trim_ows(val);
     if trimmed.is_empty() {
-        return Err("Empty media-type".into());
+        return Err(MediaTypeError::Empty);
     }
 
     let mut parts = trimmed.splitn(2, ';');
@@ -69,10 +87,7 @@ pub fn parse_media_type(val: &str) -> Result<ParsedMediaType<'_>, String> {
 
     // cite(RFC 9110 § 8.3.1, label: media-type grammar): "media-type = type "/" subtype parameters"
     if !media.contains('/') {
-        return Err(format!(
-            "Invalid media-type '{}': missing '/' between type and subtype",
-            val
-        ));
+        return Err(MediaTypeError::SlashMissing);
     }
 
     let mut ts = media.splitn(2, '/');
@@ -80,10 +95,7 @@ pub fn parse_media_type(val: &str) -> Result<ParsedMediaType<'_>, String> {
     let subtype = ts.next().unwrap_or("");
 
     if type_.is_empty() || subtype.is_empty() {
-        return Err(format!(
-            "Invalid media-type '{}': empty type or subtype",
-            val
-        ));
+        return Err(MediaTypeError::PartEmpty);
     }
 
     Ok(ParsedMediaType {

--- a/lint-http-rules/src/rules/content_type_valid.rs
+++ b/lint-http-rules/src/rules/content_type_valid.rs
@@ -2,9 +2,14 @@
 //
 // SPDX-License-Identifier: ISC
 
+use crate::helpers::media_type::MediaTypeError;
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
 use crate::violations::field::{FIELD_LINE_DUPLICATED, RFC_9110_5_3};
+use crate::violations::media_type::{
+    media_type_error, MEDIA_TYPE_EMPTY, MEDIA_TYPE_MALFORMED, MEDIA_TYPE_WILDCARD_FORBIDDEN,
+    RFC_9110_12_5_1, RFC_9110_8_3_1,
+};
 use crate::violations::parameter::{
     PARAMETER_EQUALS_MISSING, PARAMETER_VALUE_EMPTY, RFC_9110_5_6_6,
 };
@@ -28,11 +33,11 @@ pub struct ContentTypeValid;
 /// joins a parameter's halves is § 5.6.6's. `Accept-Patch` declares the same
 /// nine, because `1#media-type` asks the same question of each of its members.
 ///
-/// The rule's own findings stay on the older API and are named here so the
-/// omission is a decision on the page: the duplicated field line, the wildcard,
-/// and the two shapes `parse_media_type` refuses — no `/` and an empty half.
-/// The first two are this field's own reading rather than a production's, and
-/// the last two belong to a `media-type` subject that nothing has written yet.
+/// What is left over is the pair itself, and it has a subject now: the two
+/// shapes `parse_media_type` refuses — no `/` and an empty half — and the
+/// wildcard, which is a `tchar` the grammar admits and a *range* where one
+/// media type belongs. Those three are `media_type`'s, and the duplicated field
+/// line is the `field` subject's, so this rule words none of its findings.
 ///
 /// One of the nine cannot be reached through a field line, and is declared
 /// because the mapping is exhaustive rather than because this rule can report
@@ -42,6 +47,9 @@ pub struct ContentTypeValid;
 /// reading of every body rather than to this list.
 static DECLARED: &[&ViolationDef] = &[
     &FIELD_LINE_DUPLICATED,
+    &MEDIA_TYPE_EMPTY,
+    &MEDIA_TYPE_MALFORMED,
+    &MEDIA_TYPE_WILDCARD_FORBIDDEN,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
     &TOKEN_CHARACTER_FORBIDDEN,
     &TOKEN_EMPTY,
@@ -61,18 +69,6 @@ const RFC_9110_8_3: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("8.3"),
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3",
     note: "Content-Type: `Content-Type = media-type`, and the paragraph naming duplicated field lines as an error whose recipient handling differs between implementations",
-};
-const RFC_9110_8_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("8.3.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1",
-    note: "Media Type: `media-type = type \"/\" subtype parameters`, both halves `token`, both case-insensitive",
-};
-const RFC_9110_12_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("12.5.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.1",
-    note: "Accept: where `*` belongs — `media-range`, which names a set of media types. Cited to explain why a wildcard is reported in Content-Type, which carries a `media-type`",
 };
 
 impl RuleMeta for ContentTypeValid {
@@ -287,13 +283,22 @@ fn check_content_type(
     // two "this is not a media-type at all" shapes: no "/", or an empty half.
     let parsed = match parse_media_type(val) {
         Ok(p) => p,
-        Err(msg) => {
-            let message = if msg == "Empty media-type" {
-                "Empty Content-Type header".into()
-            } else {
-                msg.replace("media-type", "Content-Type")
+        Err(defect) => {
+            // The wording is this rule's because the field name is: the reader
+            // answers about a `media-type` and this caller knows it was read
+            // out of a `Content-Type`. The id is the catalogue's, and the two
+            // structural verdicts share one — see `media_type_error`.
+            let message = match defect {
+                MediaTypeError::Empty => "Empty Content-Type header".into(),
+                MediaTypeError::SlashMissing => format!(
+                    "Invalid Content-Type '{}': missing '/' between type and subtype",
+                    val
+                ),
+                MediaTypeError::PartEmpty => {
+                    format!("Invalid Content-Type '{}': empty type or subtype", val)
+                }
             };
-            return Some(ContentTypeValid.violation(ctx.severity, message));
+            return Some(ctx.report_with(media_type_error(defect), message));
         }
     };
 
@@ -303,10 +308,9 @@ fn check_content_type(
     // representation, while the asterisk exists to name a *range* of them, and
     // ranges belong to the `media-range` production Accept uses. A wildcard
     // here identifies nothing, so the field says nothing.
-    // cite(RFC 9110 § 12.5.1): "The asterisk "*" character is used to group media types into ranges, with "*/*" indicating all media types and "type/*" indicating all subtypes of that type."
     if parsed.type_ == "*" || parsed.subtype == "*" {
-        return Some(ContentTypeValid.violation(
-            ctx.severity,
+        return Some(ctx.report_with(
+            &MEDIA_TYPE_WILDCARD_FORBIDDEN,
             format!(
                 "Content-Type '{}' uses a wildcard, which names a set of media types rather than one; a representation's Content-Type is expected to identify a single media type (wildcards belong to Accept's media-range)",
                 val

--- a/lint-http-rules/src/violations/media_type.rs
+++ b/lint-http-rules/src/violations/media_type.rs
@@ -5,24 +5,28 @@
 //! `media-type` defects — what a type/subtype pair can be wrong about once it
 //! is well formed.
 //!
-//! The grammar half of this production is already spoken for and deliberately
-//! not here: a `media-type` is `type "/" subtype parameters`, all of it built
-//! from `token`, `parameter` and `quoted-string`, so a malformed one answers
-//! under those subjects wherever it is read — `Content-Type`, `Accept`,
-//! `Accept-Patch`, a multipart body's part. What is left over is the pair
-//! *itself*: two well-formed tokens naming something.
+//! Most of the grammar is spoken for elsewhere and deliberately not here: the
+//! halves of `type "/" subtype parameters` are built from `token`, `parameter`
+//! and `quoted-string`, so a mangled octet or a parameter with no `=` answers
+//! under those subjects wherever the value is read — `Content-Type`, `Accept`,
+//! `Accept-Patch`, a multipart body's part. **What is here is the pair
+//! itself**: the `/` that separates it, the two halves that must not be empty,
+//! and what the pair can be wrong about once both are well formed.
 //!
-//! Which is why the one entry below is a registry entry, and why it is the
-//! second of that shape after
-//! [`auth_scheme_unregistered`](crate::violations::auth_scheme::AUTH_SCHEME_UNREGISTERED).
-//! Both are an `ought to` addressed to whoever defines the name, measured
-//! against a list the operator wrote — and in both cases naming the id after
-//! the sentence rather than after the list is what keeps an operator's
-//! configuration meaningful when the list changes.
+//! Two of the four entries are about the pair failing to exist — nothing
+//! written, or nothing on one side of the `/` — and the other two are about a
+//! well-formed pair saying something it may not: a *range* where one type
+//! belongs, and a name the deployment does not expect. That last one is the
+//! second registry entry of the catalogue, after
+//! [`auth_scheme_unregistered`](crate::violations::auth_scheme::AUTH_SCHEME_UNREGISTERED):
+//! an `ought to` addressed to whoever defines the name, measured against a list
+//! the operator wrote, with the id naming the sentence rather than the list so
+//! that an operator's configuration survives the list changing.
 
+use crate::helpers::media_type::MediaTypeError;
 use crate::lint::Severity;
 use crate::rules::SpecRef;
-use crate::violations::defects;
+use crate::violations::{defects, ViolationDef};
 
 /// The production, the case-insensitivity of its two tokens, and the
 /// registration guidance the entry below carries.
@@ -30,10 +34,74 @@ pub const RFC_9110_8_3_1: SpecRef = SpecRef {
     spec: "RFC 9110",
     section: Some("8.3.1"),
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1",
-    note: "`media-type` syntax, the case-insensitivity of its tokens, and the \"ought to be registered with IANA\" guidance that motivates this rule — guidance, not a requirement, and not something this rule verifies",
+    note: "Media Type: `media-type = type \"/\" subtype parameters`, both halves `token` and both case-insensitive, and the \"ought to be registered with IANA\" guidance — guidance rather than a requirement, and not something this crate verifies",
+};
+
+/// The wider `media-range` the request side uses, where the asterisk means
+/// what it means.
+pub const RFC_9110_12_5_1: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("12.5.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.1",
+    note: "Accept and its `media-range` — where the asterisk groups media types into ranges, which is the reason it names nothing in a Content-Type",
 };
 
 defects! {
+    /// A field written with no media type on it at all, once the `OWS` its own
+    /// production prints comes off. The field states the media type of the
+    /// representation, so an empty one states none — and a recipient that has
+    /// to guess is exactly what the field exists to prevent.
+    ///
+    // cite(RFC 9110 § 8.3.1, label: media-type grammar): "media-type = type "/" subtype parameters"
+    MEDIA_TYPE_EMPTY = {
+        id: "media_type_empty",
+        title: "Media type is written with nothing in it",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_8_3_1),
+    }
+
+    /// A value that is not a `type "/" subtype` pair: no `/` anywhere, or a `/`
+    /// with nothing on one side of it. One id for both, because the two are the
+    /// same failure seen from either side of the separator — `text` names no
+    /// subtype and `text/` names no subtype either — and the message says which
+    /// was written.
+    ///
+    /// This is the entry every other reader of a media type *gates* on: a
+    /// dozen rules call the shared reader and return `None` here, because a
+    /// value that is not a media type cannot be asked whether it is registered,
+    /// whether its suffix is known, or what its charset says.
+    ///
+    // cite(RFC 9110 § 8.3.1, label: media-type grammar): "media-type = type "/" subtype parameters"
+    MEDIA_TYPE_MALFORMED = {
+        id: "media_type_malformed",
+        title: "Media type is not a type/subtype pair",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_8_3_1),
+    }
+
+    /// An asterisk in either half of a `Content-Type`. `*` is a `tchar`, so
+    /// `*/plain` derives from the production and nothing about the grammar
+    /// refuses it — what refuses it is that the field states *the* media type
+    /// of a representation while the asterisk exists to name a *range* of them.
+    ///
+    /// The same shape as
+    /// [`content_coding_wildcard_forbidden`](crate::violations::content_coding::CONTENT_CODING_WILDCARD_FORBIDDEN),
+    /// and for the same reason: a word that belongs to the field expressing
+    /// preferences, written in the field stating what was done. Both entries
+    /// quote the field that gives the word its meaning, because the field that
+    /// forbids it says nothing about it at all.
+    ///
+    // cite(RFC 9110 § 12.5.1): "The asterisk "*" character is used to group media types into ranges, with "*/*" indicating all media types and "type/*" indicating all subtypes of that type."
+    MEDIA_TYPE_WILDCARD_FORBIDDEN = {
+        id: "media_type_wildcard_forbidden",
+        title: "A media range is written where one media type belongs",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_12_5_1),
+    }
+
     /// A well-formed `type/subtype` that the deployment does not expect. The
     /// tokens parse, the pair is comparable, and a recipient still has nothing
     /// telling it what the bytes are.
@@ -60,15 +128,47 @@ defects! {
     }
 }
 
+/// The defect a [`MediaTypeError`] reports as.
+///
+/// Exhaustive, so a new way for the pair to fail does not compile until the
+/// catalogue names it — and two of the three collapse deliberately, which is
+/// the kind of decision that belongs on the page rather than in a `match` arm
+/// nobody re-read.
+pub fn media_type_error(defect: MediaTypeError) -> &'static ViolationDef {
+    match defect {
+        MediaTypeError::Empty => &MEDIA_TYPE_EMPTY,
+        MediaTypeError::SlashMissing | MediaTypeError::PartEmpty => &MEDIA_TYPE_MALFORMED,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// The entry carries the registration sentence and not the suffix one.
-    /// Before it existed, the finding cited RFC 6838 § 4.2.8 — the sentence
-    /// defining `+json` as a structured syntax suffix, which is how one
-    /// *allowlist entry* is matched and says nothing about whether a type is
-    /// registered.
+    /// Two of the reader's three verdicts share an id and the third does not,
+    /// which is the split written down: an empty field says nothing, and a
+    /// value with a `/` in the wrong place or missing says the wrong thing.
+    #[test]
+    fn the_readers_verdicts_collapse_where_the_defect_is_one() {
+        assert_eq!(
+            media_type_error(MediaTypeError::Empty).id,
+            "media_type_empty"
+        );
+        assert_eq!(
+            media_type_error(MediaTypeError::SlashMissing).id,
+            "media_type_malformed"
+        );
+        assert_eq!(
+            media_type_error(MediaTypeError::PartEmpty).id,
+            "media_type_malformed"
+        );
+    }
+
+    /// The registry entry carries the registration sentence and not the suffix
+    /// one. Before it existed, the finding cited RFC 6838 § 4.2.8 — the
+    /// sentence defining `+json` as a structured syntax suffix, which is how
+    /// one *allowlist entry* is matched and says nothing about whether a type
+    /// is registered.
     #[test]
     fn the_entry_quotes_the_registration_sentence() {
         assert_eq!(MEDIA_TYPE_UNREGISTERED.spec, Some(RFC_9110_8_3_1));

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -383,7 +383,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 142;
+        const FLOOR: usize = 145;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -4716,10 +4716,10 @@ sources:
       line: 239
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 252
-    - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 306
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 277
+    - file: lint-http-rules/src/violations/media_type.rs
+      line: 96
   - label: accept_and_content_type_negotiation (11)
     section: § 12.5.1
     snippet: The media-range can include media type parameters that are applicable to that range.
@@ -4747,7 +4747,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
       line: 161
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 218
+      line: 214
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 226
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
@@ -5401,7 +5401,7 @@ sources:
     - file: lint-http-rules/src/rules/charset_registered.rs
       line: 148
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 177
+      line: 173
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
       line: 142
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
@@ -5723,7 +5723,7 @@ sources:
     - file: lint-http-rules/src/rules/content_type_present.rs
       line: 179
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 216
+      line: 212
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 46
   - label: content_type_present (4)
@@ -5757,7 +5757,7 @@ sources:
     snippet: Although Content-Type is defined as a singleton field, it is sometimes incorrectly generated multiple times, resulting in a combined field value that appears to be a list.
     cited_by:
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 217
+      line: 213
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 225
   - label: context_fields_direction
@@ -7011,7 +7011,7 @@ sources:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
       line: 253
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 219
+      line: 215
     - file: lint-http-rules/src/rules/deprecation_header_syntax.rs
       line: 101
     - file: lint-http-rules/src/rules/etag_syntax.rs
@@ -7055,7 +7055,7 @@ sources:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
       line: 252
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 240
+      line: 236
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
       line: 260
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
@@ -7259,7 +7259,7 @@ sources:
     snippet: A field value does not include leading or trailing whitespace.  When a specific version of HTTP allows such whitespace to appear in a message, a field parsing implementation MUST exclude such whitespace prior to evaluating the field value.
     cited_by:
     - file: lint-http-rules/src/helpers/media_type.rs
-      line: 55
+      line: 73
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 209
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
@@ -7291,7 +7291,7 @@ sources:
     snippet: Parameter names are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/media_type.rs
-      line: 355
+      line: 367
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
       line: 251
     - file: lint-http-rules/src/rules/charset_registered.rs
@@ -7303,7 +7303,7 @@ sources:
     snippet: parameter-name  = token
     cited_by:
     - file: lint-http-rules/src/helpers/media_type.rs
-      line: 295
+      line: 307
     - file: lint-http-rules/src/helpers/parameter.rs
       line: 81
     - file: lint-http-rules/src/helpers/parameter.rs
@@ -7317,7 +7317,7 @@ sources:
     snippet: parameter-value = ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/helpers/media_type.rs
-      line: 308
+      line: 320
     - file: lint-http-rules/src/helpers/word.rs
       line: 26
     - file: lint-http-rules/src/rules/expect_header_valid.rs
@@ -7331,7 +7331,7 @@ sources:
     snippet: parameters      = *( OWS ";" OWS [ parameter ] )
     cited_by:
     - file: lint-http-rules/src/helpers/media_type.rs
-      line: 54
+      line: 72
     - file: lint-http-rules/src/helpers/parameter.rs
       line: 20
     - file: lint-http-rules/src/helpers/parameter.rs
@@ -7347,7 +7347,7 @@ sources:
     snippet: The type and subtype tokens are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/media_type.rs
-      line: 246
+      line: 258
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
       line: 299
     - file: lint-http-rules/src/rules/charset_present.rs
@@ -7373,7 +7373,7 @@ sources:
     snippet: The type/subtype MAY be followed by semicolon-delimited parameters (Section 5.6.6) in the form of name/value pairs.
     cited_by:
     - file: lint-http-rules/src/helpers/media_type.rs
-      line: 262
+      line: 274
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 88
   - label: media-type grammar
@@ -7381,17 +7381,21 @@ sources:
     snippet: media-type = type "/" subtype parameters
     cited_by:
     - file: lint-http-rules/src/helpers/media_type.rs
-      line: 70
+      line: 88
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
       line: 150
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
       line: 172
+    - file: lint-http-rules/src/violations/media_type.rs
+      line: 55
+    - file: lint-http-rules/src/violations/media_type.rs
+      line: 75
   - label: lint-http-rules/src/helpers/media_type.rs (7)
     section: § 8.3.1
     snippet: type       = token subtype    = token
     cited_by:
     - file: lint-http-rules/src/helpers/media_type.rs
-      line: 245
+      line: 257
   - label: lint-http-rules/src/helpers/parameter.rs
     section: § 5.6.6
     snippet: parameter       = parameter-name "=" parameter-value
@@ -7811,7 +7815,7 @@ sources:
     snippet: Media types ought to be registered with IANA according to the procedures defined in [BCP13].
     cited_by:
     - file: lint-http-rules/src/violations/media_type.rs
-      line: 53
+      line: 121
   - label: multipart_boundary_syntax
     section: § 5.6.6
     snippet: A parameter value that matches the token production can be transmitted either as a token or within a quoted-string.


### PR DESCRIPTION
The shared reader stops returning prose and returns a verdict, so the one caller that reports it keeps the wording while the catalogue keeps the id: nothing written, and a value that is not a type/subtype pair, which collapse to two entries because a missing slash and an empty half are the same failure from either side of it. The wildcard joins them as a range written where one media type belongs, mirroring the coding entry the Content-Encoding reading produced.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
