### PR TITLE
A delimiter is measured by its own document

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1095,6 +1095,22 @@ severity = "error"
 # Basic credentials hold no ':' separator
 severity = "warn"
 
+[violations.boundary_character_forbidden]
+# Boundary holds a character outside the delimiter set
+severity = "warn"
+
+[violations.boundary_length_invalid]
+# Boundary is empty or longer than seventy characters
+severity = "warn"
+
+[violations.boundary_missing]
+# A multipart media type carries no boundary parameter
+severity = "warn"
+
+[violations.boundary_trailing_space_forbidden]
+# Boundary ends with a space
+severity = "warn"
+
 [violations.bws_forbidden]
 # Whitespace written where the grammar admits BWS
 severity = "info"

--- a/lint-http-rules/src/rules/multipart_boundary_syntax.rs
+++ b/lint-http-rules/src/rules/multipart_boundary_syntax.rs
@@ -4,6 +4,10 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::boundary::{
+    BOUNDARY_CHARACTER_FORBIDDEN, BOUNDARY_LENGTH_INVALID, BOUNDARY_MISSING,
+    BOUNDARY_TRAILING_SPACE_FORBIDDEN, RFC_2046_5_1_1,
+};
 use crate::violations::parameter::{PARAMETER_VALUE_EMPTY, RFC_9110_5_6_6};
 use crate::violations::quoted_pair::QUOTED_PAIR_MALFORMED;
 use crate::violations::quoted_string::{
@@ -32,6 +36,10 @@ pub struct MultipartBoundarySyntax;
 /// all, and whether it is a boundary — and only the first has a subject
 /// written.
 static DECLARED: &[&ViolationDef] = &[
+    &BOUNDARY_MISSING,
+    &BOUNDARY_CHARACTER_FORBIDDEN,
+    &BOUNDARY_LENGTH_INVALID,
+    &BOUNDARY_TRAILING_SPACE_FORBIDDEN,
     &PARAMETER_VALUE_EMPTY,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
     &TOKEN_CHARACTER_FORBIDDEN,
@@ -44,12 +52,6 @@ static DECLARED: &[&ViolationDef] = &[
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_2046_5_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 2046",
-    section: Some("5.1.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc2046.html#section-5.1.1",
-    note: "Multipart common syntax: the required `boundary` parameter, the `boundary`/`bchars`/`bcharsnospace` grammar, the 1-to-70-character limit and the ban on a trailing space, and the warning that a boundary often has to be quoted",
-};
 const RFC_9110_8_3_3: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
     section: Some("8.3.3"),
@@ -353,8 +355,6 @@ fn check_multipart_boundary(
                     // case — a boundary is matched against the delimiter
                     // lines in the content literally, which is the case-
                     // sensitive end of what §5.6.6 leaves to each parameter.
-                    // cite(RFC 2046 § 5.1.1): "bchars := bcharsnospace / " ""
-                    // cite(RFC 2046 § 5.1.1): "bcharsnospace := DIGIT / ALPHA / "'" / "(" / ")" / "+" / "_" / "," / "-" / "." / "/" / ":" / "=" / "?""
                     // cite(RFC 9110 § 5.6.6): "Parameter values might or might not be case-sensitive, depending on the semantics of the parameter name."
                     for ch in boundary_unquoted.chars() {
                         if ch.is_ascii_alphanumeric()
@@ -376,8 +376,8 @@ fn check_multipart_boundary(
                         {
                             continue;
                         }
-                        return Some(MultipartBoundarySyntax.violation(
-                            ctx.severity,
+                        return Some(ctx.report_with(
+                            &BOUNDARY_CHARACTER_FORBIDDEN,
                             format!(
                                 "Invalid multipart Content-Type in {}: boundary contains invalid character '{}'",
                                 which, ch
@@ -391,11 +391,10 @@ fn check_multipart_boundary(
                     // what `boundary=""` leaves after unquoting, and the
                     // grammar has no empty alternative.
                     // cite(RFC 2046 § 5.1.1): "boundary := 0*69<bchars> bcharsnospace"
-                    // cite(RFC 2046 § 5.1.1): "The only mandatory global parameter for the "multipart" media type is the boundary parameter, which consists of 1 to 70 characters from a set of characters known to be very robust through mail gateways, and NOT ending with white space."
                     let len = boundary_unquoted.chars().count();
                     if len == 0 || len > 70 {
-                        return Some(MultipartBoundarySyntax.violation(
-                            ctx.severity,
+                        return Some(ctx.report_with(
+                            &BOUNDARY_LENGTH_INVALID,
                             format!(
                                 "Invalid multipart Content-Type in {}: 'boundary' must be between 1 and 70 characters",
                                 which
@@ -413,8 +412,8 @@ fn check_multipart_boundary(
                     // recipient cannot tell it from the delimiter's own.
                     // cite(RFC 2046 § 5.1.1): "boundary := 0*69<bchars> bcharsnospace"
                     if boundary_unquoted.ends_with(' ') {
-                        return Some(MultipartBoundarySyntax.violation(
-                            ctx.severity,
+                        return Some(ctx.report_with(
+                            &BOUNDARY_TRAILING_SPACE_FORBIDDEN,
                             format!(
                                 "Invalid multipart Content-Type in {}: 'boundary' must not end with whitespace",
                                 which
@@ -429,7 +428,6 @@ fn check_multipart_boundary(
         // default: without a boundary there is no delimiter line, so nothing in
         // the content can be told from anything else. RFC 2046 states it as a
         // requirement of the field and RFC 9110 repeats it for HTTP.
-        // cite(RFC 2046 § 5.1.1): "The Content-Type field for multipart entities requires one parameter, "boundary"."
         // cite(RFC 2046 § 5.1.1): "The boundary delimiter line is then defined as a line consisting entirely of two hyphen characters ("-", decimal value 45) followed by the boundary parameter value from the Content-Type header field, optional linear whitespace, and a terminating CRLF."
         //
         // Not reported when the quoting never closed, because then this is a
@@ -438,8 +436,8 @@ fn check_multipart_boundary(
         // what the broken quoting makes unknowable. An unreadable parameter
         // list is `content_type_valid`'s finding.
         if !found && !unreadable {
-            return Some(MultipartBoundarySyntax.violation(
-                ctx.severity,
+            return Some(ctx.report_with(
+                &BOUNDARY_MISSING,
                 format!(
                     "Invalid multipart Content-Type in {}: missing required 'boundary' parameter",
                     which

--- a/lint-http-rules/src/violations/boundary.rs
+++ b/lint-http-rules/src/violations/boundary.rs
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `boundary` defects — the delimiter that tells one body part from the next.
+//!
+//! The parameter is a `parameter` like any other, so a missing `=`, an empty
+//! value or a `quoted-string` that never closes answer under those subjects.
+//! What is here is the *value* against RFC 2046 § 5.1.1's own production, which
+//! is not an HTTP one and is deliberately narrower than `token`: `bchars` is a
+//! set chosen to survive mail gateways, and it admits SP everywhere but at the
+//! end.
+//!
+//! **The alphabet is not `token`'s and the two are incomparable**, which is why
+//! this subject exists rather than borrowing: `(`, `)`, `,`, `/`, `:`, `=`, `?`
+//! and SP are `bchars` and are not `tchar`s, while `!`, `#`, `$`, `&`, `*`,
+//! `^`, `` ` `` and `|` are `tchar`s and not `bchars`. A boundary written with
+//! either set alone would be reported by the wrong sentence.
+//!
+//! **Every entry here is about the delimiter working**, not about framing: HTTP
+//! does not use the boundary to find where the message ends (RFC 9110 § 8.3.3
+//! says so outright), so what a bad boundary costs is a recipient that cannot
+//! separate the parts it was handed.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// The multipart common syntax: the required parameter, its grammar, its
+/// length, and the trailing space that is not allowed to be there.
+pub const RFC_2046_5_1_1: SpecRef = SpecRef {
+    spec: "RFC 2046",
+    section: Some("5.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc2046.html#section-5.1.1",
+    note: "Multipart common syntax: the required `boundary` parameter, the `boundary`/`bchars`/`bcharsnospace` grammar, the 1-to-70-character limit and the ban on a trailing space, and the warning that a boundary often has to be quoted",
+};
+
+defects! {
+    /// A multipart media type with no `boundary` at all. Absence is the whole
+    /// defect and it is a requirement rather than a default: the delimiter line
+    /// is two hyphens followed by this value, so without it there is no line
+    /// that separates anything and the parts are indistinguishable from their
+    /// own content.
+    ///
+    // cite(RFC 2046 § 5.1.1): "The Content-Type field for multipart entities requires one parameter, "boundary"."
+    BOUNDARY_MISSING = {
+        id: "boundary_missing",
+        title: "A multipart media type carries no boundary parameter",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_2046_5_1_1),
+    }
+
+    /// A character the delimiter set does not hold. The set is small and
+    /// chosen, not an accident of the grammar: RFC 2046 picked characters
+    /// "known to be very robust through mail gateways", so an octet outside it
+    /// is one a gateway may rewrite — and a rewritten delimiter separates
+    /// nothing.
+    ///
+    // cite(RFC 2046 § 5.1.1, label: bchars with space): "bchars := bcharsnospace / " ""
+    // cite(RFC 2046 § 5.1.1, label: bcharsnospace): "bcharsnospace := DIGIT / ALPHA / "'" / "(" / ")" / "+" / "_" / "," / "-" / "." / "/" / ":" / "=" / "?""
+    BOUNDARY_CHARACTER_FORBIDDEN = {
+        id: "boundary_character_forbidden",
+        title: "Boundary holds a character outside the delimiter set",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_2046_5_1_1),
+    }
+
+    /// A boundary of no characters, or of more than seventy. The production
+    /// states the ceiling as `0*69<bchars>` followed by one more character and
+    /// the prose states it again in words, so both ends are the document's:
+    /// there is no empty alternative, and `boundary=""` reaches this entry
+    /// after the quotes come off.
+    ///
+    // cite(RFC 2046 § 5.1.1, label: boundary production): "boundary := 0*69<bchars> bcharsnospace"
+    // cite(RFC 2046 § 5.1.1): "The only mandatory global parameter for the "multipart" media type is the boundary parameter, which consists of 1 to 70 characters from a set of characters known to be very robust through mail gateways, and NOT ending with white space."
+    BOUNDARY_LENGTH_INVALID = {
+        id: "boundary_length_invalid",
+        title: "Boundary is empty or longer than seventy characters",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_2046_5_1_1),
+    }
+
+    /// A boundary whose last character is a space. SP is a `bchar` everywhere
+    /// else in the value, which is why this is its own entry rather than a case
+    /// of the alphabet: the production spells the exception into its shape by
+    /// ending on `bcharsnospace`.
+    ///
+    /// The reason is a recipient's rather than a sender's. A gateway may append
+    /// whitespace to a line, so a delimiter that legitimately ends in a space
+    /// cannot be told from one that was padded in transit — and the recipient
+    /// has to guess which of the two it is holding.
+    ///
+    // cite(RFC 2046 § 5.1.1, label: boundary production): "boundary := 0*69<bchars> bcharsnospace"
+    BOUNDARY_TRAILING_SPACE_FORBIDDEN = {
+        id: "boundary_trailing_space_forbidden",
+        title: "Boundary ends with a space",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_2046_5_1_1),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One document behind all four, and it is not an HTTP one — which is the
+    /// subject's reason for existing. A boundary borrowed `token`'s ids would
+    /// be measured against an alphabet that neither contains nor is contained
+    /// by the one its own document prints.
+    #[test]
+    fn every_entry_is_measured_against_the_multipart_document() {
+        for def in [
+            &BOUNDARY_MISSING,
+            &BOUNDARY_CHARACTER_FORBIDDEN,
+            &BOUNDARY_LENGTH_INVALID,
+            &BOUNDARY_TRAILING_SPACE_FORBIDDEN,
+        ] {
+            assert_eq!(def.spec, Some(RFC_2046_5_1_1), "{}", def.id);
+        }
+    }
+}

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -33,6 +33,7 @@ pub mod alpn;
 pub mod auth_scheme;
 pub mod base64;
 pub mod basic_credentials;
+pub mod boundary;
 pub mod bws;
 pub mod challenge;
 pub mod charset;
@@ -383,7 +384,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 145;
+        const FLOOR: usize = 149;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -894,60 +894,56 @@ sources:
 - label: RFC 2046
   url: https://www.rfc-editor.org/rfc/rfc2046.html
   fragments:
+  - label: boundary
+    section: § 5.1.1
+    snippet: The only mandatory global parameter for the "multipart" media type is the boundary parameter, which consists of 1 to 70 characters from a set of characters known to be very robust through mail gateways, and NOT ending with white space.
+    cited_by:
+    - file: lint-http-rules/src/violations/boundary.rs
+      line: 77
+  - label: bchars with space
+    section: § 5.1.1
+    snippet: bchars := bcharsnospace / " "
+    cited_by:
+    - file: lint-http-rules/src/violations/boundary.rs
+      line: 60
+  - label: bcharsnospace
+    section: § 5.1.1
+    snippet: bcharsnospace := DIGIT / ALPHA / "'" / "(" / ")" / "+" / "_" / "," / "-" / "." / "/" / ":" / "=" / "?"
+    cited_by:
+    - file: lint-http-rules/src/violations/boundary.rs
+      line: 61
   - label: multipart_boundary_syntax
     section: § 5.1.1
     snippet: All subtypes of "multipart" must use this syntax.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 240
+      line: 242
   - label: multipart_boundary_syntax (2)
-    section: § 5.1.1
-    snippet: The Content-Type field for multipart entities requires one parameter, "boundary".
-    cited_by:
-    - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 432
-    - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 121
-  - label: multipart_boundary_syntax (3)
     section: § 5.1.1
     snippet: The boundary delimiter line is then defined as a line consisting entirely of two hyphen characters ("-", decimal value 45) followed by the boundary parameter value from the Content-Type header field, optional linear whitespace, and a terminating CRLF.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 433
+      line: 431
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
       line: 222
-  - label: multipart_boundary_syntax (4)
+  - label: multipart_boundary_syntax (3)
     section: § 5.1.1
     snippet: The grammar for parameters on the Content-type field is such that it is often necessary to enclose the boundary parameter values in quotes on the Content-type line.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 305
-  - label: multipart_boundary_syntax (5)
-    section: § 5.1.1
-    snippet: The only mandatory global parameter for the "multipart" media type is the boundary parameter, which consists of 1 to 70 characters from a set of characters known to be very robust through mail gateways, and NOT ending with white space.
-    cited_by:
-    - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 394
-  - label: multipart_boundary_syntax (6)
-    section: § 5.1.1
-    snippet: bchars := bcharsnospace / " "
-    cited_by:
-    - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 356
-  - label: multipart_boundary_syntax (7)
-    section: § 5.1.1
-    snippet: bcharsnospace := DIGIT / ALPHA / "'" / "(" / ")" / "+" / "_" / "," / "-" / "." / "/" / ":" / "=" / "?"
-    cited_by:
-    - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 357
-  - label: multipart_boundary_syntax (8)
+      line: 307
+  - label: boundary production
     section: § 5.1.1
     snippet: boundary := 0*69<bchars> bcharsnospace
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
       line: 393
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 414
+      line: 413
+    - file: lint-http-rules/src/violations/boundary.rs
+      line: 76
+    - file: lint-http-rules/src/violations/boundary.rs
+      line: 96
   - label: multipart_content_type_and_body_consistent
     section: § 5.1.1
     snippet: An exact match of the entire candidate line is not required; it is sufficient that the boundary appear in its entirety following the CRLF.
@@ -970,35 +966,43 @@ sources:
       line: 348
   - label: multipart_content_type_and_body_consistent (4)
     section: § 5.1.1
+    snippet: The Content-Type field for multipart entities requires one parameter, "boundary".
+    cited_by:
+    - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
+      line: 121
+    - file: lint-http-rules/src/violations/boundary.rs
+      line: 45
+  - label: multipart_content_type_and_body_consistent (5)
+    section: § 5.1.1
     snippet: The boundary delimiter MUST occur at the beginning of a line, i.e., following a CRLF, and the initial CRLF is considered to be attached to the boundary delimiter line rather than part of the preceding part.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
       line: 242
-  - label: multipart_content_type_and_body_consistent (5)
+  - label: multipart_content_type_and_body_consistent (6)
     section: § 5.1.1
     snippet: The boundary delimiter line following the last body part is a distinguished delimiter that indicates that no further body parts will follow.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
       line: 334
-  - label: multipart_content_type_and_body_consistent (6)
+  - label: multipart_content_type_and_body_consistent (7)
     section: § 5.1.1
     snippet: The use of the "multipart" media type with only a single body part may be useful in certain contexts, and is explicitly permitted.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
       line: 335
-  - label: multipart_content_type_and_body_consistent (7)
+  - label: multipart_content_type_and_body_consistent (8)
     section: § 5.1.1
     snippet: close-delimiter := delimiter "--"
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
       line: 279
-  - label: multipart_content_type_and_body_consistent (8)
+  - label: multipart_content_type_and_body_consistent (9)
     section: § 5.1.1
     snippet: dash-boundary := "--" boundary
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
       line: 221
-  - label: multipart_content_type_and_body_consistent (9)
+  - label: multipart_content_type_and_body_consistent (10)
     section: § 5.1.1
     snippet: implementations must ignore anything that appears before the first boundary delimiter line or after the last one.
     cited_by:
@@ -5405,7 +5409,7 @@ sources:
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
       line: 142
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 158
+      line: 160
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
       line: 98
   - label: charset_registered (2)
@@ -7059,7 +7063,7 @@ sources:
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
       line: 260
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 189
+      line: 191
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
       line: 151
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
@@ -7297,7 +7301,7 @@ sources:
     - file: lint-http-rules/src/rules/charset_registered.rs
       line: 193
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 274
+      line: 276
   - label: lint-http-rules/src/helpers/media_type.rs (3)
     section: § 5.6.6
     snippet: parameter-name  = token
@@ -7341,7 +7345,7 @@ sources:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
       line: 500
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 264
+      line: 266
   - label: lint-http-rules/src/helpers/media_type.rs (5)
     section: § 8.3.1
     snippet: The type and subtype tokens are case-insensitive.
@@ -7359,7 +7363,7 @@ sources:
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
       line: 211
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 241
+      line: 243
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 44
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
@@ -7821,7 +7825,7 @@ sources:
     snippet: A parameter value that matches the token production can be transmitted either as a token or within a quoted-string.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 303
+      line: 305
   - label: multipart_boundary_syntax (2)
     section: § 5.6.6
     snippet: Parameter values might or might not be case-sensitive, depending on the semantics of the parameter name.
@@ -7833,13 +7837,13 @@ sources:
     snippet: The quoted and unquoted values are equivalent.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 304
+      line: 306
   - label: multipart_boundary_syntax (4)
     section: § 8.3.3
     snippet: All multipart types share a common syntax, as defined in Section 5.1.1 of [RFC2046], and include a boundary parameter as part of the media type value.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 239
+      line: 241
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
       line: 119
   - label: multipart_content_type_and_body_consistent


### PR DESCRIPTION
The multipart boundary gets a subject rather than borrowing the token ids: its alphabet is neither wider nor narrower than tchar but crosses it, so eight characters would be reported by the wrong sentence either way. Four entries — no parameter, a character outside the set, a length outside one to seventy, and the trailing space the production spells out by ending on the set without it.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
