### PR TITLE
A body keeps the promise its boundary made

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1495,6 +1495,18 @@ severity = "warn"
 # A media range is written where one media type belongs
 severity = "warn"
 
+[violations.multipart_body_delimiter_missing]
+# The body carries no delimiter line for its boundary
+severity = "warn"
+
+[violations.multipart_body_part_missing]
+# The only delimiter line is the terminating one
+severity = "warn"
+
+[violations.multipart_body_terminator_missing]
+# The body never closes its last part
+severity = "warn"
+
 [violations.node_ipv4_address_malformed]
 # Node identifier is digits and dots that are not an IPv4 address
 severity = "warn"

--- a/lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
+++ b/lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
@@ -3,6 +3,21 @@
 // SPDX-License-Identifier: ISC
 
 use crate::lint::Violation;
+use crate::violations::multipart_body::{
+    MULTIPART_BODY_DELIMITER_MISSING, MULTIPART_BODY_PART_MISSING,
+    MULTIPART_BODY_TERMINATOR_MISSING, RFC_2046_5_1_1,
+};
+use crate::violations::ViolationDef;
+
+/// Three entries, and a body reaches at most one: it carries no delimiter line,
+/// or its only one is the terminator, or it never terminates. The boundary
+/// *value* is `multipart_boundary_syntax`'s question and answers under the
+/// `boundary` subject.
+static DECLARED: &[&ViolationDef] = &[
+    &MULTIPART_BODY_DELIMITER_MISSING,
+    &MULTIPART_BODY_PART_MISSING,
+    &MULTIPART_BODY_TERMINATOR_MISSING,
+];
 use crate::rules::{Rule, RuleMeta};
 
 pub struct MultipartContentTypeAndBodyConsistent;
@@ -10,12 +25,6 @@ pub struct MultipartContentTypeAndBodyConsistent;
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_2046_5_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 2046",
-    section: Some("5.1.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc2046.html#section-5.1.1",
-    note: "Multipart common syntax: `dash-boundary`, `delimiter` and `close-delimiter`, the requirement that a delimiter begin a line, the instruction to compare against the beginning of a candidate line rather than the whole of it, and the ignoring of preamble and epilogue",
-};
 const RFC_9110_8_3_3: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
     section: Some("8.3.3"),
@@ -50,6 +59,10 @@ severity = "warn"
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[RFC_2046_5_1_1, RFC_9110_8_3_3, RFC_9110_8_3]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -153,8 +166,7 @@ impl Rule for MultipartContentTypeAndBodyConsistent {
                     if let Some(boundary) =
                         crate::helpers::media_type::extract_multipart_boundary(&s)
                     {
-                        if let Some(v) =
-                            check_body_delimiters(which, &boundary, body.as_ref(), ctx.severity)
+                        if let Some(v) = check_body_delimiters(which, &boundary, body.as_ref(), ctx)
                         {
                             return Some(v);
                         }
@@ -277,7 +289,6 @@ fn scan_delimiter_lines(body: &[u8], boundary: &[u8]) -> DelimiterScan {
         // only thing distinguishing the closing line from one that opens a
         // part, so this comparison is the whole classification.
         // cite(RFC 2046 § 5.1.1): "close-delimiter := delimiter "--""
-        // cite(RFC 2046 § 5.1.1): "Such a delimiter line is identical to the previous delimiter lines, with the addition of two more hyphens after the boundary parameter value."
         if body[i + db.len()..].starts_with(b"--") {
             scan.closes = true;
         } else if !scan.closes {
@@ -296,7 +307,7 @@ fn check_body_delimiters(
     which: &str,
     boundary: &str,
     body: &[u8],
-    severity: crate::lint::Severity,
+    ctx: &crate::rules::RuleContext<'_>,
 ) -> Option<Violation> {
     // The boundary is text for the three findings below and octets for the scan,
     // and the two are not the same string. `boundary` is the as-written reading —
@@ -312,7 +323,6 @@ fn check_body_delimiters(
     // instruction rather than this rule's convenience: the preamble and the
     // epilogue are to be ignored, so their content can neither satisfy a check
     // nor fail one.
-    // cite(RFC 2046 § 5.1.1): "implementations must ignore anything that appears before the first boundary delimiter line or after the last one."
     if !scan.opens_a_part && !scan.closes {
         let detail = if scan.appears_off_line {
             format!(
@@ -322,8 +332,8 @@ fn check_body_delimiters(
         } else {
             format!("body does not contain boundary marker '--{}'", shown)
         };
-        return Some(MultipartContentTypeAndBodyConsistent.violation(
-            severity,
+        return Some(ctx.report_with(
+            &MULTIPART_BODY_DELIMITER_MISSING,
             format!("Invalid multipart Content-Type in {}: {}", which, detail),
         ));
     }
@@ -332,10 +342,9 @@ fn check_body_delimiters(
     // a body in which it is the only delimiter line has no part for it to
     // follow. §5.1.1 calls a single body part the useful minimum, not zero.
     // cite(RFC 2046 § 5.1.1): "The boundary delimiter line following the last body part is a distinguished delimiter that indicates that no further body parts will follow."
-    // cite(RFC 2046 § 5.1.1): "The use of the "multipart" media type with only a single body part may be useful in certain contexts, and is explicitly permitted."
     if !scan.opens_a_part {
-        return Some(MultipartContentTypeAndBodyConsistent.violation(
-            severity,
+        return Some(ctx.report_with(
+            &MULTIPART_BODY_PART_MISSING,
             format!(
                 "Invalid multipart Content-Type in {}: the only boundary delimiter line is the terminating '--{}--', so the body encapsulates no part",
                 which, shown
@@ -347,8 +356,8 @@ fn check_body_delimiters(
     // which is the whole function §5.1.1 gives it.
     // cite(RFC 2046 § 5.1.1): "Such a delimiter line is identical to the previous delimiter lines, with the addition of two more hyphens after the boundary parameter value."
     if !scan.closes {
-        return Some(MultipartContentTypeAndBodyConsistent.violation(
-            severity,
+        return Some(ctx.report_with(
+            &MULTIPART_BODY_TERMINATOR_MISSING,
             format!(
                 "Invalid multipart Content-Type in {}: body missing terminating boundary '--{}--'",
                 which, boundary

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -52,6 +52,7 @@ pub mod language;
 pub mod list;
 pub mod mailbox;
 pub mod media_type;
+pub mod multipart_body;
 pub mod node;
 pub mod origin_agent_cluster;
 pub mod parameter;
@@ -384,7 +385,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 149;
+        const FLOOR: usize = 152;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/multipart_body.rs
+++ b/lint-http-rules/src/violations/multipart_body.rs
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! Multipart body defects — the delimiter lines a declared boundary promises
+//! and the body does not carry.
+//!
+//! [`boundary`](crate::violations::boundary) is about the parameter: whether
+//! the value a sender chose can serve as a delimiter at all. This subject is
+//! about the other half of the same promise — the body — and the two are
+//! separable in both directions: a perfectly good boundary may delimit nothing,
+//! and a body full of delimiter lines may be introduced by a boundary no
+//! gateway will carry.
+//!
+//! **Every entry is measured only between the first delimiter line and the
+//! last.** § 5.1.1 tells implementations to ignore whatever precedes the first
+//! and follows the final one, so the preamble and the epilogue can neither
+//! satisfy a check here nor fail one — a body whose only occurrence of the
+//! boundary text is in its preamble reaches the first entry below, because
+//! nothing that delimits anything was found.
+//!
+//! **Nothing here is a framing check.** RFC 9110 § 8.3.3 says HTTP does not use
+//! the boundary to determine message length, so a body that is missing its
+//! terminator is not a truncated message: it is a message whose recipient
+//! cannot tell whether the parts it has are all of them.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// The delimiter lines: what opens a part, what ends the last one, and what a
+/// recipient is told to ignore on either side of them.
+pub const RFC_2046_5_1_1: SpecRef = SpecRef {
+    spec: "RFC 2046",
+    section: Some("5.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc2046.html#section-5.1.1",
+    note: "Multipart common syntax: `dash-boundary`, `delimiter` and `close-delimiter`, the requirement that a delimiter begin a line, the instruction to compare against the beginning of a candidate line rather than the whole of it, and the ignoring of preamble and epilogue",
+};
+
+defects! {
+    /// A body that carries no delimiter line for the boundary its own
+    /// `Content-Type` declared. The parts, if any, are not separated by
+    /// anything a recipient is allowed to recognise.
+    ///
+    /// The text occurring *somewhere* in the body does not count and is worth
+    /// saying twice: a delimiter is a line, so `--boundary` in the middle of one
+    /// delimits nothing. The message says which of the two was found, because
+    /// the fixes differ — a sender who wrote the text without a line break has
+    /// a different bug from one who wrote the wrong boundary.
+    ///
+    // cite(RFC 2046 § 5.1.1, label: preamble and epilogue): "implementations must ignore anything that appears before the first boundary delimiter line or after the last one."
+    MULTIPART_BODY_DELIMITER_MISSING = {
+        id: "multipart_body_delimiter_missing",
+        title: "The body carries no delimiter line for its boundary",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_2046_5_1_1),
+    }
+
+    /// A body whose only delimiter line is the terminating one. The closing
+    /// delimiter is defined as the line *following the last body part*, so a
+    /// body where it comes first follows nothing — the type says the content is
+    /// several representations and the content is none.
+    ///
+    /// One part is not the defect: § 5.1.1 permits a single body part in as
+    /// many words, so the floor this entry enforces is one and not two.
+    ///
+    // cite(RFC 2046 § 5.1.1): "The use of the "multipart" media type with only a single body part may be useful in certain contexts, and is explicitly permitted."
+    MULTIPART_BODY_PART_MISSING = {
+        id: "multipart_body_part_missing",
+        title: "The only delimiter line is the terminating one",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_2046_5_1_1),
+    }
+
+    /// A body with parts and no closing delimiter. Nothing tells a recipient
+    /// that the parts have ended, which is the entire function § 5.1.1 gives
+    /// that line — so a reader either waits for a part that is not coming or
+    /// guesses that the last one it saw was the last.
+    ///
+    // cite(RFC 2046 § 5.1.1, label: close-delimiter): "Such a delimiter line is identical to the previous delimiter lines, with the addition of two more hyphens after the boundary parameter value."
+    MULTIPART_BODY_TERMINATOR_MISSING = {
+        id: "multipart_body_terminator_missing",
+        title: "The body never closes its last part",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_2046_5_1_1),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Three entries in the order a body fails them, and the order is the
+    /// reading: no delimiter at all, then a delimiter that opens nothing, then
+    /// parts that never close. Each is a strictly later question than the one
+    /// before it, which is why a body reaches exactly one.
+    #[test]
+    fn the_three_entries_are_answered_in_one_order() {
+        for def in [
+            &MULTIPART_BODY_DELIMITER_MISSING,
+            &MULTIPART_BODY_PART_MISSING,
+            &MULTIPART_BODY_TERMINATOR_MISSING,
+        ] {
+            assert!(def.id.starts_with("multipart_body_"), "{}", def.id);
+            assert_eq!(def.spec, Some(RFC_2046_5_1_1), "{}", def.id);
+            assert!(def.message.is_empty(), "{}", def.id);
+        }
+    }
+}

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -912,6 +912,18 @@ sources:
     cited_by:
     - file: lint-http-rules/src/violations/boundary.rs
       line: 61
+  - label: multipart_body
+    section: § 5.1.1
+    snippet: The use of the "multipart" media type with only a single body part may be useful in certain contexts, and is explicitly permitted.
+    cited_by:
+    - file: lint-http-rules/src/violations/multipart_body.rs
+      line: 68
+  - label: preamble and epilogue
+    section: § 5.1.1
+    snippet: implementations must ignore anything that appears before the first boundary delimiter line or after the last one.
+    cited_by:
+    - file: lint-http-rules/src/violations/multipart_body.rs
+      line: 51
   - label: multipart_boundary_syntax
     section: § 5.1.1
     snippet: All subtypes of "multipart" must use this syntax.
@@ -925,7 +937,7 @@ sources:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
       line: 431
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 222
+      line: 234
   - label: multipart_boundary_syntax (3)
     section: § 5.1.1
     snippet: The grammar for parameters on the Content-type field is such that it is often necessary to enclose the boundary parameter values in quotes on the Content-type line.
@@ -949,65 +961,53 @@ sources:
     snippet: An exact match of the entire candidate line is not required; it is sufficient that the boundary appear in its entirety following the CRLF.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 268
+      line: 280
   - label: multipart_content_type_and_body_consistent (2)
     section: § 5.1.1
     snippet: Boundary string comparisons must compare the boundary value with the beginning of each candidate line.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 267
-  - label: multipart_content_type_and_body_consistent (3)
+      line: 279
+  - label: close-delimiter
     section: § 5.1.1
     snippet: Such a delimiter line is identical to the previous delimiter lines, with the addition of two more hyphens after the boundary parameter value.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 280
-    - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 348
-  - label: multipart_content_type_and_body_consistent (4)
+      line: 357
+    - file: lint-http-rules/src/violations/multipart_body.rs
+      line: 82
+  - label: multipart_content_type_and_body_consistent (3)
     section: § 5.1.1
     snippet: The Content-Type field for multipart entities requires one parameter, "boundary".
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 121
+      line: 134
     - file: lint-http-rules/src/violations/boundary.rs
       line: 45
-  - label: multipart_content_type_and_body_consistent (5)
+  - label: multipart_content_type_and_body_consistent (4)
     section: § 5.1.1
     snippet: The boundary delimiter MUST occur at the beginning of a line, i.e., following a CRLF, and the initial CRLF is considered to be attached to the boundary delimiter line rather than part of the preceding part.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 242
-  - label: multipart_content_type_and_body_consistent (6)
+      line: 254
+  - label: multipart_content_type_and_body_consistent (5)
     section: § 5.1.1
     snippet: The boundary delimiter line following the last body part is a distinguished delimiter that indicates that no further body parts will follow.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 334
-  - label: multipart_content_type_and_body_consistent (7)
-    section: § 5.1.1
-    snippet: The use of the "multipart" media type with only a single body part may be useful in certain contexts, and is explicitly permitted.
-    cited_by:
-    - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 335
-  - label: multipart_content_type_and_body_consistent (8)
+      line: 344
+  - label: multipart_content_type_and_body_consistent (6)
     section: § 5.1.1
     snippet: close-delimiter := delimiter "--"
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 279
-  - label: multipart_content_type_and_body_consistent (9)
+      line: 291
+  - label: multipart_content_type_and_body_consistent (7)
     section: § 5.1.1
     snippet: dash-boundary := "--" boundary
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 221
-  - label: multipart_content_type_and_body_consistent (10)
-    section: § 5.1.1
-    snippet: implementations must ignore anything that appears before the first boundary delimiter line or after the last one.
-    cited_by:
-    - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 315
+      line: 233
 - label: RFC 2068
   url: https://www.rfc-editor.org/rfc/rfc2068.html
   fragments:
@@ -5411,7 +5411,7 @@ sources:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
       line: 160
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 98
+      line: 111
   - label: charset_registered (2)
     section: § 8.3.2
     snippet: In both cases, charset names are matched case-insensitively.
@@ -7065,7 +7065,7 @@ sources:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
       line: 191
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 151
+      line: 164
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 242
     - file: lint-http-rules/src/rules/server_header_product_valid.rs
@@ -7845,19 +7845,19 @@ sources:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
       line: 241
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 119
+      line: 132
   - label: multipart_content_type_and_body_consistent
     section: § 8.3.3
     snippet: HTTP message framing does not use the multipart boundary as an indicator of message body length, though it might be used by implementations that generate or process the content.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 120
+      line: 133
   - label: multipart_content_type_and_body_consistent (2)
     section: § 8.3.3
     snippet: The message body is itself a protocol element; a sender MUST generate only CRLF to represent line breaks between body parts.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 243
+      line: 255
   - label: no_body_for_1xx_204_304
     section: § 15.3.5
     snippet: A 204 response is terminated by the end of the header section; it cannot contain content or trailers.


### PR DESCRIPTION
The other half of the multipart pair gets a subject: a body carrying no delimiter line for the boundary declared, one whose only line is the terminator and so encapsulates nothing, and one that never terminates. Three questions in one order, each strictly later than the one before, so a body reaches exactly one of them.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
