### PR TITLE
A policy states a time it did not define

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1587,6 +1587,30 @@ severity = "warn"
 # Weight is not a qvalue
 severity = "warn"
 
+[violations.strict_transport_security_directive_duplicated]
+# A directive is written more than once in one policy
+severity = "warn"
+
+[violations.strict_transport_security_directive_empty]
+# The policy holds a separator with no directive
+severity = "warn"
+
+[violations.strict_transport_security_directive_value_forbidden]
+# A valueless directive is written with a value
+severity = "warn"
+
+[violations.strict_transport_security_directive_value_missing]
+# A directive that requires a value carries none
+severity = "warn"
+
+[violations.strict_transport_security_empty]
+# The policy is written with nothing in it
+severity = "warn"
+
+[violations.strict_transport_security_max_age_missing]
+# The policy states no max-age
+severity = "warn"
+
 [violations.te_chunked_forbidden]
 # TE names the chunked coding, which cannot be declined
 severity = "warn"

--- a/docs/rules/strict_transport_security_valid.md
+++ b/docs/rules/strict_transport_security_valid.md
@@ -15,6 +15,7 @@ The `Strict-Transport-Security` response header signals HSTS policies. This rule
 - [RFC 6797 §6.1](https://www.rfc-editor.org/rfc/rfc6797.html#section-6.1): Strict-Transport-Security header
 - [RFC 6797 §6.1.1](https://www.rfc-editor.org/rfc/rfc6797.html#section-6.1.1): The max-age Directive
 - [RFC 6797 §6.1.2](https://www.rfc-editor.org/rfc/rfc6797.html#section-6.1.2): The includeSubDomains Directive
+- [RFC 9111 §1.2.2](https://www.rfc-editor.org/rfc/rfc9111.html#section-1.2.2): `delta-seconds = 1*DIGIT` — the production every field carrying a time in seconds writes its value in, and the clamp that makes an over-long run of digits conforming
 - [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 - [RFC 9110 §5.6.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4): `quoted-string = DQUOTE *( qdtext / quoted-pair ) DQUOTE` — the two delimiters, the class between them, and the backslash escape
 

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1312,7 +1312,7 @@ severity = "warn"
         /// directive list, and neither says anything about an encoding. Each
         /// field's octet is now `token`'s, under an id the rule already
         /// declared.
-        const FLOOR: usize = 134;
+        const FLOOR: usize = 132;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/rules/strict_transport_security_valid.rs
+++ b/lint-http-rules/src/rules/strict_transport_security_valid.rs
@@ -4,10 +4,19 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::delta_seconds::{
+    DELTA_SECONDS_CHARACTER_FORBIDDEN, DELTA_SECONDS_EMPTY, RFC_9111_1_2_2,
+};
 use crate::violations::quoted_pair::QUOTED_PAIR_MALFORMED;
 use crate::violations::quoted_string::{
     quoted_string_defect, QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
     QUOTED_STRING_DELIMITER_MISSING, QUOTED_STRING_QUOTE_ESCAPE_MISSING, RFC_9110_5_6_4,
+};
+use crate::violations::strict_transport_security::{
+    RFC_6797_6_1, RFC_6797_6_1_1, RFC_6797_6_1_2, STRICT_TRANSPORT_SECURITY_DIRECTIVE_DUPLICATED,
+    STRICT_TRANSPORT_SECURITY_DIRECTIVE_EMPTY, STRICT_TRANSPORT_SECURITY_DIRECTIVE_VALUE_FORBIDDEN,
+    STRICT_TRANSPORT_SECURITY_DIRECTIVE_VALUE_MISSING, STRICT_TRANSPORT_SECURITY_EMPTY,
+    STRICT_TRANSPORT_SECURITY_MAX_AGE_MISSING,
 };
 use crate::violations::token::{
     token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN, TOKEN_EMPTY,
@@ -46,6 +55,14 @@ pub struct StrictTransportSecurityValid;
 /// one reason that survives an octet-wise read: a control octet cannot enter a
 /// `hyper::HeaderValue`, whatever the rule does with it afterwards.
 static DECLARED: &[&ViolationDef] = &[
+    &STRICT_TRANSPORT_SECURITY_EMPTY,
+    &STRICT_TRANSPORT_SECURITY_DIRECTIVE_EMPTY,
+    &STRICT_TRANSPORT_SECURITY_MAX_AGE_MISSING,
+    &STRICT_TRANSPORT_SECURITY_DIRECTIVE_DUPLICATED,
+    &STRICT_TRANSPORT_SECURITY_DIRECTIVE_VALUE_MISSING,
+    &STRICT_TRANSPORT_SECURITY_DIRECTIVE_VALUE_FORBIDDEN,
+    &DELTA_SECONDS_EMPTY,
+    &DELTA_SECONDS_CHARACTER_FORBIDDEN,
     &TOKEN_EMPTY,
     &TOKEN_CHARACTER_FORBIDDEN,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
@@ -54,28 +71,6 @@ static DECLARED: &[&ViolationDef] = &[
     &QUOTED_STRING_QUOTE_ESCAPE_MISSING,
     &QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
 ];
-
-/// The specification references this rule declares, each named so a finding
-/// site can cite the one it enforces. `specifications()` below is built from
-/// exactly these, so the docs and the citations cannot name different text.
-const RFC_6797_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 6797",
-    section: Some("6.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc6797.html#section-6.1",
-    note: "Strict-Transport-Security header",
-};
-const RFC_6797_6_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 6797",
-    section: Some("6.1.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc6797.html#section-6.1.1",
-    note: "The max-age Directive",
-};
-const RFC_6797_6_1_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 6797",
-    section: Some("6.1.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc6797.html#section-6.1.2",
-    note: "The includeSubDomains Directive",
-};
 
 impl RuleMeta for StrictTransportSecurityValid {
     fn id(&self) -> &'static str {
@@ -97,6 +92,7 @@ severity = "warn"
             RFC_6797_6_1,
             RFC_6797_6_1_1,
             RFC_6797_6_1_2,
+            RFC_9111_1_2_2,
             RFC_9110_5_6_2,
             RFC_9110_5_6_4,
         ]
@@ -175,10 +171,7 @@ impl Rule for StrictTransportSecurityValid {
                 // declares nothing is not a policy, which is a statement about
                 // this field and not about a production it broke.
                 if v.is_empty() {
-                    return Some(self.violation(
-                        ctx.severity,
-                        "Strict-Transport-Security header must not be empty".into(),
-                    ));
+                    return Some(ctx.report(&STRICT_TRANSPORT_SECURITY_EMPTY));
                 }
 
                 let mut saw_max_age = false;
@@ -195,10 +188,7 @@ impl Rule for StrictTransportSecurityValid {
                     // `Sec-WebSocket-Extensions` made about RFC 2616's list.
                     if member.is_empty() {
                         // skip stray semicolons but flag as violation
-                        return Some(self.violation(
-                            ctx.severity,
-                            "Empty directive in Strict-Transport-Security header".into(),
-                        ));
+                        return Some(ctx.report(&STRICT_TRANSPORT_SECURITY_DIRECTIVE_EMPTY));
                     }
 
                     // directive = token [ "=" token ]
@@ -225,7 +215,6 @@ impl Rule for StrictTransportSecurityValid {
                     match lname.as_str() {
                         // max-age is REQUIRED (enforced by the `saw_max_age` check after the loop)
                         // and its value is a count of seconds, i.e. all-digits (checked below).
-                        // cite(RFC 6797 § 6.1.1): "The REQUIRED "max-age" directive specifies the number of seconds, after the reception of the STS header field, during which the UA regards the host (from whom the message was received) as a Known HSTS Host."
                         "max-age" => {
                             max_age_count += 1;
                             saw_max_age = true;
@@ -233,7 +222,7 @@ impl Rule for StrictTransportSecurityValid {
                             if let Some(vpart) = kv.next() {
                                 let vpart = crate::helpers::headers::trim_ows(vpart);
                                 if vpart.is_empty() {
-                                    return Some(self.violation(ctx.severity, "Strict-Transport-Security 'max-age' must have a numeric value".into()));
+                                    return Some(ctx.report_with(&DELTA_SECONDS_EMPTY, "Strict-Transport-Security 'max-age' must have a numeric value".into()));
                                 }
                                 // Asked before the digits, and answered by the
                                 // catalogue: a `directive-value` is a `token` or
@@ -245,25 +234,33 @@ impl Rule for StrictTransportSecurityValid {
                                 {
                                     return Some(ctx.report_with(token_character(c), format!("Strict-Transport-Security 'max-age' contains invalid character: {}", crate::helpers::shown::describe_char(c))));
                                 }
+                                // The sign of `-1` and the point of `1.5` are the
+                                // production's defect and answer under its id,
+                                // whichever field imported it.
                                 if vpart.chars().any(|ch| !ch.is_ascii_digit()) {
-                                    return Some(self.violation(ctx.severity, "Strict-Transport-Security 'max-age' must be a non-negative integer".into()));
+                                    return Some(ctx.report_with(&DELTA_SECONDS_CHARACTER_FORBIDDEN, "Strict-Transport-Security 'max-age' must be a non-negative integer".into()));
                                 }
-                                if vpart.parse::<u64>().is_err() {
-                                    return Some(self.violation(ctx.severity, "Strict-Transport-Security 'max-age' value is not a valid integer".into()));
-                                }
+                                // A run of digits too long for a `u64` used to be
+                                // reported here as "not a valid integer", and it is
+                                // not a defect at all: `delta-seconds` sets no
+                                // ceiling and a recipient meeting a value it cannot
+                                // hold is told to clamp it, so such a policy is
+                                // conforming and what could not hold it was this
+                                // reader. The `delta_seconds` subject records the
+                                // same reading, and refuses the entry for the same
+                                // reason.
                             } else {
-                                return Some(self.violation(
-                                    ctx.severity,
+                                return Some(ctx.report_with(
+                                    &STRICT_TRANSPORT_SECURITY_DIRECTIVE_VALUE_MISSING,
                                     "Strict-Transport-Security 'max-age' must have a value".into(),
                                 ));
                             }
                         }
-                        // cite(RFC 6797 § 6.1.2): "The OPTIONAL "includeSubDomains" directive is a valueless directive which, if present (i.e., it is "asserted"), signals the UA that the HSTS Policy applies to this HSTS Host as well as any subdomains of the host's domain name."
                         "includesubdomains" => {
                             // canonical name is includeSubDomains, but accept case-insensitively
                             // must NOT have a value (it is "valueless" per §6.1.2)
                             if kv.next().is_some() {
-                                return Some(self.violation(ctx.severity, "Strict-Transport-Security 'includeSubDomains' directive must not have a value".into()));
+                                return Some(ctx.report_with(&STRICT_TRANSPORT_SECURITY_DIRECTIVE_VALUE_FORBIDDEN, "Strict-Transport-Security 'includeSubDomains' directive must not have a value".into()));
                             }
                         }
                         // `preload` is not an RFC 6797 directive — it is a de-facto extension (the
@@ -272,7 +269,7 @@ impl Rule for StrictTransportSecurityValid {
                         // governs this branch; it is validated like a known valueless directive.
                         "preload" => {
                             if kv.next().is_some() {
-                                return Some(self.violation(ctx.severity, "Strict-Transport-Security 'preload' directive must not have a value".into()));
+                                return Some(ctx.report_with(&STRICT_TRANSPORT_SECURITY_DIRECTIVE_VALUE_FORBIDDEN, "Strict-Transport-Security 'preload' directive must not have a value".into()));
                             }
                         }
                         _ => {
@@ -296,21 +293,16 @@ impl Rule for StrictTransportSecurityValid {
                     }
                 }
 
-                // cite(RFC 6797 § 6.1): "All directives MUST appear only once in an STS header field."
                 if max_age_count > 1 {
-                    return Some(self.cited(&RFC_6797_6_1, ctx.severity, "Strict-Transport-Security MUST NOT contain multiple 'max-age' directives"
-                                .into()));
+                    return Some(ctx.report_with(
+                        &STRICT_TRANSPORT_SECURITY_DIRECTIVE_DUPLICATED,
+                        "Strict-Transport-Security MUST NOT contain multiple 'max-age' directives"
+                            .into(),
+                    ));
                 }
 
                 if !saw_max_age {
-                    return Some(
-                        self.cited(
-                            &RFC_6797_6_1,
-                            ctx.severity,
-                            "Strict-Transport-Security header missing required 'max-age' directive"
-                                .into(),
-                        ),
-                    );
+                    return Some(ctx.report(&STRICT_TRANSPORT_SECURITY_MAX_AGE_MISSING));
                 }
             }
 
@@ -379,8 +371,12 @@ mod tests {
     /// required, that two directives are valueless, and that a directive
     /// appears once.
     #[rstest]
-    #[case::empty_value("", "must not be empty", "")]
-    #[case::empty_directive("max-age=1;;preload", "Empty directive in", "")]
+    #[case::empty_value("", "must not be empty", "strict_transport_security_empty")]
+    #[case::empty_directive(
+        "max-age=1;;preload",
+        "Empty directive in",
+        "strict_transport_security_directive_empty"
+    )]
     #[case::empty_name("max-age=1; =2", "Empty directive name", "token_empty")]
     #[case::name_character(
         "max-age=1; pre@load",
@@ -392,15 +388,27 @@ mod tests {
         "'max-age' contains invalid",
         "token_character_forbidden"
     )]
-    #[case::max_age_not_a_number("max-age=1.5", "non-negative integer", "")]
-    #[case::max_age_empty("max-age=", "must have a numeric value", "")]
-    #[case::max_age_valueless("max-age", "must have a value", "")]
+    #[case::max_age_not_a_number(
+        "max-age=1.5",
+        "non-negative integer",
+        "delta_seconds_character_forbidden"
+    )]
+    #[case::max_age_empty("max-age=", "must have a numeric value", "delta_seconds_empty")]
+    #[case::max_age_valueless(
+        "max-age",
+        "must have a value",
+        "strict_transport_security_directive_value_missing"
+    )]
     #[case::include_subdomains_valued(
         "max-age=1; includeSubDomains=1",
         "must not have a value",
-        ""
+        "strict_transport_security_directive_value_forbidden"
     )]
-    #[case::preload_valued("max-age=1; preload=1", "must not have a value", "")]
+    #[case::preload_valued(
+        "max-age=1; preload=1",
+        "must not have a value",
+        "strict_transport_security_directive_value_forbidden"
+    )]
     #[case::value_character(
         "max-age=1; foo=b@r",
         "value contains invalid",
@@ -421,8 +429,16 @@ mod tests {
         "Invalid quoted-string",
         "quoted_pair_malformed"
     )]
-    #[case::repeated_max_age("max-age=1; max-age=2", "multiple 'max-age'", "")]
-    #[case::missing_max_age("includeSubDomains", "missing required 'max-age'", "")]
+    #[case::repeated_max_age(
+        "max-age=1; max-age=2",
+        "multiple 'max-age'",
+        "strict_transport_security_directive_duplicated"
+    )]
+    #[case::missing_max_age(
+        "includeSubDomains",
+        "missing required 'max-age'",
+        "strict_transport_security_max_age_missing"
+    )]
     fn each_finding_reports_the_production_it_belongs_to(
         #[case] value: &str,
         #[case] expected: &str,

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -59,6 +59,7 @@ pub mod parameter;
 pub mod quoted_pair;
 pub mod quoted_string;
 pub mod qvalue;
+pub mod strict_transport_security;
 pub mod te;
 pub mod token;
 pub mod token68;
@@ -385,7 +386,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 152;
+        const FLOOR: usize = 156;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/strict_transport_security.rs
+++ b/lint-http-rules/src/violations/strict_transport_security.rs
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `Strict-Transport-Security` defects — what a policy can be wrong about once
+//! its directives are spelled correctly.
+//!
+//! The field is a semicolon-separated list of `directive = token [ "=" ( token
+//! / quoted-string ) ]`, so every spelling question already has an owner: a
+//! directive name that is not a `token`, a value that is neither a `token` nor
+//! a well-formed `quoted-string`, an octet no `tchar` admits. What is left is
+//! the *policy* — whether the directives that are there add up to one.
+//!
+//! **The time is not this field's.** RFC 6797 § 6.1.1 writes `max-age-value =
+//! delta-seconds` and says outright that the production is specified elsewhere,
+//! so a `max-age` with no digits or with a sign answers under
+//! [`delta_seconds`](crate::violations::delta_seconds) exactly as `Age`'s value
+//! and `Alt-Svc`'s `ma` do. What stays here is the directive: that it is
+//! required, that it may appear once, and that it has to carry a value at all.
+//!
+//! **A value a reader cannot hold is not an entry**, for the reason
+//! `delta_seconds` records: the production sets no ceiling and a recipient
+//! meeting an unrepresentable value is told to clamp it, so a forty-digit
+//! `max-age` is a conforming policy and this crate's inability to store it is
+//! this crate's problem.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// The field's own grammar, the once-only rule for its directives, and the
+/// extension mechanism that makes an unknown one acceptable.
+pub const RFC_6797_6_1: SpecRef = SpecRef {
+    spec: "RFC 6797",
+    section: Some("6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6797.html#section-6.1",
+    note: "Strict-Transport-Security header",
+};
+
+/// The required directive, and what its value is a count of.
+pub const RFC_6797_6_1_1: SpecRef = SpecRef {
+    spec: "RFC 6797",
+    section: Some("6.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6797.html#section-6.1.1",
+    note: "The max-age Directive",
+};
+
+/// The valueless directive, and what asserting it means.
+pub const RFC_6797_6_1_2: SpecRef = SpecRef {
+    spec: "RFC 6797",
+    section: Some("6.1.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc6797.html#section-6.1.2",
+    note: "The includeSubDomains Directive",
+};
+
+defects! {
+    /// A field line with no policy on it at all.
+    ///
+    /// **No `spec`, and the grammar is the reason.** § 6.1 writes
+    /// `[ directive ] *( ";" [ directive ] )`, whose optional brackets make the
+    /// empty value derive — so this is not a sentence being broken but this
+    /// crate saying that a policy declaring nothing is not a policy. The
+    /// missing `max-age` is the same message from the document's side, and a
+    /// value that is empty never reaches it: the two are ordered, and this one
+    /// is answered first because it is the one the operator can see.
+    STRICT_TRANSPORT_SECURITY_EMPTY = {
+        id: "strict_transport_security_empty",
+        title: "The policy is written with nothing in it",
+        message: "Strict-Transport-Security header must not be empty",
+        default_severity: Severity::Warn,
+        spec: None,
+    }
+
+    /// A semicolon with no directive on one side of it. The same optional
+    /// brackets generate this too, so the refusal is again this crate's —
+    /// kept because a stray separator is nearly always a directive that was
+    /// deleted or never expanded, and a policy is small enough that the
+    /// difference is worth showing.
+    STRICT_TRANSPORT_SECURITY_DIRECTIVE_EMPTY = {
+        id: "strict_transport_security_directive_empty",
+        title: "The policy holds a separator with no directive",
+        message: "Empty directive in Strict-Transport-Security header",
+        default_severity: Severity::Warn,
+        spec: None,
+    }
+
+    /// The policy does not state how long it lasts. `max-age` is the one
+    /// required directive, and without it a user agent has nothing to note the
+    /// host for — the rest of the field is qualification of a duration that was
+    /// never given.
+    ///
+    // cite(RFC 6797 § 6.1.1, label: max-age is required): "The REQUIRED "max-age" directive specifies the number of seconds, after the reception of the STS header field, during which the UA regards the host (from whom the message was received) as a Known HSTS Host."
+    STRICT_TRANSPORT_SECURITY_MAX_AGE_MISSING = {
+        id: "strict_transport_security_max_age_missing",
+        title: "The policy states no max-age",
+        message: "Strict-Transport-Security header missing required 'max-age' directive",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_6797_6_1_1),
+    }
+
+    /// One directive written twice in one field. § 6.1 admits no such thing,
+    /// and the reason is that the field is not a list of preferences: two
+    /// `max-age` directives are two durations for one policy, and nothing tells
+    /// a user agent which of them it is being asked to note.
+    ///
+    // cite(RFC 6797 § 6.1): "All directives MUST appear only once in an STS header field."
+    STRICT_TRANSPORT_SECURITY_DIRECTIVE_DUPLICATED = {
+        id: "strict_transport_security_directive_duplicated",
+        title: "A directive is written more than once in one policy",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_6797_6_1),
+    }
+
+    /// A directive whose definition requires a value, written without one —
+    /// `max-age` with no `=` at all. Distinct from a `max-age=` that is written
+    /// and empty, which is the [`delta_seconds`](crate::violations::delta_seconds)
+    /// subject's `_empty`: different senders, different fixes, and the same
+    /// `_missing`/`_empty` split the id convention draws everywhere else.
+    ///
+    // cite(RFC 6797 § 6.1.1, label: max-age carries a value): "The syntax of the max-age directive's REQUIRED value (after quoted-string unescaping, if necessary) is defined as:"
+    STRICT_TRANSPORT_SECURITY_DIRECTIVE_VALUE_MISSING = {
+        id: "strict_transport_security_directive_value_missing",
+        title: "A directive that requires a value carries none",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_6797_6_1_1),
+    }
+
+    /// A valueless directive carrying a value: `includeSubDomains=1`, or a
+    /// `preload` with anything after an `=`. Asserting such a directive is the
+    /// whole of its meaning, so a value says nothing a user agent can read and
+    /// suggests the sender expected it to mean something.
+    ///
+    /// `preload` is not RFC 6797's directive at all — it is the de-facto
+    /// extension § 6.1 anticipates being defined elsewhere — so what governs it
+    /// here is the convention its consumers implement rather than the sentence
+    /// quoted below, which is `includeSubDomains`'.
+    ///
+    // cite(RFC 6797 § 6.1.2): "The OPTIONAL "includeSubDomains" directive is a valueless directive which, if present (i.e., it is "asserted"), signals the UA that the HSTS Policy applies to this HSTS Host as well as any subdomains of the host's domain name."
+    STRICT_TRANSPORT_SECURITY_DIRECTIVE_VALUE_FORBIDDEN = {
+        id: "strict_transport_security_directive_value_forbidden",
+        title: "A valueless directive is written with a value",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_6797_6_1_2),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The two entries with no sentence behind them are the two the grammar
+    /// *generates*: `[ directive ]` is optional at both levels, so an empty
+    /// field and an empty member both derive, and refusing them is this crate's
+    /// own claim rather than a document's.
+    #[test]
+    fn the_two_entries_the_grammar_generates_carry_no_sentence() {
+        assert_eq!(STRICT_TRANSPORT_SECURITY_EMPTY.spec, None);
+        assert_eq!(STRICT_TRANSPORT_SECURITY_DIRECTIVE_EMPTY.spec, None);
+        for def in [
+            &STRICT_TRANSPORT_SECURITY_MAX_AGE_MISSING,
+            &STRICT_TRANSPORT_SECURITY_DIRECTIVE_DUPLICATED,
+            &STRICT_TRANSPORT_SECURITY_DIRECTIVE_VALUE_MISSING,
+            &STRICT_TRANSPORT_SECURITY_DIRECTIVE_VALUE_FORBIDDEN,
+        ] {
+            assert!(def.spec.is_some(), "{}", def.id);
+        }
+    }
+}

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -3110,42 +3110,48 @@ sources:
 - label: RFC 6797
   url: https://www.rfc-editor.org/rfc/rfc6797.html
   fragments:
-  - label: strict_transport_security_valid
+  - label: strict_transport_security
     section: § 6.1
     snippet: All directives MUST appear only once in an STS header field.
     cited_by:
-    - file: lint-http-rules/src/rules/strict_transport_security_valid.rs
-      line: 299
-  - label: strict_transport_security_valid (2)
+    - file: lint-http-rules/src/violations/strict_transport_security.rs
+      line: 106
+  - label: max-age is required
+    section: § 6.1.1
+    snippet: The REQUIRED "max-age" directive specifies the number of seconds, after the reception of the STS header field, during which the UA regards the host (from whom the message was received) as a Known HSTS Host.
+    cited_by:
+    - file: lint-http-rules/src/violations/strict_transport_security.rs
+      line: 92
+  - label: max-age carries a value
+    section: § 6.1.1
+    snippet: 'The syntax of the max-age directive''s REQUIRED value (after quoted-string unescaping, if necessary) is defined as:'
+    cited_by:
+    - file: lint-http-rules/src/violations/strict_transport_security.rs
+      line: 121
+  - label: strict_transport_security (2)
+    section: § 6.1.2
+    snippet: The OPTIONAL "includeSubDomains" directive is a valueless directive which, if present (i.e., it is "asserted"), signals the UA that the HSTS Policy applies to this HSTS Host as well as any subdomains of the host's domain name.
+    cited_by:
+    - file: lint-http-rules/src/violations/strict_transport_security.rs
+      line: 140
+  - label: strict_transport_security_valid
     section: § 6.1
     snippet: UAs MUST ignore any STS header field containing directives, or other header field value data, that does not conform to the syntax defined in this specification.
     cited_by:
     - file: lint-http-rules/src/rules/strict_transport_security_valid.rs
-      line: 160
-  - label: strict_transport_security_valid (3)
+      line: 156
+  - label: strict_transport_security_valid (2)
     section: § 6.1
     snippet: directive-name            = token
     cited_by:
     - file: lint-http-rules/src/rules/strict_transport_security_valid.rs
-      line: 219
-  - label: strict_transport_security_valid (4)
+      line: 209
+  - label: strict_transport_security_valid (3)
     section: § 6.1
     snippet: directive-value           = token | quoted-string
     cited_by:
     - file: lint-http-rules/src/rules/strict_transport_security_valid.rs
-      line: 280
-  - label: strict_transport_security_valid (5)
-    section: § 6.1.1
-    snippet: The REQUIRED "max-age" directive specifies the number of seconds, after the reception of the STS header field, during which the UA regards the host (from whom the message was received) as a Known HSTS Host.
-    cited_by:
-    - file: lint-http-rules/src/rules/strict_transport_security_valid.rs
-      line: 228
-  - label: strict_transport_security_valid (6)
-    section: § 6.1.2
-    snippet: The OPTIONAL "includeSubDomains" directive is a valueless directive which, if present (i.e., it is "asserted"), signals the UA that the HSTS Policy applies to this HSTS Host as well as any subdomains of the host's domain name.
-    cited_by:
-    - file: lint-http-rules/src/rules/strict_transport_security_valid.rs
-      line: 261
+      line: 277
 - label: RFC 6838
   url: https://www.rfc-editor.org/rfc/rfc6838.html
   fragments:


### PR DESCRIPTION
Strict-Transport-Security gets a subject for what its directives add up to — nothing written, a separator with no directive, the required directive absent, one written twice, a directive that needs a value without one, and a valueless one carrying a value. Its max-age is a delta-seconds by the section's own import, so the digits answer under that production's ids.

The value a u64 could not hold stops being reported: the production sets no ceiling and a recipient meeting such a value is told to clamp it, so what could not hold it was this reader.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
