### PR TITLE
A coding listed twice is listed for a reason

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1171,6 +1171,10 @@ severity = "warn"
 # The identity coding is named where a coding belongs
 severity = "warn"
 
+[violations.content_coding_redundant]
+# One coding is named twice in one field
+severity = "info"
+
 [violations.content_coding_unregistered]
 # Content coding is not one the deployment recognises
 severity = "warn"

--- a/docs/rules/content_encoding_and_type_consistent.md
+++ b/docs/rules/content_encoding_and_type_consistent.md
@@ -20,7 +20,8 @@ Repeating a coding is likewise a judgement call rather than a conformance failur
 
 ## Specifications
 
-- [RFC 9110 §8.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4): `Content-Encoding = #content-coding` — the list the member checks walk. Note it does not forbid repeating a coding, so the duplicate check is this rule's judgement
+- [RFC 9110 §8.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4): `Content-Encoding = #content-coding`, and the reservation of `identity` for Accept-Encoding — the reason it is flagged here
+- [RFC 9110 §12.5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.3): The wider Accept-Encoding grammar (`codings = content-coding / "identity" / "*"`), which is why the two headers are checked against different vocabularies
 - [RFC 9110 §15.4.5](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.5): Why a 304 should not carry Content-Encoding: a sender SHOULD NOT include representation metadata beyond the listed fields. (This reference previously pointed at §8.3, which is Content-Type, not message-body rules.) The 1xx and 204 cases have no such sentence and are inferred
 - [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 

--- a/lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
+++ b/lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
@@ -4,8 +4,11 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::content_coding::{
+    CONTENT_CODING_REDUNDANT, CONTENT_CODING_WILDCARD_FORBIDDEN, RFC_9110_12_5_3, RFC_9110_8_4,
+};
 use crate::violations::token::{
-    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
+    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN, TOKEN_EMPTY,
     TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
 };
 use crate::violations::ViolationDef;
@@ -30,17 +33,14 @@ pub struct ContentEncodingAndTypeConsistent;
 static DECLARED: &[&ViolationDef] = &[
     &TOKEN_CHARACTER_FORBIDDEN,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+    &TOKEN_EMPTY,
+    &CONTENT_CODING_WILDCARD_FORBIDDEN,
+    &CONTENT_CODING_REDUNDANT,
 ];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_9110_8_4: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("8.4"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4",
-    note: "`Content-Encoding = #content-coding` — the list the member checks walk. Note it does not forbid repeating a coding, so the duplicate check is this rule's judgement",
-};
 const RFC_9110_15_4_5: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
     section: Some("15.4.5"),
@@ -64,7 +64,12 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[RFC_9110_8_4, RFC_9110_15_4_5, RFC_9110_5_6_2]
+        &[
+            RFC_9110_8_4,
+            RFC_9110_12_5_3,
+            RFC_9110_15_4_5,
+            RFC_9110_5_6_2,
+        ]
     }
 
     fn violations(&self) -> &'static [&'static ViolationDef] {
@@ -122,18 +127,19 @@ impl Rule for ContentEncodingAndTypeConsistent {
                     // "member".** The walk above drops the list's empty members
                     // before this sees them, so what reaches here is a member
                     // that is *present* and whose coding half is missing --
-                    // `;q=1` and the like. That is `#content-coding`'s element
-                    // saying it is not optional, which is a statement about the
-                    // member's assembly and belongs to no subject.
+                    // `;q=1` and the like. `content-coding = token` and `1*tchar`
+                    // has a floor, so the name that is not there is the token's
+                    // own defect: the mirror rule on `Transfer-Encoding` reached
+                    // the same id from the same member shape.
                     if token.is_empty() {
-                        return Some(self.violation(
-                            ctx.severity,
+                        return Some(ctx.report_with(
+                            &TOKEN_EMPTY,
                             format!("{} header contains empty member", hdr_name),
                         ));
                     }
                     if token == "*" && hdr_name.eq_ignore_ascii_case("Content-Encoding") {
-                        return Some(self.violation(
-                            ctx.severity,
+                        return Some(ctx.report_with(
+                            &CONTENT_CODING_WILDCARD_FORBIDDEN,
                             format!("Wildcard '*' is not valid in {} header", hdr_name),
                         ));
                     }
@@ -157,11 +163,12 @@ impl Rule for ContentEncodingAndTypeConsistent {
                     // `gzip, gzip` a well-formed way to say gzip was applied twice. Flagging
                     // it is this rule's judgement that a repeat is far more often a
                     // configuration accident (two layers each adding the header) than a
-                    // deliberate double-encoding. Uncited, since no sentence licenses it.
+                    // deliberate double-encoding -- and the document's own aside about a
+                    // coding listed a second time is what the entry quotes.
                     let key = token.to_ascii_lowercase();
                     if !seen.insert(key.clone()) {
-                        return Some(self.violation(
-                            ctx.severity,
+                        return Some(ctx.report_with(
+                            &CONTENT_CODING_REDUNDANT,
                             format!("Duplicate content-coding '{}' in {} header", key, hdr_name),
                         ));
                     }
@@ -305,13 +312,16 @@ mod tests {
         assert_eq!(here.message, registered.message);
     }
 
-    /// What this rule is named for keeps its own severity and no id: a coding
-    /// repeated and a wildcard where none is defined are both well-formed
-    /// tokens in a well-formed list, saying something § 8.4 does not license.
+    /// Every finding here names the production the failing part is written in.
+    /// A coding repeated and a wildcard where none is defined are both
+    /// well-formed tokens in a well-formed list, so their ids are the
+    /// `content_coding` subject's rather than this field's — and a member that
+    /// is nothing but a parameter has no name at all, which is the `token`
+    /// floor and the id the mirror rule reaches from the same shape.
     #[rstest]
-    #[case::duplicate("gzip, gzip", "")]
-    #[case::wildcard("*", "")]
-    #[case::no_coding("gzip, ;q=1", "")]
+    #[case::duplicate("gzip, gzip", "content_coding_redundant")]
+    #[case::wildcard("*", "content_coding_wildcard_forbidden")]
+    #[case::no_coding("gzip, ;q=1", "token_empty")]
     #[case::bad_octet("x@bad", "token_character_forbidden")]
     #[case::space_inside("g zip", "token_whitespace_or_control_forbidden")]
     fn the_grammars_defects_are_the_grammars(#[case] value: &str, #[case] violation: &str) {

--- a/lint-http-rules/src/violations/content_coding.rs
+++ b/lint-http-rules/src/violations/content_coding.rs
@@ -86,6 +86,27 @@ defects! {
         spec: Some(RFC_9110_8_4),
     }
 
+    /// One coding named twice in one field: `Content-Encoding: gzip, gzip`.
+    /// Nothing forbids it — § 8.4 has the sender list the codings in the order
+    /// they were applied, so a repeat is a well-formed way to say the same
+    /// transformation ran twice — and the document's own aside is what makes it
+    /// reportable: a coding is listed a second time only *for some bizarre
+    /// reason*.
+    ///
+    /// `info`, with the catalogue's other `_redundant` entry, and for the same
+    /// reason: the message is decodable and the work was avoidable. In practice
+    /// it is two layers of a deployment each adding the field rather than a
+    /// sender meaning it.
+    ///
+    // cite(RFC 9110 § 8.4, label: a coding listed twice): "Such a content coding would only be listed if, for some bizarre reason, it is applied a second time to form the representation."
+    CONTENT_CODING_REDUNDANT = {
+        id: "content_coding_redundant",
+        title: "One coding is named twice in one field",
+        message: "",
+        default_severity: Severity::Info,
+        spec: Some(RFC_9110_8_4),
+    }
+
     /// A coding name the deployment does not recognise, matched
     /// case-insensitively because the names are. Measured against the
     /// operator's `allowed` list and not against IANA's table, the stand-in

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -386,7 +386,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 156;
+        const FLOOR: usize = 157;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -5459,7 +5459,7 @@ sources:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 146
     - file: lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
-      line: 117
+      line: 122
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
       line: 135
   - label: compression_and_transfer_encoding_consistent (5)
@@ -5468,26 +5468,28 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 243
-  - label: compression_and_transfer_encoding_consistent (6)
+  - label: a coding listed twice
     section: § 8.4
     snippet: Such a content coding would only be listed if, for some bizarre reason, it is applied a second time to form the representation.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 236
-  - label: compression_and_transfer_encoding_consistent (7)
+    - file: lint-http-rules/src/violations/content_coding.rs
+      line: 101
+  - label: compression_and_transfer_encoding_consistent (6)
     section: § 8.4
     snippet: Unlike Transfer-Encoding (Section 6.1 of [HTTP/1.1]), the codings listed in Content-Encoding are a characteristic of the representation; the representation is defined in terms of the coded form, and all other metadata about the representation is about the coded form unless otherwise noted in the metadata definition.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 219
-  - label: compression_and_transfer_encoding_consistent (8)
+  - label: compression_and_transfer_encoding_consistent (7)
     section: § 8.4.1
     snippet: All content codings are case-insensitive and ought to be registered within the "HTTP Content Coding Registry",
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 166
     - file: lint-http-rules/src/violations/content_coding.rs
-      line: 98
+      line: 119
   - label: conditional_headers_consistent
     section: § 13.1.3
     snippet: A recipient MUST ignore If-Modified-Since if the request contains an If-None-Match header field
@@ -5617,7 +5619,7 @@ sources:
     snippet: a sender SHOULD NOT generate representation metadata other than the above listed fields unless said metadata exists for the purpose of guiding cache updates
     cited_by:
     - file: lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
-      line: 201
+      line: 208
   - label: content_encoding_registered
     section: § 12.5.3
     snippet: codings = content-coding / "identity" / "*"


### PR DESCRIPTION
The pairing rule stops wording three findings of its own: a member with no coding name is the token floor, a wildcard is the entry the sibling rule already wrote, and a coding named twice becomes the second redundant entry — quoting the document's own aside that a coding is listed a second time only for some bizarre reason, which is what makes a repeat readable as work rather than as an error.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
