### PR TITLE
A status answers a request nobody made

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1591,6 +1591,14 @@ severity = "warn"
 # Weight is not a qvalue
 severity = "warn"
 
+[violations.status_206_unsolicited]
+# 206 Partial Content answers a request that asked for no range
+severity = "warn"
+
+[violations.status_416_unsolicited]
+# 416 Range Not Satisfiable answers a request that named no range
+severity = "warn"
+
 [violations.strict_transport_security_directive_duplicated]
 # A directive is written more than once in one policy
 severity = "warn"

--- a/docs/development.md
+++ b/docs/development.md
@@ -124,6 +124,7 @@ member is malformed".
 | Appears more times than the grammar allows | `_duplicated` | — |
 | Written where the specification prohibits it | `_forbidden` | — |
 | Permitted, and almost certainly not what was meant | `_redundant` | — |
+| Sent in answer to something the other side never asked for | `_unsolicited` | — |
 | Retired by a later specification | `_obsolete` | — |
 
 `_redundant` is the one ending that condemns nothing: it names work a message
@@ -133,6 +134,15 @@ applied to the representation and then again in transit — is not `_duplicated`
 since no definition is being exceeded, and not `_invalid`, since the message is
 perfectly decodable. An entry ending this way defaults to `info` unless there is
 an argument on the page for more.
+
+`_unsolicited` is the one ending whose evidence is in the *other* message.
+`status_206_unsolicited` — a `206 Partial Content` answering a request that
+carried no `Range` — is not `_forbidden`, since no sentence prohibits the status
+code; not `_invalid`, since no value is being measured past its grammar; and not
+`_redundant`, since nothing was done twice. What is wrong is the exchange: the
+status code's definition is written in terms of a request that did not happen. A
+rule reporting one of these has to read both messages, which is why the subject
+is the status code and never the field it is read against.
 
 `_missing` and `_empty` are not alternatives to pick between: `_missing` is a
 sender that never wrote the thing, `_empty` is a sender that wrote it and put

--- a/docs/rules/range_and_content_range_consistent.md
+++ b/docs/rules/range_and_content_range_consistent.md
@@ -24,7 +24,7 @@ A 416 answering a *partial PUT* is the exception: such a request names its range
 
 ## Specifications
 
-- [RFC 9110 §15.3.7](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7): 206 Partial Content: single-part 206 responses MUST include a `Content-Range` header describing the enclosed range
+- [RFC 9110 §15.3.7](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7): 206 Partial Content: the status code is a range request being fulfilled, and a single-part 206 MUST carry a `Content-Range` describing the enclosed range
 - [RFC 9110 §15.3.7.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7.2): 206 Partial Content, multiple parts: the parts carry the `Content-Range` fields and the header section MUST NOT carry one; a request for a single range MUST NOT be answered with a multipart response
 - [RFC 9110 §14.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-14.4): Content-Range: syntax of `Content-Range` and the semantics for satisfied and unsatisfiable ranges
 - [RFC 9110 §14.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-14.1): Range Units — the `range-unit` token, case-insensitive and registered

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1312,7 +1312,7 @@ severity = "warn"
         /// directive list, and neither says anything about an encoding. Each
         /// field's octet is now `token`'s, under an id the rule already
         /// declared.
-        const FLOOR: usize = 132;
+        const FLOOR: usize = 131;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/rules/range_and_content_range_consistent.rs
+++ b/lint-http-rules/src/rules/range_and_content_range_consistent.rs
@@ -12,19 +12,29 @@ use crate::violations::content_range::{
     CONTENT_RANGE_SPEC_WHITESPACE_FORBIDDEN, CONTENT_RANGE_UNIT_MALFORMED,
     CONTENT_RANGE_UNSATISFIED_RANGE_MALFORMED, RFC_9110_14_1, RFC_9110_14_1_2, RFC_9110_14_4,
 };
+use crate::violations::status::{
+    RFC_9110_15_3_7, RFC_9110_15_5_17, STATUS_206_UNSOLICITED, STATUS_416_UNSOLICITED,
+};
 use crate::violations::ViolationDef;
 
 pub struct RangeAndContentRangeConsistent;
 
-/// The defects this rule reports so far, and they are all one field's: the
-/// eleven ways `Content-Range = range-unit SP ( range-resp / unsatisfied-range )`
-/// is not that. They are the *field's* rather than this rule's — five other
-/// rules parse the same value, and the four that only ask whether it parsed
-/// will report these same ids when they say why.
+/// The defects this rule reports so far. Eleven of them are one field's: the
+/// ways `Content-Range = range-unit SP ( range-resp / unsatisfied-range )` is
+/// not that. They are the *field's* rather than this rule's — five other rules
+/// parse the same value, and the four that only ask whether it parsed will
+/// report these same ids when they say why.
+///
+/// The last two are not a field's at all. A 206 and a 416 are each defined in
+/// terms of the request's `Range`, so one sent where that field was never
+/// written describes an exchange that did not happen — the status code is the
+/// subject, and both fields it is read against are blameless.
 ///
 /// The rest of what this rule says is about two fields *agreeing*, which is a
 /// different subject and converts with the reading that owns the pair.
 static DECLARED: &[&ViolationDef] = &[
+    &STATUS_206_UNSOLICITED,
+    &STATUS_416_UNSOLICITED,
     &CONTENT_RANGE_EMPTY,
     &CONTENT_RANGE_UNIT_MALFORMED,
     &CONTENT_RANGE_SPEC_MISSING,
@@ -118,23 +128,11 @@ fn response_is_multipart_byteranges(headers: &hyper::HeaderMap) -> bool {
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_9110_15_3_7: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("15.3.7"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7",
-    note: "206 Partial Content: single-part 206 responses MUST include a `Content-Range` header describing the enclosed range",
-};
 const RFC_9110_15_3_7_2: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
     section: Some("15.3.7.2"),
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7.2",
     note: "206 Partial Content, multiple parts: the parts carry the `Content-Range` fields and the header section MUST NOT carry one; a request for a single range MUST NOT be answered with a multipart response",
-};
-const RFC_9110_15_5_17: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("15.5.17"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.17",
-    note: "416 Range Not Satisfiable: the status code is the rejection of the ranges in the request's `Range` field; a server answering a *byte*-range request SHOULD include `Content-Range: bytes */<complete-length>`",
 };
 
 impl RuleMeta for RangeAndContentRangeConsistent {
@@ -259,15 +257,12 @@ impl Rule for RangeAndContentRangeConsistent {
                 .and_then(crate::helpers::content_range::split_ranges_specifier);
 
             // A 206 is *defined* as the answer to a range request, so one returned to a
-            // request that asked for no range contradicts its own status code. No MUST
-            // states this, and none is needed: the sentence says what the code
-            // indicates, and here it indicates something that did not happen. This
-            // check used to sit two branches deeper, where only a 206 carrying a
-            // well-formed satisfied Content-Range could reach it.
-            // cite(RFC 9110 § 15.3.7): "The 206 (Partial Content) status code indicates that the server is successfully fulfilling a range request for the target resource by transferring one or more parts of the selected representation."
+            // request that asked for no range contradicts its own status code -- the
+            // status is the defect and neither range field is, which is why the id is
+            // the status code's. This check used to sit two branches deeper, where only
+            // a 206 carrying a well-formed satisfied Content-Range could reach it.
             if status == 206 && !has_range_request {
-                return Some(self.cited(&RFC_9110_15_3_7, config.severity, "206 Partial Content response received but request did not include a Range header"
-                            .into()));
+                return Some(ctx.report(&STATUS_206_UNSOLICITED));
             }
 
             // 206 Partial Content rules
@@ -403,7 +398,8 @@ impl Rule for RangeAndContentRangeConsistent {
             if status == 416 {
                 // The status names the request field it is about, the same way 206's
                 // definition does, so a 416 to a request carrying no Range announces
-                // the rejection of nothing.
+                // the rejection of nothing -- the status code's own defect, and the
+                // entry beside the 206 one.
                 //
                 // Unless the range is in the other field. A partial PUT names the
                 // range it is writing in the request's own Content-Range, so a server
@@ -414,13 +410,11 @@ impl Rule for RangeAndContentRangeConsistent {
                 // it would be supplying one. The 206 side above keeps its finding:
                 // nothing in § 14.5 gives a response to a PUT an enclosed part to
                 // describe, which is the only thing a 206 says.
-                // cite(RFC 9110 § 15.5.17): "The 416 (Range Not Satisfiable) status code indicates that the set of ranges in the request's Range header field (Section 14.2) has been rejected either because none of the requested ranges are satisfiable or because the client has requested an excessive number of small or overlapping ranges (a potential denial of service attack)."
                 // cite(RFC 9110 § 14.5): "Some origin servers support PUT of a partial representation when the user agent sends a Content-Range header field (Section 14.4) in the request, though such support is inconsistent and depends on private agreements with user agents."
                 let request_names_a_range_elsewhere =
                     tx.request.headers.get("content-range").is_some();
                 if !has_range_request && !request_names_a_range_elsewhere {
-                    return Some(self.violation(config.severity, "416 Range Not Satisfiable response sent to a request with no Range header"
-                                .into()));
+                    return Some(ctx.report(&STATUS_416_UNSOLICITED));
                 }
 
                 let cr = crate::helpers::headers::get_header_str(&resp.headers, "content-range");

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -59,6 +59,7 @@ pub mod parameter;
 pub mod quoted_pair;
 pub mod quoted_string;
 pub mod qvalue;
+pub mod status;
 pub mod strict_transport_security;
 pub mod te;
 pub mod token;
@@ -386,7 +387,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 157;
+        const FLOOR: usize = 159;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,
@@ -410,6 +411,7 @@ mod tests {
         "obsolete",
         "redundant",
         "unregistered",
+        "unsolicited",
     ];
 
     /// Whether `id` is `<subject>[_<part>]_<defect>`: a defect from the list

--- a/lint-http-rules/src/violations/status.rs
+++ b/lint-http-rules/src/violations/status.rs
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! Status-code defects — a response whose status describes an exchange that did
+//! not happen.
+//!
+//! **The subject is the status code**, which is neither a field nor a
+//! production: it is the response's own control data, and a status code that
+//! contradicts its request is wrong in a way no field on either message is.
+//! Both entries below are read out of *two* messages — the status the server
+//! sent and the field the client did not — which is what separates them from
+//! every other subject in this catalogue, where the defect is visible inside
+//! one message.
+//!
+//! **What the entries have in common is the word that names them.** A status
+//! code whose definition is written in terms of a request field says that
+//! field arrived; where it did not, nothing is malformed, nothing is
+//! prohibited, and nothing was done twice — the server answered a question
+//! nobody asked. `_unsolicited` is the ending for that, and
+//! `docs/development.md` carries the argument for it beside the rest of the
+//! closed vocabulary.
+//!
+//! Both default to `warn`, which is the severity the rule reporting them had
+//! already chosen for itself: a client that asked for no part of a
+//! representation and is handed one has to notice that on its own, and the
+//! documents describe the status codes rather than forbidding them here.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// What a 206 says it is doing, and the field a single-part one has to carry
+/// while it does.
+pub const RFC_9110_15_3_7: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.3.7"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7",
+    note: "206 Partial Content: the status code is a range request being fulfilled, and a single-part 206 MUST carry a `Content-Range` describing the enclosed range",
+};
+
+/// What a 416 says it is doing — a rejection of the ranges the request named —
+/// and the field a server answering a byte-range request ought to send with it.
+pub const RFC_9110_15_5_17: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.5.17"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.17",
+    note: "416 Range Not Satisfiable: the status code is the rejection of the ranges in the request's `Range` field; a server answering a *byte*-range request SHOULD include `Content-Range: bytes */<complete-length>`",
+};
+
+defects! {
+    /// A 206 answering a request that named no range. The status code is
+    /// defined as a range request being fulfilled, so a response carrying it
+    /// asserts a request that is not there to read — and the client, which
+    /// asked for a representation and is being handed a part of one, has no
+    /// field of its own to blame.
+    ///
+    /// **No sentence prohibits this**, and none is needed: the definition says
+    /// what the code indicates, and here it indicates something that did not
+    /// happen. The finding stands whatever the response's `Content-Range` says,
+    /// including when it says nothing — a 206 to a request with no `Range` is
+    /// already wrong before its fields are read.
+    ///
+    // cite(RFC 9110 § 15.3.7): "The 206 (Partial Content) status code indicates that the server is successfully fulfilling a range request for the target resource by transferring one or more parts of the selected representation."
+    STATUS_206_UNSOLICITED = {
+        id: "status_206_unsolicited",
+        title: "206 Partial Content answers a request that asked for no range",
+        message: "206 Partial Content response received but request did not include a Range header",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_15_3_7),
+    }
+
+    /// A 416 answering a request that named no range. The status code is the
+    /// rejection of a set of ranges the request wrote, so with no `Range` field
+    /// there is no set for it to have rejected.
+    ///
+    /// The one request that names a range elsewhere is not this defect: a
+    /// partial `PUT` writes its range in the request's own `Content-Range`, and
+    /// a server refusing *that* has something to be about. § 14.5 leaves the
+    /// exchange to private agreement between the two parties, so the rule
+    /// reading this entry excludes it at the site — a condition on when the
+    /// defect exists, rather than a second defect.
+    ///
+    // cite(RFC 9110 § 15.5.17): "The 416 (Range Not Satisfiable) status code indicates that the set of ranges in the request's Range header field (Section 14.2) has been rejected either because none of the requested ranges are satisfiable or because the client has requested an excessive number of small or overlapping ranges (a potential denial of service attack)."
+    STATUS_416_UNSOLICITED = {
+        id: "status_416_unsolicited",
+        title: "416 Range Not Satisfiable answers a request that named no range",
+        message: "416 Range Not Satisfiable response sent to a request with no Range header",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_15_5_17),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The status code is the subject, and neither `Range` nor `Content-Range`
+    /// is: both fields are well-formed or absent in these findings, and an
+    /// operator silencing `status_206_unsolicited` is silencing a status code
+    /// sent where nothing invited it — not anything about a range field.
+    #[test]
+    fn each_id_names_the_status_and_not_the_field_it_is_read_against() {
+        for def in [&STATUS_206_UNSOLICITED, &STATUS_416_UNSOLICITED] {
+            assert!(def.id.starts_with("status_"), "{} is not a status", def.id);
+            assert!(!def.id.contains("range"), "{} names a field", def.id);
+        }
+    }
+
+    /// Both entries carry their whole message, which is the shape of the defect
+    /// rather than a convenience: what is wrong is that a field is *absent*, so
+    /// there is no value the site could interpolate and no wording that varies
+    /// between one finding and the next.
+    #[test]
+    fn neither_entry_leaves_its_message_to_the_site() {
+        for def in [&STATUS_206_UNSOLICITED, &STATUS_416_UNSOLICITED] {
+            assert!(!def.message.is_empty(), "{} holds no message", def.id);
+        }
+    }
+}

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -5120,8 +5120,8 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
       line: 118
-    - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 267
+    - file: lint-http-rules/src/violations/status.rs
+      line: 64
   - label: accept_ranges_on_partial_content
     section: § 14.2
     snippet: A server MUST ignore a Range header field received with a request method that is unrecognized or for which range handling is not defined.
@@ -6503,7 +6503,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 371
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 85
+      line: 95
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 293
     - file: lint-http-rules/src/violations/content_range.rs
@@ -6555,7 +6555,7 @@ sources:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 358
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 300
+      line: 295
     - file: lint-http-rules/src/rules/status_code_semantics.rs
       line: 16
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -7379,7 +7379,7 @@ sources:
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
       line: 164
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 104
+      line: 114
   - label: lint-http-rules/src/helpers/media_type.rs (6)
     section: § 8.3.1
     snippet: The type/subtype MAY be followed by semicolon-delimited parameters (Section 5.6.6) in the form of name/value pairs.
@@ -8093,97 +8093,91 @@ sources:
     snippet: If the representation data has a content coding applied, each byte range is calculated with respect to the encoded sequence of bytes, not the sequence of underlying bytes that would be obtained after decoding.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 362
+      line: 357
   - label: range_and_content_range_consistent (2)
     section: § 14.1.2
     snippet: The first-pos value in a bytes int-range gives the offset of the first byte in a range.  The last-pos value gives the offset of the last byte in the range; that is, the byte positions specified are inclusive.  Byte offsets start at zero.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 349
+      line: 344
   - label: range_and_content_range_consistent (3)
     section: § 14.4
     snippet: 'A server generating a 416 (Range Not Satisfiable) response to a byte-range request SHOULD send a Content-Range header field with an unsatisfied-range value, as in the following example:'
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 435
+      line: 429
   - label: range_and_content_range_consistent (4)
     section: § 14.4
     snippet: If a 206 (Partial Content) response contains a Content-Range header field with a range unit (Section 14.1) that the recipient does not understand, the recipient MUST NOT attempt to recombine it with a stored representation.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 350
+      line: 345
   - label: range_and_content_range_consistent (5)
     section: § 14.4
     snippet: The "Content-Range" header field is sent in a single part 206 (Partial Content) response to indicate the partial range of the selected representation enclosed as the message content, sent in each part of a multipart 206 response to indicate the range enclosed within each body part (Section 14.6), and sent in 416 (Range Not Satisfiable) responses to provide information about the selected representation.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 274
+      line: 269
   - label: range_and_content_range_consistent (6)
     section: § 14.4
     snippet: The Content-Range header field has no meaning for status codes that do not explicitly describe its semantic.  For this specification, only the 206 (Partial Content) and 416 (Range Not Satisfiable) status codes describe a meaning for Content-Range.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 235
+      line: 233
   - label: range_and_content_range_consistent (7)
     section: § 14.4
     snippet: The complete-length in a 416 response indicates the current length of the selected representation.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 453
+      line: 447
   - label: range_and_content_range_consistent (8)
     section: § 14.5
     snippet: Some origin servers support PUT of a partial representation when the user agent sends a Content-Range header field (Section 14.4) in the request, though such support is inconsistent and depends on private agreements with user agents.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 418
+      line: 413
   - label: range_and_content_range_consistent (9)
     section: § 15.3.7
     snippet: A Content-Length header field present in a 206 response indicates the number of octets in the content of this message, which is usually not the complete length of the selected representation.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 361
+      line: 356
   - label: range_and_content_range_consistent (10)
     section: § 15.3.7.1
     snippet: If a single part is being transferred, the server generating the 206 response MUST generate a Content-Range header field, describing what range of the selected representation is enclosed, and a content consisting of the range.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 318
+      line: 313
   - label: range_and_content_range_consistent (11)
     section: § 15.3.7.2
     snippet: A server MUST NOT generate a multipart response to a request for a single range, since a client that does not request multiple parts might not support multipart responses.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 299
+      line: 294
   - label: range_and_content_range_consistent (12)
     section: § 15.3.7.2
     snippet: If multiple parts are being transferred, the server generating the 206 response MUST generate "multipart/byteranges" content, as defined in Section 14.6, and a Content-Type header field containing the "multipart/byteranges" media type and its required boundary parameter.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 285
+      line: 280
   - label: range_and_content_range_consistent (13)
     section: § 15.3.7.2
     snippet: To avoid confusion with single-part responses, a server MUST NOT generate a Content-Range header field in the HTTP header section of a multiple part response (this field will be sent in each part instead).
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 287
+      line: 282
   - label: range_and_content_range_consistent (14)
     section: § 15.3.7.2
     snippet: Within the header area of each body part in the multipart content, the server MUST generate a Content-Range header field corresponding to the range being enclosed in that body part.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 312
+      line: 307
   - label: range_and_content_range_consistent (15)
     section: § 15.5.17
     snippet: A server that generates a 416 response to a byte-range request SHOULD generate a Content-Range header field specifying the current length of the selected representation (Section 14.4).
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 434
-  - label: range_and_content_range_consistent (16)
-    section: § 15.5.17
-    snippet: The 416 (Range Not Satisfiable) status code indicates that the set of ranges in the request's Range header field (Section 14.2) has been rejected either because none of the requested ranges are satisfiable or because the client has requested an excessive number of small or overlapping ranges (a potential denial of service attack).
-    cited_by:
-    - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 417
+      line: 428
   - label: range_header_syntax
     section: § 14.1.1
     snippet: A ranges-specifier is invalid if it contains any range-spec that is invalid or undefined for the indicated range-unit.
@@ -8720,6 +8714,12 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 43
+  - label: status
+    section: § 15.5.17
+    snippet: The 416 (Range Not Satisfiable) status code indicates that the set of ranges in the request's Range header field (Section 14.2) has been rejected either because none of the requested ranges are satisfiable or because the client has requested an excessive number of small or overlapping ranges (a potential denial of service attack).
+    cited_by:
+    - file: lint-http-rules/src/violations/status.rs
+      line: 84
   - label: status_101_switching_protocols
     section: § 15.2.2
     snippet: The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field (Section 7.8), for a change in the application protocol being used on this connection.


### PR DESCRIPTION
A 206 and a 416 are each defined in terms of the request's Range, so one sent where that field was never written describes an exchange that did not happen. Neither range field is at fault, which makes the status code the subject — the first one here that is neither a field nor a production, and the first whose evidence is in the other message.

The defect word is new: not forbidden, since no sentence prohibits the status code; not invalid, since no value is being measured; not redundant, since nothing was done twice. The closed vocabulary gains _unsolicited, in the test that checks it and in the page that defines it.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
