### PR TITLE
Content-Range answers for its own absence

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1215,8 +1215,24 @@ severity = "error"
 # Content-Range is empty
 severity = "warn"
 
+[violations.content_range_forbidden]
+# Content-Range is written in the header section of a multipart 206
+severity = "warn"
+
+[violations.content_range_form_invalid]
+# Content-Range uses the form belonging to the other status code
+severity = "warn"
+
 [violations.content_range_incl_range_malformed]
 # Content-Range range is not first-pos '-' last-pos
+severity = "warn"
+
+[violations.content_range_length_conflicting]
+# Content-Range describes a range that is not the declared Content-Length
+severity = "warn"
+
+[violations.content_range_missing]
+# Content-Range is absent from a response whose range it would describe
 severity = "warn"
 
 [violations.content_range_numeral_invalid]

--- a/docs/rules/range_and_content_range_consistent.md
+++ b/docs/rules/range_and_content_range_consistent.md
@@ -25,6 +25,7 @@ A 416 answering a *partial PUT* is the exception: such a request names its range
 ## Specifications
 
 - [RFC 9110 §15.3.7](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7): 206 Partial Content: the status code is a range request being fulfilled, and a single-part 206 MUST carry a `Content-Range` describing the enclosed range
+- [RFC 9110 §15.3.7.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7.1): 206 Partial Content, single part: the response MUST carry a `Content-Range` describing the enclosed range
 - [RFC 9110 §15.3.7.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7.2): 206 Partial Content, multiple parts: the parts carry the `Content-Range` fields and the header section MUST NOT carry one; a request for a single range MUST NOT be answered with a multipart response
 - [RFC 9110 §14.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-14.4): Content-Range: syntax of `Content-Range` and the semantics for satisfied and unsatisfiable ranges
 - [RFC 9110 §14.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-14.1): Range Units — the `range-unit` token, case-insensitive and registered

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1312,7 +1312,7 @@ severity = "warn"
         /// directive list, and neither says anything about an encoding. Each
         /// field's octet is now `token`'s, under an id the rule already
         /// declared.
-        const FLOOR: usize = 131;
+        const FLOOR: usize = 129;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/rules/range_and_content_range_consistent.rs
+++ b/lint-http-rules/src/rules/range_and_content_range_consistent.rs
@@ -6,11 +6,13 @@ use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
 use crate::violations::content_range::{
     content_range_defect, CONTENT_RANGE_COMPLETE_LENGTH_CONFLICTING, CONTENT_RANGE_EMPTY,
-    CONTENT_RANGE_INCL_RANGE_MALFORMED, CONTENT_RANGE_NUMERAL_INVALID,
+    CONTENT_RANGE_FORBIDDEN, CONTENT_RANGE_FORM_INVALID, CONTENT_RANGE_INCL_RANGE_MALFORMED,
+    CONTENT_RANGE_LENGTH_CONFLICTING, CONTENT_RANGE_MISSING, CONTENT_RANGE_NUMERAL_INVALID,
     CONTENT_RANGE_NUMERAL_MALFORMED, CONTENT_RANGE_POSITIONS_CONFLICTING,
     CONTENT_RANGE_SLASH_MISSING, CONTENT_RANGE_SPEC_MISSING,
     CONTENT_RANGE_SPEC_WHITESPACE_FORBIDDEN, CONTENT_RANGE_UNIT_MALFORMED,
     CONTENT_RANGE_UNSATISFIED_RANGE_MALFORMED, RFC_9110_14_1, RFC_9110_14_1_2, RFC_9110_14_4,
+    RFC_9110_15_3_7_1, RFC_9110_15_3_7_2,
 };
 use crate::violations::status::{
     RFC_9110_15_3_7, RFC_9110_15_5_17, STATUS_206_UNSOLICITED, STATUS_416_UNSOLICITED,
@@ -19,22 +21,32 @@ use crate::violations::ViolationDef;
 
 pub struct RangeAndContentRangeConsistent;
 
-/// The defects this rule reports so far. Eleven of them are one field's: the
-/// ways `Content-Range = range-unit SP ( range-resp / unsatisfied-range )` is
-/// not that. They are the *field's* rather than this rule's — five other rules
-/// parse the same value, and the four that only ask whether it parsed will
-/// report these same ids when they say why.
+/// The defects this rule reports so far. Eleven of them are the ways
+/// `Content-Range = range-unit SP ( range-resp / unsatisfied-range )` is not
+/// that, read out of the value. They are the *field's* rather than this rule's
+/// — five other rules parse the same value, and the four that only ask whether
+/// it parsed will report these same ids when they say why.
+///
+/// Four more are the same field's without being read out of it: whether it is
+/// due, prohibited, written in the form the other status code uses, or counting
+/// octets its neighbour counts differently. § 14.4 gives the field one meaning
+/// per status code that describes a semantic for it, so the status is the
+/// condition and the field stays the subject.
 ///
 /// The last two are not a field's at all. A 206 and a 416 are each defined in
 /// terms of the request's `Range`, so one sent where that field was never
 /// written describes an exchange that did not happen — the status code is the
 /// subject, and both fields it is read against are blameless.
 ///
-/// The rest of what this rule says is about two fields *agreeing*, which is a
-/// different subject and converts with the reading that owns the pair.
+/// What is left unconverted is one site: a multipart response to a request for
+/// a single range, which is a claim about neither field.
 static DECLARED: &[&ViolationDef] = &[
     &STATUS_206_UNSOLICITED,
     &STATUS_416_UNSOLICITED,
+    &CONTENT_RANGE_MISSING,
+    &CONTENT_RANGE_FORBIDDEN,
+    &CONTENT_RANGE_FORM_INVALID,
+    &CONTENT_RANGE_LENGTH_CONFLICTING,
     &CONTENT_RANGE_EMPTY,
     &CONTENT_RANGE_UNIT_MALFORMED,
     &CONTENT_RANGE_SPEC_MISSING,
@@ -125,16 +137,6 @@ fn response_is_multipart_byteranges(headers: &hyper::HeaderMap) -> bool {
     }
 }
 
-/// The specification references this rule declares, each named so a finding
-/// site can cite the one it enforces. `specifications()` below is built from
-/// exactly these, so the docs and the citations cannot name different text.
-const RFC_9110_15_3_7_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("15.3.7.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7.2",
-    note: "206 Partial Content, multiple parts: the parts carry the `Content-Range` fields and the header section MUST NOT carry one; a request for a single range MUST NOT be answered with a multipart response",
-};
-
 impl RuleMeta for RangeAndContentRangeConsistent {
     fn id(&self) -> &'static str {
         "range_and_content_range_consistent"
@@ -173,6 +175,7 @@ units = ["bytes"]
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
             RFC_9110_15_3_7,
+            RFC_9110_15_3_7_1,
             RFC_9110_15_3_7_2,
             RFC_9110_14_4,
             RFC_9110_14_1,
@@ -265,8 +268,10 @@ impl Rule for RangeAndContentRangeConsistent {
                 return Some(ctx.report(&STATUS_206_UNSOLICITED));
             }
 
-            // 206 Partial Content rules
-            // cite(RFC 9110 § 14.4): "The "Content-Range" header field is sent in a single part 206 (Partial Content) response to indicate the partial range of the selected representation enclosed as the message content, sent in each part of a multipart 206 response to indicate the range enclosed within each body part (Section 14.6), and sent in 416 (Range Not Satisfiable) responses to provide information about the selected representation."
+            // 206 Partial Content rules. What the field means in this status --
+            // and in the 416 below, which is the only other one that gives it a
+            // meaning -- is § 14.4's opening sentence, and it is quoted on
+            // `content_range_form_invalid`, the entry that enforces it.
             if status == 206 {
                 let cr = crate::helpers::headers::get_header_str(&resp.headers, "content-range");
 
@@ -279,9 +284,8 @@ impl Rule for RangeAndContentRangeConsistent {
                 // written; the code never had the condition.
                 // cite(RFC 9110 § 15.3.7.2): "If multiple parts are being transferred, the server generating the 206 response MUST generate "multipart/byteranges" content, as defined in Section 14.6, and a Content-Type header field containing the "multipart/byteranges" media type and its required boundary parameter."
                 if response_is_multipart_byteranges(&resp.headers) {
-                    // cite(RFC 9110 § 15.3.7.2): "To avoid confusion with single-part responses, a server MUST NOT generate a Content-Range header field in the HTTP header section of a multiple part response (this field will be sent in each part instead)."
                     if cr.is_some() {
-                        return Some(self.cited(&RFC_9110_15_3_7_2, config.severity, "multipart/byteranges 206 response must not carry a Content-Range header field in its header section (each body part carries its own)".into()));
+                        return Some(ctx.report_with(&CONTENT_RANGE_FORBIDDEN, "multipart/byteranges 206 response must not carry a Content-Range header field in its header section (each body part carries its own)".into()));
                     }
 
                     // One requested range may not be answered with a multipart
@@ -308,14 +312,15 @@ impl Rule for RangeAndContentRangeConsistent {
                     return None;
                 }
 
-                // Single part: the field is required, and this is the sentence the
-                // rule has been reporting all along -- with its opening condition gone.
-                // cite(RFC 9110 § 15.3.7.1): "If a single part is being transferred, the server generating the 206 response MUST generate a Content-Range header field, describing what range of the selected representation is enclosed, and a content consisting of the range."
+                // Single part: the field is required, and this is the finding the
+                // rule has been reporting all along -- with its opening condition
+                // gone. The sentence asking for it is on the id, which the 416 half
+                // below reports too.
                 let cr = match cr {
                     Some(v) => v,
                     None => {
-                        return Some(self.violation(
-                            config.severity,
+                        return Some(ctx.report_with(
+                            &CONTENT_RANGE_MISSING,
                             "206 Partial Content response missing Content-Range header".into(),
                         ))
                     }
@@ -347,13 +352,13 @@ impl Rule for RangeAndContentRangeConsistent {
                             return None;
                         }
 
-                        // What makes the comparison mean anything: in a 206 the
-                        // Content-Length counts the octets of *this* message's content,
-                        // which for a single part is the enclosed range. A content
-                        // coding does not put the two numbers on different scales --
-                        // byte ranges are calculated over the encoded octets, which are
-                        // the ones being counted here.
-                        // cite(RFC 9110 § 15.3.7): "A Content-Length header field present in a 206 response indicates the number of octets in the content of this message, which is usually not the complete length of the selected representation."
+                        // What makes the comparison mean anything is on the id: in a
+                        // 206 the Content-Length counts the octets of *this* message's
+                        // content, which for a single part is the enclosed range. What
+                        // is quoted here is the half of that the entry does not carry
+                        // -- a content coding does not put the two numbers on different
+                        // scales, because byte ranges are calculated over the encoded
+                        // octets, which are the ones being counted.
                         // cite(RFC 9110 § 14.1.2): "If the representation data has a content coding applied, each byte range is calculated with respect to the encoded sequence of bytes, not the sequence of underlying bytes that would be obtained after decoding."
                         //
                         // The value is read through the field's owner rather than
@@ -369,7 +374,7 @@ impl Rule for RangeAndContentRangeConsistent {
                             Ok(Some(cl_v)) => {
                                 let expected = (last - first) + 1;
                                 if cl_v != expected {
-                                    return Some(self.violation(config.severity, format!("Content-Length ({}) does not match Content-Range length ({})", cl_v, expected)));
+                                    return Some(ctx.report_with(&CONTENT_RANGE_LENGTH_CONFLICTING, format!("Content-Length ({}) does not match Content-Range length ({})", cl_v, expected)));
                                 }
                             }
                             Ok(None) => {}
@@ -380,10 +385,11 @@ impl Rule for RangeAndContentRangeConsistent {
                         // In a 206 the field says which part of the representation is
                         // enclosed; the unsatisfied-range form says only how long the
                         // whole thing is, which is what a 416 has to say and a 206
-                        // never does. The message used to call this form
+                        // never does -- the 416 site below is the same defect written
+                        // from the other end. The message used to call this form
                         // `byte-range-resp-spec`, RFC 7233's name for a production
                         // RFC 9110 splits into `range-resp` and `unsatisfied-range`.
-                        return Some(self.violation(config.severity, "206 response uses the unsatisfied-range form ('*/complete-length'), which describes no enclosed range (that form belongs in a 416)".into()));
+                        return Some(ctx.report_with(&CONTENT_RANGE_FORM_INVALID, "206 response uses the unsatisfied-range form ('*/complete-length'), which describes no enclosed range (that form belongs in a 416)".into()));
                     }
                     Err(e) => {
                         return Some(ctx.report_with(
@@ -428,7 +434,7 @@ impl Rule for RangeAndContentRangeConsistent {
                     // cite(RFC 9110 § 15.5.17): "A server that generates a 416 response to a byte-range request SHOULD generate a Content-Range header field specifying the current length of the selected representation (Section 14.4)."
                     // cite(RFC 9110 § 14.4): "A server generating a 416 (Range Not Satisfiable) response to a byte-range request SHOULD send a Content-Range header field with an unsatisfied-range value, as in the following example:"
                     if requested.as_ref().is_some_and(|(unit, _)| unit == "bytes") {
-                        return Some(self.violation(config.severity, "416 Range Not Satisfiable response to a byte-range request should include a Content-Range header (bytes */<complete-length>)".into()));
+                        return Some(ctx.report_with(&CONTENT_RANGE_MISSING, "416 Range Not Satisfiable response to a byte-range request should include a Content-Range header (bytes */<complete-length>)".into()));
                     }
                     return None;
                 }
@@ -441,11 +447,12 @@ impl Rule for RangeAndContentRangeConsistent {
                         // A 416 encloses no part of the representation, so the only
                         // thing its Content-Range has to say is how long the
                         // representation currently is -- which is the unsatisfied-range
-                        // form and nothing else. This is checked whatever the unit,
-                        // because it is about a field the server chose to send rather
-                        // than about one the spec asked it for.
+                        // form and nothing else -- the 206 site above is this same
+                        // defect with the two forms exchanged. This is checked whatever
+                        // the unit, because it is about a field the server chose to
+                        // send rather than about one the spec asked it for.
                         // cite(RFC 9110 § 14.4): "The complete-length in a 416 response indicates the current length of the selected representation."
-                        return Some(self.cited(&RFC_9110_14_4, config.severity, "416 response should use the '*/complete-length' form in Content-Range"
+                        return Some(ctx.report_with(&CONTENT_RANGE_FORM_INVALID, "416 response should use the '*/complete-length' form in Content-Range"
                                     .into()));
                     }
                     Err(e) => {

--- a/lint-http-rules/src/violations/content_range.rs
+++ b/lint-http-rules/src/violations/content_range.rs
@@ -2,25 +2,35 @@
 //
 // SPDX-License-Identifier: ISC
 
-//! `Content-Range` defects — the eleven ways a server's account of what it sent
-//! is not one.
+//! `Content-Range` defects — the ways a server's account of what it sent is not
+//! one.
 //!
 //! `Content-Range = range-unit SP ( range-resp / unsatisfied-range )`, and the
-//! entries below follow the value left to right the way the parser does: the
-//! field, the unit, the single space, the `/`, the `-`, the numerals, and then
-//! the two conditions that are not grammar at all.
+//! first eleven entries below follow the value left to right the way the parser
+//! does: the field, the unit, the single space, the `/`, the `-`, the numerals,
+//! and then the two conditions that are not grammar at all.
 //!
-//! **Those last two are why this subject has two severities.** § 14.4 writes one
+//! **Those two are why this subject has two severities.** § 14.4 writes one
 //! sentence declaring a value *invalid* when its `last-pos` precedes its
 //! `first-pos`, or when its `complete-length` does not exceed its `last-pos`.
 //! Such a value is well formed by the ABNF; what is wrong with it is that no
 //! representation has the shape it describes, and a cache that recombines on it
-//! writes octets nobody sent. Everything else here is a value a recipient
+//! writes octets nobody sent. Everything else there is a value a recipient
 //! cannot parse — bad, and bad in a way that stops at the parse.
+//!
+//! **The four after them are not read out of the value at all**, and they are
+//! the field's rather than the response's for one reason: § 14.4 gives the
+//! field two meanings, one per status code that describes a semantic for it, so
+//! whether the field is due, prohibited, or written in the wrong one of its two
+//! forms is settled by *this* field's own section. The status code is the
+//! condition; the field is the subject. Where a defect is the status code's
+//! instead — a 206 answering a request that named no range — the entry is in
+//! `violations/status.rs` and the reason is written there.
 
 use crate::helpers::content_range::ContentRangeDefect;
 use crate::lint::Severity;
 use crate::rules::SpecRef;
+use crate::violations::status::RFC_9110_15_3_7;
 use crate::violations::{defects, ViolationDef};
 
 /// The field: its grammar, and the sentence that says which well-formed values
@@ -30,6 +40,24 @@ pub const RFC_9110_14_4: SpecRef = SpecRef {
     section: Some("14.4"),
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.4",
     note: "Content-Range: syntax of `Content-Range` and the semantics for satisfied and unsatisfiable ranges",
+};
+
+/// The MUST that asks a single-part 206 for the field. Its sibling below is the
+/// MUST NOT that refuses the same field to a multipart one: two subsections of
+/// one status code, wanting opposite things of the same header section.
+pub const RFC_9110_15_3_7_1: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.3.7.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7.1",
+    note: "206 Partial Content, single part: the response MUST carry a `Content-Range` describing the enclosed range",
+};
+
+/// The other half: where the parts carry the field, the header section may not.
+pub const RFC_9110_15_3_7_2: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.3.7.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7.2",
+    note: "206 Partial Content, multiple parts: the parts carry the `Content-Range` fields and the header section MUST NOT carry one; a request for a single range MUST NOT be answered with a multipart response",
 };
 
 /// Range units: what the name at the front of the value has to be.
@@ -193,6 +221,95 @@ defects! {
         default_severity: Severity::Error,
         spec: Some(RFC_9110_14_4),
     }
+
+    /// A response that has a range to describe and no field describing it: a
+    /// single-part 206, or a 416 answering a byte-range request. The client is
+    /// told to read this field to learn what it was sent, and there is nothing
+    /// to read.
+    ///
+    /// **One entry for a MUST and a SHOULD**, which is a decision. § 15.3.7.1
+    /// requires the field of a single-part 206 and § 15.5.17 recommends it of a
+    /// 416 to a byte-range request; the sender's fix differs only in which of
+    /// the field's two forms to write, and an operator silencing "the field
+    /// that describes the range is absent" means both. What follows is that the
+    /// entry **defaults to the weaker of the two sentences**: raising it would
+    /// raise the SHOULD half with the MUST half, and a recommendation is not an
+    /// error because it shares an id with a requirement.
+    ///
+    /// The 416 half is reported for byte ranges only — both sentences asking
+    /// for the field there say so — which is a condition at the site rather
+    /// than a second defect.
+    ///
+    // cite(RFC 9110 § 15.3.7.1): "If a single part is being transferred, the server generating the 206 response MUST generate a Content-Range header field, describing what range of the selected representation is enclosed, and a content consisting of the range."
+    CONTENT_RANGE_MISSING = {
+        id: "content_range_missing",
+        title: "Content-Range is absent from a response whose range it would describe",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_15_3_7_1),
+    }
+
+    /// The field written in the header section of a multipart 206, where each
+    /// body part carries its own. Nothing is wrong with the value; what is
+    /// wrong is that it is there, and § 15.3.7.2 says why in the sentence
+    /// itself — a client reading it would take the response for a single part
+    /// and the first range for the whole of what was sent.
+    ///
+    // cite(RFC 9110 § 15.3.7.2): "To avoid confusion with single-part responses, a server MUST NOT generate a Content-Range header field in the HTTP header section of a multiple part response (this field will be sent in each part instead)."
+    CONTENT_RANGE_FORBIDDEN = {
+        id: "content_range_forbidden",
+        title: "Content-Range is written in the header section of a multipart 206",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_15_3_7_2),
+    }
+
+    /// The wrong one of the field's two forms for the status carrying it. A 206
+    /// encloses a part and says which one, so `*/complete-length` — which
+    /// describes no enclosed range — says nothing a 206 has to say; a 416
+    /// encloses nothing, so `first-pos-last-pos/complete-length` describes a
+    /// part that is not there.
+    ///
+    /// `_invalid` rather than `_malformed`: both values are well formed, and
+    /// both are the *other* status code's form. One entry for the two
+    /// directions, because the quoted sentence states both meanings at once and
+    /// the defect is the same one read from either end — the form and the
+    /// status do not describe the same message.
+    ///
+    // cite(RFC 9110 § 14.4): "The "Content-Range" header field is sent in a single part 206 (Partial Content) response to indicate the partial range of the selected representation enclosed as the message content, sent in each part of a multipart 206 response to indicate the range enclosed within each body part (Section 14.6), and sent in 416 (Range Not Satisfiable) responses to provide information about the selected representation."
+    CONTENT_RANGE_FORM_INVALID = {
+        id: "content_range_form_invalid",
+        title: "Content-Range uses the form belonging to the other status code",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_14_4),
+    }
+
+    /// The range described and the length declared are not the same number of
+    /// octets. In a 206 the `Content-Length` counts the content of *this*
+    /// message, which for a single part is exactly the enclosed range, so
+    /// `last-pos - first-pos + 1` and the declared length are two statements of
+    /// one count.
+    ///
+    /// **Which of the two is wrong is not knowable here**, and that is what
+    /// keeps this entry at `warn` while `content_length_conflicting` — the same
+    /// disagreement measured against the octets that actually arrived — is an
+    /// `error`. That one knows what came; this one has two claims and no
+    /// evidence between them.
+    ///
+    /// Only for units whose positions count octets, which is `bytes` and
+    /// whatever else the reading rule's operator has asserted the same of. For
+    /// any other unit there is no equation to write down, so there is no defect
+    /// to name.
+    ///
+    // cite(RFC 9110 § 15.3.7): "A Content-Length header field present in a 206 response indicates the number of octets in the content of this message, which is usually not the complete length of the selected representation."
+    CONTENT_RANGE_LENGTH_CONFLICTING = {
+        id: "content_range_length_conflicting",
+        title: "Content-Range describes a range that is not the declared Content-Length",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_15_3_7),
+    }
 }
 
 /// The defect a parsed [`ContentRangeDefect`] reports as.
@@ -284,6 +401,30 @@ mod tests {
         ] {
             assert_eq!(content_range_defect(defect).id, id);
         }
+    }
+
+    /// Two fields disagreeing ranks below one field disagreeing with the octets
+    /// that arrived. `content_length_conflicting` is measured against the body
+    /// and knows which claim is wrong; this one holds two claims and nothing to
+    /// decide between them, so it advises where the other one condemns.
+    #[test]
+    fn a_disagreement_with_no_evidence_ranks_below_one_with_some() {
+        assert_eq!(
+            CONTENT_RANGE_LENGTH_CONFLICTING.default_severity,
+            Severity::Warn
+        );
+        assert_eq!(
+            crate::violations::content_length::CONTENT_LENGTH_CONFLICTING.default_severity,
+            Severity::Error,
+        );
+    }
+
+    /// An id shared by a MUST site and a SHOULD site defaults to the weaker of
+    /// the two: the 206 half of `content_range_missing` is required and the 416
+    /// half recommended, and an operator raising the entry would raise both.
+    #[test]
+    fn the_entry_two_sentences_share_defaults_to_the_weaker_one() {
+        assert_eq!(CONTENT_RANGE_MISSING.default_severity, Severity::Warn);
     }
 
     /// The two conditions § 14.4 calls *invalid* rank above the ones a parser

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -387,7 +387,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 159;
+        const FLOOR: usize = 163;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -5712,6 +5712,30 @@ sources:
       line: 282
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
       line: 328
+  - label: content_range
+    section: § 14.4
+    snippet: The "Content-Range" header field is sent in a single part 206 (Partial Content) response to indicate the partial range of the selected representation enclosed as the message content, sent in each part of a multipart 206 response to indicate the range enclosed within each body part (Section 14.6), and sent in 416 (Range Not Satisfiable) responses to provide information about the selected representation.
+    cited_by:
+    - file: lint-http-rules/src/violations/content_range.rs
+      line: 279
+  - label: content_range (2)
+    section: § 15.3.7
+    snippet: A Content-Length header field present in a 206 response indicates the number of octets in the content of this message, which is usually not the complete length of the selected representation.
+    cited_by:
+    - file: lint-http-rules/src/violations/content_range.rs
+      line: 305
+  - label: content_range (3)
+    section: § 15.3.7.1
+    snippet: If a single part is being transferred, the server generating the 206 response MUST generate a Content-Range header field, describing what range of the selected representation is enclosed, and a content consisting of the range.
+    cited_by:
+    - file: lint-http-rules/src/violations/content_range.rs
+      line: 243
+  - label: content_range (4)
+    section: § 15.3.7.2
+    snippet: To avoid confusion with single-part responses, a server MUST NOT generate a Content-Range header field in the HTTP header section of a multiple part response (this field will be sent in each part instead).
+    cited_by:
+    - file: lint-http-rules/src/violations/content_range.rs
+      line: 258
   - label: content_type_present
     section: § 15.3.6
     snippet: Since the 205 status code implies that no additional content will be provided, a server MUST NOT generate content in a 205 response.
@@ -6503,11 +6527,11 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 371
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 95
+      line: 107
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 293
     - file: lint-http-rules/src/violations/content_range.rs
-      line: 69
+      line: 97
   - label: lint-http-rules/src/helpers/accept_ranges.rs (2)
     section: § 14.1
     snippet: Range units are intended to be extensible, as described in Section 16.5.
@@ -6555,7 +6579,7 @@ sources:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 358
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 295
+      line: 299
     - file: lint-http-rules/src/rules/status_code_semantics.rs
       line: 16
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -6837,7 +6861,7 @@ sources:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 458
     - file: lint-http-rules/src/violations/content_range.rs
-      line: 158
+      line: 186
   - label: lint-http-rules/src/helpers/content_range.rs (4)
     section: § 14.4
     snippet: A Content-Range field value is invalid if it contains a range-resp that has a last-pos value less than its first-pos value, or a complete-length value less than or equal to its last-pos value.
@@ -6847,9 +6871,9 @@ sources:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 299
     - file: lint-http-rules/src/violations/content_range.rs
-      line: 173
+      line: 201
     - file: lint-http-rules/src/violations/content_range.rs
-      line: 188
+      line: 216
   - label: Content-Range grammar
     section: § 14.4
     snippet: Content-Range = range-unit SP ( range-resp / unsatisfied-range )
@@ -6859,11 +6883,11 @@ sources:
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 47
     - file: lint-http-rules/src/violations/content_range.rs
-      line: 56
+      line: 84
     - file: lint-http-rules/src/violations/content_range.rs
-      line: 81
+      line: 109
     - file: lint-http-rules/src/violations/content_range.rs
-      line: 93
+      line: 121
   - label: lint-http-rules/src/helpers/content_range.rs (5)
     section: § 14.4
     snippet: complete-length = 1*DIGIT
@@ -6873,7 +6897,7 @@ sources:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 337
     - file: lint-http-rules/src/violations/content_range.rs
-      line: 142
+      line: 170
   - label: lint-http-rules/src/helpers/content_range.rs (6)
     section: § 14.4
     snippet: incl-range = first-pos "-" last-pos
@@ -6881,7 +6905,7 @@ sources:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 268
     - file: lint-http-rules/src/violations/content_range.rs
-      line: 130
+      line: 158
   - label: lint-http-rules/src/helpers/content_range.rs (7)
     section: § 14.4
     snippet: range-resp = incl-range "/" ( complete-length / "*" )
@@ -6889,7 +6913,7 @@ sources:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 267
     - file: lint-http-rules/src/violations/content_range.rs
-      line: 104
+      line: 132
   - label: lint-http-rules/src/helpers/content_range.rs (8)
     section: § 14.4
     snippet: unsatisfied-range = "*/" complete-length
@@ -6897,7 +6921,7 @@ sources:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 251
     - file: lint-http-rules/src/violations/content_range.rs
-      line: 117
+      line: 145
   - label: lint-http-rules/src/helpers/content_range.rs (9)
     section: § 5.5
     snippet: A field value does not include leading or trailing whitespace.
@@ -7379,7 +7403,7 @@ sources:
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
       line: 164
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 114
+      line: 126
   - label: lint-http-rules/src/helpers/media_type.rs (6)
     section: § 8.3.1
     snippet: The type/subtype MAY be followed by semicolon-delimited parameters (Section 5.6.6) in the form of name/value pairs.
@@ -8093,91 +8117,67 @@ sources:
     snippet: If the representation data has a content coding applied, each byte range is calculated with respect to the encoded sequence of bytes, not the sequence of underlying bytes that would be obtained after decoding.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 357
+      line: 362
   - label: range_and_content_range_consistent (2)
     section: § 14.1.2
     snippet: The first-pos value in a bytes int-range gives the offset of the first byte in a range.  The last-pos value gives the offset of the last byte in the range; that is, the byte positions specified are inclusive.  Byte offsets start at zero.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 344
+      line: 349
   - label: range_and_content_range_consistent (3)
     section: § 14.4
     snippet: 'A server generating a 416 (Range Not Satisfiable) response to a byte-range request SHOULD send a Content-Range header field with an unsatisfied-range value, as in the following example:'
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 429
+      line: 435
   - label: range_and_content_range_consistent (4)
     section: § 14.4
     snippet: If a 206 (Partial Content) response contains a Content-Range header field with a range unit (Section 14.1) that the recipient does not understand, the recipient MUST NOT attempt to recombine it with a stored representation.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 345
+      line: 350
   - label: range_and_content_range_consistent (5)
-    section: § 14.4
-    snippet: The "Content-Range" header field is sent in a single part 206 (Partial Content) response to indicate the partial range of the selected representation enclosed as the message content, sent in each part of a multipart 206 response to indicate the range enclosed within each body part (Section 14.6), and sent in 416 (Range Not Satisfiable) responses to provide information about the selected representation.
-    cited_by:
-    - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 269
-  - label: range_and_content_range_consistent (6)
     section: § 14.4
     snippet: The Content-Range header field has no meaning for status codes that do not explicitly describe its semantic.  For this specification, only the 206 (Partial Content) and 416 (Range Not Satisfiable) status codes describe a meaning for Content-Range.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 233
-  - label: range_and_content_range_consistent (7)
+      line: 236
+  - label: range_and_content_range_consistent (6)
     section: § 14.4
     snippet: The complete-length in a 416 response indicates the current length of the selected representation.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 447
-  - label: range_and_content_range_consistent (8)
+      line: 454
+  - label: range_and_content_range_consistent (7)
     section: § 14.5
     snippet: Some origin servers support PUT of a partial representation when the user agent sends a Content-Range header field (Section 14.4) in the request, though such support is inconsistent and depends on private agreements with user agents.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 413
-  - label: range_and_content_range_consistent (9)
-    section: § 15.3.7
-    snippet: A Content-Length header field present in a 206 response indicates the number of octets in the content of this message, which is usually not the complete length of the selected representation.
-    cited_by:
-    - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 356
-  - label: range_and_content_range_consistent (10)
-    section: § 15.3.7.1
-    snippet: If a single part is being transferred, the server generating the 206 response MUST generate a Content-Range header field, describing what range of the selected representation is enclosed, and a content consisting of the range.
-    cited_by:
-    - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 313
-  - label: range_and_content_range_consistent (11)
+      line: 419
+  - label: range_and_content_range_consistent (8)
     section: § 15.3.7.2
     snippet: A server MUST NOT generate a multipart response to a request for a single range, since a client that does not request multiple parts might not support multipart responses.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 294
-  - label: range_and_content_range_consistent (12)
+      line: 298
+  - label: range_and_content_range_consistent (9)
     section: § 15.3.7.2
     snippet: If multiple parts are being transferred, the server generating the 206 response MUST generate "multipart/byteranges" content, as defined in Section 14.6, and a Content-Type header field containing the "multipart/byteranges" media type and its required boundary parameter.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 280
-  - label: range_and_content_range_consistent (13)
-    section: § 15.3.7.2
-    snippet: To avoid confusion with single-part responses, a server MUST NOT generate a Content-Range header field in the HTTP header section of a multiple part response (this field will be sent in each part instead).
-    cited_by:
-    - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 282
-  - label: range_and_content_range_consistent (14)
+      line: 285
+  - label: range_and_content_range_consistent (10)
     section: § 15.3.7.2
     snippet: Within the header area of each body part in the multipart content, the server MUST generate a Content-Range header field corresponding to the range being enclosed in that body part.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 307
-  - label: range_and_content_range_consistent (15)
+      line: 311
+  - label: range_and_content_range_consistent (11)
     section: § 15.5.17
     snippet: A server that generates a 416 response to a byte-range request SHOULD generate a Content-Range header field specifying the current length of the selected representation (Section 14.4).
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 428
+      line: 434
   - label: range_header_syntax
     section: § 14.1.1
     snippet: A ranges-specifier is invalid if it contains any range-spec that is invalid or undefined for the indicated range-unit.


### PR DESCRIPTION
Four findings the pairing rule had been wording itself become the field's own: the field absent where a response has a range to describe, written where each body part carries its own, written in the form belonging to the other status code, and describing a length its neighbour declares differently.

The status code is the condition and the field is the subject, because §14.4 gives the field one meaning per status that describes a semantic for it. Two decisions come with that. One id covers a MUST site and a SHOULD site, and defaults to the weaker: raising it would raise both. And two fields disagreeing ranks below one field disagreeing with the octets that arrived, since this comparison has two claims and nothing to decide between them.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
