### PR TITLE
A multipart answer to a single-range ask

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1607,6 +1607,10 @@ severity = "warn"
 # Weight is not a qvalue
 severity = "warn"
 
+[violations.status_206_multipart_forbidden]
+# A multipart 206 answers a request that asked for a single range
+severity = "warn"
+
 [violations.status_206_unsolicited]
 # 206 Partial Content answers a request that asked for no range
 severity = "warn"

--- a/lint-http-rules/src/rules/range_and_content_range_consistent.rs
+++ b/lint-http-rules/src/rules/range_and_content_range_consistent.rs
@@ -15,7 +15,8 @@ use crate::violations::content_range::{
     RFC_9110_15_3_7_1, RFC_9110_15_3_7_2,
 };
 use crate::violations::status::{
-    RFC_9110_15_3_7, RFC_9110_15_5_17, STATUS_206_UNSOLICITED, STATUS_416_UNSOLICITED,
+    RFC_9110_15_3_7, RFC_9110_15_5_17, STATUS_206_MULTIPART_FORBIDDEN, STATUS_206_UNSOLICITED,
+    STATUS_416_UNSOLICITED,
 };
 use crate::violations::ViolationDef;
 
@@ -33,16 +34,17 @@ pub struct RangeAndContentRangeConsistent;
 /// per status code that describes a semantic for it, so the status is the
 /// condition and the field stays the subject.
 ///
-/// The last two are not a field's at all. A 206 and a 416 are each defined in
-/// terms of the request's `Range`, so one sent where that field was never
-/// written describes an exchange that did not happen — the status code is the
-/// subject, and both fields it is read against are blameless.
-///
-/// What is left unconverted is one site: a multipart response to a request for
-/// a single range, which is a claim about neither field.
+/// The last three are not a field's at all, and the rule declares nothing
+/// outside these three groups. A 206 and a 416 are each defined in terms of the
+/// request's `Range`, so one sent where that field was never written describes
+/// an exchange that did not happen; a multipart 206 answering a request for one
+/// range is a response the client asked for and may be unable to read. All
+/// three are the status code's — every one of them is read out of the request
+/// and the response at once, and neither range field is at fault in any.
 static DECLARED: &[&ViolationDef] = &[
     &STATUS_206_UNSOLICITED,
     &STATUS_416_UNSOLICITED,
+    &STATUS_206_MULTIPART_FORBIDDEN,
     &CONTENT_RANGE_MISSING,
     &CONTENT_RANGE_FORBIDDEN,
     &CONTENT_RANGE_FORM_INVALID,
@@ -295,14 +297,12 @@ impl Rule for RangeAndContentRangeConsistent {
                     // the shared list splitter is the one that counts them -- and a
                     // `Range` this rule could not split into a specifier leaves
                     // `requested` empty, which reports nothing.
-                    // cite(RFC 9110 § 15.3.7.2): "A server MUST NOT generate a multipart response to a request for a single range, since a client that does not request multiple parts might not support multipart responses."
                     // cite(RFC 9110 § 5.6.1.2): "Empty elements do not contribute to the count of elements present."
                     let requested_ranges = requested
                         .as_ref()
                         .map(|(_, set)| crate::helpers::list::list_members(set).count());
                     if requested_ranges == Some(1) {
-                        return Some(self.violation(config.severity, "multipart/byteranges 206 response sent to a request for a single range"
-                                    .into()));
+                        return Some(ctx.report(&STATUS_206_MULTIPART_FORBIDDEN));
                     }
 
                     // Each part's own Content-Range is in the message content, which

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -387,7 +387,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 163;
+        const FLOOR: usize = 164;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/status.rs
+++ b/lint-http-rules/src/violations/status.rs
@@ -8,26 +8,31 @@
 //! **The subject is the status code**, which is neither a field nor a
 //! production: it is the response's own control data, and a status code that
 //! contradicts its request is wrong in a way no field on either message is.
-//! Both entries below are read out of *two* messages — the status the server
-//! sent and the field the client did not — which is what separates them from
-//! every other subject in this catalogue, where the defect is visible inside
-//! one message.
+//! Every entry below is read out of *two* messages — what the server sent and
+//! what the client asked for — which is what separates this subject from every
+//! other one in this catalogue, where the defect is visible inside one message.
 //!
-//! **What the entries have in common is the word that names them.** A status
-//! code whose definition is written in terms of a request field says that
-//! field arrived; where it did not, nothing is malformed, nothing is
-//! prohibited, and nothing was done twice — the server answered a question
-//! nobody asked. `_unsolicited` is the ending for that, and
-//! `docs/development.md` carries the argument for it beside the rest of the
-//! closed vocabulary.
+//! **The first two share the word that names them.** A status code whose
+//! definition is written in terms of a request field says that field arrived;
+//! where it did not, nothing is malformed, nothing is prohibited, and nothing
+//! was done twice — the server answered a question nobody asked.
+//! `_unsolicited` is the ending for that, and `docs/development.md` carries the
+//! argument for it beside the rest of the closed vocabulary.
 //!
-//! Both default to `warn`, which is the severity the rule reporting them had
-//! already chosen for itself: a client that asked for no part of a
-//! representation and is handed one has to notice that on its own, and the
-//! documents describe the status codes rather than forbidding them here.
+//! **The third is the same subject and a different word**, which is what keeps
+//! the first two honest: a multipart 206 answering a single-range request is a
+//! MUST NOT written out, about a response the client did invite. Where a
+//! sentence prohibits the message, the entry is `_forbidden`; `_unsolicited` is
+//! for the ones no sentence prohibits and the exchange refutes.
+//!
+//! All three default to `warn`, which is the severity the rule reporting them
+//! had already chosen for itself: a client handed a response it did not ask
+//! for, or cannot parse, has to notice that on its own, and only one of the
+//! three documents a prohibition.
 
 use crate::lint::Severity;
 use crate::rules::SpecRef;
+use crate::violations::content_range::RFC_9110_15_3_7_2;
 use crate::violations::defects;
 
 /// What a 206 says it is doing, and the field a single-part one has to carry
@@ -89,6 +94,33 @@ defects! {
         default_severity: Severity::Warn,
         spec: Some(RFC_9110_15_5_17),
     }
+
+    /// A 206 in its multipart form, answering a request that asked for one
+    /// range. The status is right and the request did ask for something — what
+    /// is prohibited is the *form*, and the sentence gives the reason with the
+    /// prohibition: a client that did not ask for multiple parts might have no
+    /// way to read them, so a response it cannot parse is what it gets for
+    /// asking correctly.
+    ///
+    /// `_forbidden` rather than `_unsolicited`, and the difference is worth
+    /// keeping straight beside its neighbours: those two entries are a status
+    /// code answering a request that named no range at all, with no sentence
+    /// prohibiting them; this one is a MUST NOT, written out, about a message
+    /// the client did invite.
+    ///
+    /// The section is `Content-Range`'s as well — § 15.3.7.2 states two
+    /// prohibitions, one about the field in the header section and one about
+    /// the response's form — and the [`SpecRef`] sits beside the entry that was
+    /// written first.
+    ///
+    // cite(RFC 9110 § 15.3.7.2): "A server MUST NOT generate a multipart response to a request for a single range, since a client that does not request multiple parts might not support multipart responses."
+    STATUS_206_MULTIPART_FORBIDDEN = {
+        id: "status_206_multipart_forbidden",
+        title: "A multipart 206 answers a request that asked for a single range",
+        message: "multipart/byteranges 206 response sent to a request for a single range",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_15_3_7_2),
+    }
 }
 
 #[cfg(test)]
@@ -101,19 +133,40 @@ mod tests {
     /// sent where nothing invited it — not anything about a range field.
     #[test]
     fn each_id_names_the_status_and_not_the_field_it_is_read_against() {
-        for def in [&STATUS_206_UNSOLICITED, &STATUS_416_UNSOLICITED] {
+        for def in [
+            &STATUS_206_UNSOLICITED,
+            &STATUS_416_UNSOLICITED,
+            &STATUS_206_MULTIPART_FORBIDDEN,
+        ] {
             assert!(def.id.starts_with("status_"), "{} is not a status", def.id);
             assert!(!def.id.contains("range"), "{} names a field", def.id);
         }
     }
 
-    /// Both entries carry their whole message, which is the shape of the defect
-    /// rather than a convenience: what is wrong is that a field is *absent*, so
-    /// there is no value the site could interpolate and no wording that varies
-    /// between one finding and the next.
+    /// The two words this subject uses are not interchangeable: a sentence
+    /// prohibiting the message makes the entry `_forbidden`, and `_unsolicited`
+    /// is for the ones no sentence prohibits — where what refutes the message is
+    /// the request it answers.
     #[test]
-    fn neither_entry_leaves_its_message_to_the_site() {
+    fn only_the_entry_a_sentence_prohibits_is_the_forbidden_one() {
+        assert!(STATUS_206_MULTIPART_FORBIDDEN.id.ends_with("_forbidden"));
         for def in [&STATUS_206_UNSOLICITED, &STATUS_416_UNSOLICITED] {
+            assert!(def.id.ends_with("_unsolicited"), "{}", def.id);
+        }
+    }
+
+    /// Every entry carries its whole message, which is the shape of the defect
+    /// rather than a convenience: what is wrong here is the pairing of two
+    /// messages and never a value one of them wrote, so there is nothing for a
+    /// site to interpolate and no wording that varies between one finding and
+    /// the next.
+    #[test]
+    fn no_entry_leaves_its_message_to_the_site() {
+        for def in [
+            &STATUS_206_UNSOLICITED,
+            &STATUS_416_UNSOLICITED,
+            &STATUS_206_MULTIPART_FORBIDDEN,
+        ] {
             assert!(!def.message.is_empty(), "{} holds no message", def.id);
         }
     }

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -5121,7 +5121,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
       line: 118
     - file: lint-http-rules/src/violations/status.rs
-      line: 64
+      line: 69
   - label: accept_ranges_on_partial_content
     section: § 14.2
     snippet: A server MUST ignore a Range header field received with a request method that is unrecognized or for which range handling is not defined.
@@ -6527,7 +6527,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 371
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 107
+      line: 109
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 293
     - file: lint-http-rules/src/violations/content_range.rs
@@ -6579,7 +6579,7 @@ sources:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 358
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 299
+      line: 300
     - file: lint-http-rules/src/rules/status_code_semantics.rs
       line: 16
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -7403,7 +7403,7 @@ sources:
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
       line: 164
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 126
+      line: 128
   - label: lint-http-rules/src/helpers/media_type.rs (6)
     section: § 8.3.1
     snippet: The type/subtype MAY be followed by semicolon-delimited parameters (Section 5.6.6) in the form of name/value pairs.
@@ -8141,7 +8141,7 @@ sources:
     snippet: The Content-Range header field has no meaning for status codes that do not explicitly describe its semantic.  For this specification, only the 206 (Partial Content) and 416 (Range Not Satisfiable) status codes describe a meaning for Content-Range.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 236
+      line: 238
   - label: range_and_content_range_consistent (6)
     section: § 14.4
     snippet: The complete-length in a 416 response indicates the current length of the selected representation.
@@ -8156,23 +8156,17 @@ sources:
       line: 419
   - label: range_and_content_range_consistent (8)
     section: § 15.3.7.2
-    snippet: A server MUST NOT generate a multipart response to a request for a single range, since a client that does not request multiple parts might not support multipart responses.
-    cited_by:
-    - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 298
-  - label: range_and_content_range_consistent (9)
-    section: § 15.3.7.2
     snippet: If multiple parts are being transferred, the server generating the 206 response MUST generate "multipart/byteranges" content, as defined in Section 14.6, and a Content-Type header field containing the "multipart/byteranges" media type and its required boundary parameter.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 285
-  - label: range_and_content_range_consistent (10)
+      line: 287
+  - label: range_and_content_range_consistent (9)
     section: § 15.3.7.2
     snippet: Within the header area of each body part in the multipart content, the server MUST generate a Content-Range header field corresponding to the range being enclosed in that body part.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
       line: 311
-  - label: range_and_content_range_consistent (11)
+  - label: range_and_content_range_consistent (10)
     section: § 15.5.17
     snippet: A server that generates a 416 response to a byte-range request SHOULD generate a Content-Range header field specifying the current length of the selected representation (Section 14.4).
     cited_by:
@@ -8715,11 +8709,17 @@ sources:
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 43
   - label: status
+    section: § 15.3.7.2
+    snippet: A server MUST NOT generate a multipart response to a request for a single range, since a client that does not request multiple parts might not support multipart responses.
+    cited_by:
+    - file: lint-http-rules/src/violations/status.rs
+      line: 116
+  - label: status (2)
     section: § 15.5.17
     snippet: The 416 (Range Not Satisfiable) status code indicates that the set of ranges in the request's Range header field (Section 14.2) has been rejected either because none of the requested ranges are satisfiable or because the client has requested an excessive number of small or overlapping ranges (a potential denial of service attack).
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 84
+      line: 89
   - label: status_101_switching_protocols
     section: § 15.2.2
     snippet: The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field (Section 7.8), for a change in the application protocol being used on this connection.


### PR DESCRIPTION
The last site of the pairing rule becomes the status code's third entry: a 206 in its multipart form, answering a request that asked for one range. The status is right and the client did invite the response — what is prohibited is the form, because a client that asked for one part might have no way to read several.

_forbidden and not _unsolicited, which is the distinction that keeps both words usable: a sentence prohibiting the message makes the first, and the second is for the ones no sentence prohibits and the request refutes.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
