### PR TITLE
A field that landed on the wrong side

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1379,6 +1379,14 @@ severity = "warn"
 # Field name is not one the deployment expects
 severity = "warn"
 
+[violations.field_request_context_misdirected]
+# A request context field is written in a response
+severity = "info"
+
+[violations.field_response_context_misdirected]
+# A response context field is written in a request
+severity = "info"
+
 [violations.http_date_malformed]
 # Timestamp derives from no HTTP-date format
 severity = "warn"

--- a/docs/development.md
+++ b/docs/development.md
@@ -125,6 +125,7 @@ member is malformed".
 | Written where the specification prohibits it | `_forbidden` | — |
 | Permitted, and almost certainly not what was meant | `_redundant` | — |
 | Sent in answer to something the other side never asked for | `_unsolicited` | — |
+| Sent in the direction its definition does not describe | `_misdirected` | — |
 | Retired by a later specification | `_obsolete` | — |
 
 `_redundant` is the one ending that condemns nothing: it names work a message
@@ -143,6 +144,15 @@ code; not `_invalid`, since no value is being measured past its grammar; and not
 status code's definition is written in terms of a request that did not happen. A
 rule reporting one of these has to read both messages, which is why the subject
 is the status code and never the field it is read against.
+
+`_misdirected` is the ending for a field that landed on the wrong side of the
+exchange. RFC 9110 §10 sorts nine fields into the ones that say something about
+a request and the ones that say something about a response, and attaches no
+keyword to either arrival — so a `Server` in a request is not `_forbidden`, and
+the line is too well formed to be `_invalid`. What is wrong is that it states
+nothing where it was sent. Entries ending this way default to `info`, and the
+ending is deliberately narrower than "in the wrong place": a field a sentence
+prohibits somewhere is `_forbidden` there, whichever direction it was going.
 
 `_missing` and `_empty` are not alternatives to pick between: `_missing` is a
 sender that never wrote the thing, `_empty` is a sender that wrote it and put

--- a/docs/rules/context_fields_direction.md
+++ b/docs/rules/context_fields_direction.md
@@ -22,8 +22,8 @@ Reports a message context field arriving in the direction it is not defined for:
 
 ## Specifications
 
-- [RFC 9110 §10.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1): Request Context Fields — the five fields whose subjects are the user, user agent and resource behind a request; the section split this rule reads the direction from
-- [RFC 9110 §10.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2): Response Context Fields — the four whose subjects are the server, the target resource and related resources. No sentence in either section forbids the misdirection, which is why the finding is advice
+- [RFC 9110 §10.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1): Request Context Fields — the five fields whose subjects are the user, user agent and resource behind a request; the section split the direction is read from
+- [RFC 9110 §10.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2): Response Context Fields — the four whose subjects are the server, the target resource and related resources. No sentence in either section forbids the misdirection, which is why both entries are advice
 
 ## Configuration
 

--- a/docs/rules/te_header_valid.md
+++ b/docs/rules/te_header_valid.md
@@ -24,7 +24,7 @@ Scope: this rule reads a request's header section, and a response's only to repo
 
 - [RFC 9110 §5.6.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3): Whitespace — `BWS` is printed where a grammar allows optional whitespace for historical reasons only, with a MUST NOT on the sender and a matching MUST on the recipient to remove it before interpreting the element
 - [RFC 9110 §10.1.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.4): The field: what a member is, the grammar of its parameters, and the connection option a sender of TE must send beside it
-- [RFC 9110 §10.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1): The section the field is defined in — request context fields. It is the whole of the ground for reporting a TE in a response, and it carries no modal
+- [RFC 9110 §10.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1): Request Context Fields — the five fields whose subjects are the user, user agent and resource behind a request; the section split the direction is read from
 - [RFC 9110 §A](https://www.rfc-editor.org/rfc/rfc9110.html#appendix-A): The collected grammar, where the list construct is expanded for a sender — the form that shows both that the whole value may be empty and that a member may not
 - [RFC 9110 §12.4.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-12.4.2): Quality Values — `weight = OWS ";" OWS "q=" qvalue`, the `qvalue` production and its three-digit fraction, the case-insensitive `q` parameter name, and what a weight of zero means
 - [RFC 9110 §5.6.1.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1): The list construct — `1#element => element *( OWS "," OWS element )`, and the sender's MUST NOT against an empty element

--- a/lint-http-rules/src/rules/context_fields_direction.rs
+++ b/lint-http-rules/src/rules/context_fields_direction.rs
@@ -4,8 +4,22 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::field::{
+    FIELD_REQUEST_CONTEXT_MISDIRECTED, FIELD_RESPONSE_CONTEXT_MISDIRECTED, RFC_9110_10_1,
+    RFC_9110_10_2,
+};
+use crate::violations::ViolationDef;
 
 pub struct ContextFieldsDirection;
+
+/// The two defects, one per direction. They are the *field line's* rather than
+/// this rule's: the claim is about where a line landed and never about the
+/// value on it, which is the whole of the `field` subject — and `te_header_valid`
+/// reports the first of them for its own field from the other end.
+static DECLARED: &[&ViolationDef] = &[
+    &FIELD_REQUEST_CONTEXT_MISDIRECTED,
+    &FIELD_RESPONSE_CONTEXT_MISDIRECTED,
+];
 
 /// RFC 9110 § 10.1's five request context fields, each with the subject its
 /// own section gives it — the clause the finding prints, so the report says
@@ -66,26 +80,6 @@ const RESPONSE_CONTEXT_FIELDS: &[(&str, &str)] = &[
     ),
 ];
 
-/// The specification references this rule declares, each named so a finding
-/// site can cite the one it enforces. `specifications()` below is built from
-/// exactly these, so the docs and the citations cannot name different text.
-const RFC_9110_10_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("10.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1",
-    note: "Request Context Fields — the five fields whose subjects are the user, \
-           user agent and resource behind a request; the section split this rule \
-           reads the direction from",
-};
-const RFC_9110_10_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("10.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2",
-    note: "Response Context Fields — the four whose subjects are the server, the \
-           target resource and related resources. No sentence in either section \
-           forbids the misdirection, which is why the finding is advice",
-};
-
 impl RuleMeta for ContextFieldsDirection {
     fn id(&self) -> &'static str {
         "context_fields_direction"
@@ -143,6 +137,10 @@ severity = "info"
         &[RFC_9110_10_1, RFC_9110_10_2]
     }
 
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
+    }
+
     fn examples(&self) -> &'static [crate::rules::Example] {
         use crate::rules::{Compliance, Example};
         &[
@@ -183,13 +181,14 @@ impl Rule for ContextFieldsDirection {
             // in a response. Each table is probed against the *other* direction
             // only — in its own direction the field is what its section says it
             // is, and its value is its own rule's question.
-            let message = misdirected(
+            let (def, message) = misdirected(
                 &tx.request.headers,
                 RESPONSE_CONTEXT_FIELDS,
                 "Request",
                 "response context field",
                 "a request",
             )
+            .map(|message| (&FIELD_RESPONSE_CONTEXT_MISDIRECTED, message))
             .or_else(|| {
                 tx.response.as_ref().and_then(|resp| {
                     misdirected(
@@ -199,10 +198,11 @@ impl Rule for ContextFieldsDirection {
                         "request context field",
                         "a response",
                     )
+                    .map(|message| (&FIELD_REQUEST_CONTEXT_MISDIRECTED, message))
                 })
             })?;
 
-            Some(self.violation(ctx.severity, message))
+            Some(ctx.report_with(def, message))
         };
         Vec::from_iter(finding())
     }

--- a/lint-http-rules/src/rules/te_header_valid.rs
+++ b/lint-http-rules/src/rules/te_header_valid.rs
@@ -9,6 +9,7 @@ use crate::helpers::qvalue::valid_qvalue;
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
 use crate::violations::bws::{BWS_FORBIDDEN, RFC_9110_5_6_3};
+use crate::violations::field::{FIELD_REQUEST_CONTEXT_MISDIRECTED, RFC_9110_10_1};
 use crate::violations::list::{LIST_MEMBER_EMPTY, RFC_9110_5_6_1_1};
 use crate::violations::parameter::{
     PARAMETER_EQUALS_MISSING, PARAMETER_VALUE_EMPTY, RFC_9110_5_6_6,
@@ -43,6 +44,7 @@ use crate::violations::ViolationDef;
 /// of their own.
 static DECLARED: &[&ViolationDef] = &[
     &BWS_FORBIDDEN,
+    &FIELD_REQUEST_CONTEXT_MISDIRECTED,
     &QVALUE_MALFORMED,
     &LIST_MEMBER_EMPTY,
     &PARAMETER_EQUALS_MISSING,
@@ -406,12 +408,6 @@ const RFC_9110_10_1_4: crate::rules::SpecRef = crate::rules::SpecRef {
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.4",
     note: "The field: what a member is, the grammar of its parameters, and the connection option a sender of TE must send beside it",
 };
-const RFC_9110_10_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("10.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1",
-    note: "The section the field is defined in — request context fields. It is the whole of the ground for reporting a TE in a response, and it carries no modal",
-};
 const RFC_9110_A: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
     section: Some("A"),
@@ -583,7 +579,11 @@ impl Rule for TeHeaderValid {
                 // findings for one field, and the weaker of the two would be the one
                 // saying RFC 9110 merely gives it no meaning.
                 //
-                // cite(RFC 9110 § 10.1): "The request header fields below provide additional information about the request context, including information about the user, user agent, and resource behind the request."
+                // The finding is the field line's and not this field's: nine fields
+                // are sorted into a direction by § 10 and `context_fields_direction`
+                // reports the same defect for all of them, `TE` included. Two rules,
+                // one id -- which is the whole point of the id.
+                //
                 // cite(RFC 9110 § 10.1.4): "The "TE" header field describes capabilities of the client with regard to transfer codings and trailer sections."
                 // The gate is a condition on this branch and not an early return:
                 // the request-side checks below are this rule's main body, and a
@@ -593,7 +593,7 @@ impl Rule for TeHeaderValid {
                 {
                     let value =
                         combined_field_value_as_written(&resp.headers, "te").unwrap_or_default();
-                    return Some(self.violation(ctx.severity, format!(
+                    return Some(ctx.report_with(&FIELD_REQUEST_CONTEXT_MISDIRECTED, format!(
                             "Response carries a TE header field: '{}'; TE is a request context field describing the client's capabilities, and RFC 9110 gives it no meaning in a response",
                             value.escape_debug()
                         )));

--- a/lint-http-rules/src/violations/field.rs
+++ b/lint-http-rules/src/violations/field.rs
@@ -33,6 +33,18 @@
 //! use for the hop-by-hop control the field states. The third is the name on
 //! that line being one nobody here expects. **No entry in this subject ever
 //! reads a value** — which is what makes it a subject rather than a drawer.
+//!
+//! **The last two are the same claim about a direction rather than a version.**
+//! RFC 9110 § 10 sorts nine fields into the ones that say something about a
+//! request and the ones that say something about a response, and a sender that
+//! writes one in the other direction has written a line that states nothing
+//! where it landed. No sentence in either section forbids it — the split is how
+//! the document says what each field is *about*, not a prohibition — so both
+//! entries are `info`, and the word for them is neither `_forbidden` nor
+//! `_invalid`. They are two entries rather than one because the two sections
+//! are two sentences and a def carries one quote, and because the senders are
+//! two: a client leaking a server's field and a server echoing a client's are
+//! different mistakes with different fixes.
 
 use crate::lint::Severity;
 use crate::rules::SpecRef;
@@ -56,6 +68,24 @@ pub const RFC_9110_5_3: SpecRef = SpecRef {
     note: "Field Order — a sender MUST NOT write multiple field lines of one name, in the \
            headers or the trailers, unless at least one alternative of the field's definition \
            allows the lines to be recombined as a comma-separated list",
+};
+
+/// The request context fields, and what the section says they are about. The
+/// half of § 10 that a response has no use for.
+pub const RFC_9110_10_1: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1",
+    note: "Request Context Fields — the five fields whose subjects are the user, user agent and resource behind a request; the section split the direction is read from",
+};
+
+/// The other half, and the same silence: neither section attaches a keyword to
+/// a field arriving in the direction it does not describe.
+pub const RFC_9110_10_2: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2",
+    note: "Response Context Fields — the four whose subjects are the server, the target resource and related resources. No sentence in either section forbids the misdirection, which is why both entries are advice",
 };
 
 defects! {
@@ -140,6 +170,48 @@ defects! {
         message: "",
         default_severity: Severity::Warn,
         spec: Some(RFC_9110_5_1),
+    }
+
+    /// One of § 10.1's five request context fields — `Expect`, `From`,
+    /// `Referer`, `TE`, `User-Agent` — written into a response. Each of them is
+    /// defined as a fact about the request's side of the exchange: who the user
+    /// is, what the user agent is, where the target URI came from, what the
+    /// client can accept. A server writing one states none of those things
+    /// about itself; it writes a line with no subject.
+    ///
+    /// **`info`, and the reason is the absence of a modal rather than a
+    /// judgment about how much it matters.** § 10.1 says what the fields are
+    /// for and stops. Nothing forbids the arrival, so `_forbidden` would invent
+    /// a prohibition and `_invalid` would condemn a value that is perfectly
+    /// well formed — the line is legible, and what is wrong is that it landed
+    /// where its definition says nothing.
+    ///
+    // cite(RFC 9110 § 10.1): "The request header fields below provide additional information about the request context, including information about the user, user agent, and resource behind the request."
+    FIELD_REQUEST_CONTEXT_MISDIRECTED = {
+        id: "field_request_context_misdirected",
+        title: "A request context field is written in a response",
+        message: "",
+        default_severity: Severity::Info,
+        spec: Some(RFC_9110_10_1),
+    }
+
+    /// The mirror: one of § 10.2's four response context fields — `Allow`,
+    /// `Location`, `Retry-After`, `Server` — written into a request. Same
+    /// reading, opposite sender, and the same absent modal.
+    ///
+    /// A separate entry rather than a shared one, for two reasons that agree.
+    /// The sentence is § 10.2's and a def carries one quote, so a single entry
+    /// would cite the wrong section for half its findings; and the sender is
+    /// the other party, so an operator watching what its own clients emit is
+    /// watching this entry and not its sibling.
+    ///
+    // cite(RFC 9110 § 10.2): "The response header fields below provide additional information about the response, beyond what is implied by the status code, including information about the server, about the target resource, or about related resources."
+    FIELD_RESPONSE_CONTEXT_MISDIRECTED = {
+        id: "field_response_context_misdirected",
+        title: "A response context field is written in a request",
+        message: "",
+        default_severity: Severity::Info,
+        spec: Some(RFC_9110_10_2),
     }
 }
 

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -387,7 +387,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 164;
+        const FLOOR: usize = 166;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,
@@ -407,6 +407,7 @@ mod tests {
         "ignored",
         "invalid",
         "malformed",
+        "misdirected",
         "missing",
         "obsolete",
         "redundant",

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -4785,9 +4785,9 @@ sources:
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
       line: 238
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 128
+      line: 130
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 319
+      line: 321
   - label: accept_encoding_parameter_valid (3)
     section: § 12.5.3
     snippet: 'Accept-Encoding  = #( codings [ weight ] ) codings          = content-coding / "identity" / "*"'
@@ -4887,7 +4887,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 413
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 330
+      line: 332
   - label: accept_header_media_type_syntax (2)
     section: § 12.5.1
     snippet: Each media-range might be followed by optional applicable media type parameters (e.g., charset), followed by an optional "q" parameter for indicating a relative weight (Section 12.4.2).
@@ -4955,7 +4955,7 @@ sources:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 53
     - file: lint-http-rules/src/rules/context_fields_direction.rs
-      line: 46
+      line: 60
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 46
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
@@ -5191,13 +5191,15 @@ sources:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 55
     - file: lint-http-rules/src/rules/context_fields_direction.rs
-      line: 45
+      line: 59
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
       line: 151
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
       line: 206
     - file: lint-http-rules/src/rules/redirect_status_and_location_valid.rs
       line: 161
+    - file: lint-http-rules/src/violations/field.rs
+      line: 208
   - label: allow_header_method_tokens_valid (2)
     section: § 10.2.1
     snippet: An empty Allow field value indicates that the resource allows no methods, which might occur in a 405 response if the resource has been temporarily disabled by configuration.
@@ -5801,21 +5803,21 @@ sources:
     snippet: The request header fields below provide additional information about the request context, including information about the user, user agent, and resource behind the request.
     cited_by:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
-      line: 14
+      line: 28
     - file: lint-http-rules/src/rules/expect_header_valid.rs
       line: 193
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
       line: 222
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 237
-    - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 586
+    - file: lint-http-rules/src/violations/field.rs
+      line: 189
   - label: context_fields_direction (2)
     section: § 10.1.1
     snippet: The "Expect" header field in a request indicates a certain set of behaviors (expectations) that need to be supported by the server in order to properly handle this request.
     cited_by:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
-      line: 15
+      line: 29
     - file: lint-http-rules/src/rules/expect_header_valid.rs
       line: 209
   - label: context_fields_direction (3)
@@ -5823,7 +5825,7 @@ sources:
     snippet: The "From" header field contains an Internet email address for a human user who controls the requesting user agent.
     cited_by:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
-      line: 16
+      line: 30
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
       line: 253
   - label: context_fields_direction (4)
@@ -5831,7 +5833,7 @@ sources:
     snippet: The "Referer" [sic] header field allows the user agent to specify a URI reference for the resource from which the target URI was obtained (i.e., the "referrer", though the field name is misspelled).
     cited_by:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
-      line: 17
+      line: 31
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 268
   - label: context_fields_direction (5)
@@ -5839,11 +5841,11 @@ sources:
     snippet: The "TE" header field describes capabilities of the client with regard to transfer codings and trailer sections.
     cited_by:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
-      line: 18
+      line: 32
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 205
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 552
+      line: 548
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 587
   - label: context_fields_direction (6)
@@ -5851,7 +5853,7 @@ sources:
     snippet: The "User-Agent" header field contains information about the user agent originating the request
     cited_by:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
-      line: 19
+      line: 33
     - file: lint-http-rules/src/rules/user_agent_present.rs
       line: 85
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
@@ -5861,7 +5863,7 @@ sources:
     snippet: The "Location" header field is used in some responses to refer to a specific resource in relation to the response.
     cited_by:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
-      line: 47
+      line: 61
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
       line: 197
     - file: lint-http-rules/src/rules/redirect_status_and_location_valid.rs
@@ -5871,7 +5873,7 @@ sources:
     snippet: Servers send the "Retry-After" header field to indicate how long the user agent ought to wait before making a follow-up request.
     cited_by:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
-      line: 48
+      line: 62
     - file: lint-http-rules/src/rules/retry_after_date_or_delay.rs
       line: 86
     - file: lint-http-rules/src/rules/retry_after_status_valid.rs
@@ -5883,7 +5885,7 @@ sources:
     snippet: The "Server" header field contains information about the software used by the origin server to handle the request
     cited_by:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
-      line: 49
+      line: 63
   - label: date_and_time_headers_consistent
     section: § 8.8.2.1
     snippet: An origin server with a clock (as defined in Section 5.6.7) MUST NOT generate a Last-Modified date that is later than the server's time of message origination (Date, Section 6.6.1).
@@ -6061,7 +6063,7 @@ sources:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
       line: 360
     - file: lint-http-rules/src/violations/field.rs
-      line: 136
+      line: 166
   - label: extension_headers_registered (5)
     section: § 5.1
     snippet: Other recipients SHOULD ignore unrecognized header and trailer fields
@@ -6757,7 +6759,7 @@ sources:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
       line: 21
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 71
+      line: 73
   - label: lint-http-rules/src/helpers/cache_control.rs (2)
     section: § 5.6.1
     snippet: '#element => [ element ] *( OWS "," OWS [ element ] )'
@@ -7073,7 +7075,7 @@ sources:
     - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
       line: 120
     - file: lint-http-rules/src/violations/field.rs
-      line: 77
+      line: 107
   - label: lint-http-rules/src/helpers/headers.rs (5)
     section: § 5.5
     snippet: A recipient SHOULD treat other allowed octets in field content (i.e., obs-text) as opaque data.
@@ -7315,7 +7317,7 @@ sources:
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
       line: 233
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 90
+      line: 92
     - file: lint-http-rules/src/rules/upgrade_header_syntax.rs
       line: 218
   - label: lint-http-rules/src/helpers/media_type.rs (2)
@@ -7941,7 +7943,7 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 253
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 145
+      line: 147
   - label: no_connection_specific_fields (2)
     section: § A
     snippet: transfer-parameter = token BWS "=" BWS ( token / quoted-string )
@@ -7949,9 +7951,9 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 254
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 106
+      line: 108
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 244
+      line: 246
   - label: options_method_capabilities
     section: § 10.2.1
     snippet: An origin server MUST generate an Allow header field in a 405 (Method Not Allowed) response and MAY do so in any other response.
@@ -8103,7 +8105,7 @@ sources:
     - file: lint-http-rules/src/rules/proxy_connection_discouraged.rs
       line: 120
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 202
+      line: 204
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
       line: 60
   - label: range_and_content_range_consistent
@@ -9001,13 +9003,13 @@ sources:
     snippet: A sender of TE MUST also send a "TE" connection option within the Connection header field (Section 7.6.1) to inform intermediaries not to forward this field.
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 224
+      line: 226
   - label: te_header_valid (2)
     section: § 10.1.4
     snippet: The TE field value is a list of members, with each member (aside from "trailers") consisting of a transfer coding name token with an optional weight indicating the client's relative preference for that transfer coding (Section 12.4.2) and optional parameters for that transfer coding.
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 72
+      line: 74
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 459
   - label: te_header_valid (3)
@@ -9015,21 +9017,21 @@ sources:
     snippet: The BWS rule is used where the grammar allows optional whitespace only for historical reasons.  A sender MUST NOT generate BWS in messages.  A recipient MUST parse for such bad whitespace and remove it before interpreting the protocol element.
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 276
+      line: 278
   - label: te_header_valid (4)
     section: § A
     snippet: TE = [ t-codings *( OWS "," OWS t-codings ) ]
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 88
+      line: 90
   - label: te_header_valid (5)
     section: § A
     snippet: transfer-coding = token *( OWS ";" OWS transfer-parameter )
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 127
+      line: 129
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 168
+      line: 170
   - label: timing_allow_origin_valid
     section: § 5.6.1.2
     snippet: 'A recipient MUST parse and ignore a reasonable number of empty list elements: enough to handle common mistakes by senders that merge values, but not so much that they could be used as a denial-of-service mechanism'
@@ -10217,13 +10219,13 @@ sources:
     snippet: The TE header field (Section 10.1.4 of [HTTP]) uses a pseudo-parameter named "q" as the rank value when multiple transfer codings are acceptable.
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 310
+      line: 312
   - label: te_header_valid (2)
     section: § 7.4
     snippet: If the TE field value is empty or if no TE field is present, the only acceptable transfer coding is chunked.
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 89
+      line: 91
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 458
   - label: te_header_valid (3)
@@ -10231,13 +10233,13 @@ sources:
     snippet: Since the TE header field only applies to the immediate connection, a sender of TE MUST also send a "TE" connection option within the Connection header field (Section 7.6.1 of [HTTP]) in order to prevent the TE header field from being forwarded by intermediaries that do not support its semantics.
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 225
+      line: 227
   - label: te_header_valid (4)
     section: § 7.4
     snippet: When multiple transfer codings are acceptable, the client MAY rank the codings by preference using a case-insensitive "q" parameter (similar to the qvalues used in content negotiation fields; see Section 12.4.2 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 311
+      line: 313
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 351
   - label: transfer_coding
@@ -10506,7 +10508,7 @@ sources:
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
       line: 168
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 203
+      line: 205
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
       line: 62
   - label: no_connection_specific_fields
@@ -10552,7 +10554,7 @@ sources:
     snippet: The only exception to this is the TE header field, which MAY be present in an HTTP/2 request; when it is, it MUST NOT contain any value other than "trailers".
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 204
+      line: 206
     - file: lint-http-rules/src/violations/te.rs
       line: 34
 - label: RFC 9114
@@ -10819,7 +10821,7 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 161
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 205
+      line: 207
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
       line: 64
   - label: no_connection_specific_fields (2)


### PR DESCRIPTION
RFC 9110 §10 sorts nine fields into the ones that say something about a request and the ones that say something about a response, and attaches no keyword to either arrival. So a Server in a request and a User-Agent in a response are not forbidden and are too well formed to be invalid: what is wrong is that the line states nothing where it was sent. The closed vocabulary gains _misdirected for that, defaulting to info.

Two entries and not one, because the two sections are two sentences and an entry carries one quote — and because a client leaking a server's field and a server echoing a client's are different senders. The TE rule reports the first of them for its own field, which is two rules reaching one id.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
