### PR TITLE
What TE says about itself and nothing else

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1655,9 +1655,17 @@ severity = "warn"
 # TE names the chunked coding, which cannot be declined
 severity = "warn"
 
+[violations.te_connection_option_missing]
+# TE is sent without a TE connection option beside it
+severity = "warn"
+
 [violations.te_member_forbidden]
 # A request's TE holds a member other than trailers
 severity = "error"
+
+[violations.te_trailers_parameter_forbidden]
+# TE hangs a parameter or a weight off the trailers keyword
+severity = "warn"
 
 [violations.token68_body_empty]
 # token68 is padding with no body

--- a/docs/rules/te_header_valid.md
+++ b/docs/rules/te_header_valid.md
@@ -23,9 +23,9 @@ Scope: this rule reads a request's header section, and a response's only to repo
 ## Specifications
 
 - [RFC 9110 §5.6.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3): Whitespace — `BWS` is printed where a grammar allows optional whitespace for historical reasons only, with a MUST NOT on the sender and a matching MUST on the recipient to remove it before interpreting the element
-- [RFC 9110 §10.1.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.4): The field: what a member is, the grammar of its parameters, and the connection option a sender of TE must send beside it
+- [RFC 9110 §10.1.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.4): TE — what a member states, the grammar of its parameters, and the `TE` connection option a sender of the field MUST also send
 - [RFC 9110 §10.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1): Request Context Fields — the five fields whose subjects are the user, user agent and resource behind a request; the section split the direction is read from
-- [RFC 9110 §A](https://www.rfc-editor.org/rfc/rfc9110.html#appendix-A): The collected grammar, where the list construct is expanded for a sender — the form that shows both that the whole value may be empty and that a member may not
+- [RFC 9110 §A](https://www.rfc-editor.org/rfc/rfc9110.html#appendix-A): The collected grammar, where the list construct is expanded for a sender and `t-codings` is written out — the alternation that gives the `trailers` keyword neither a parameter nor a weight
 - [RFC 9110 §12.4.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-12.4.2): Quality Values — `weight = OWS ";" OWS "q=" qvalue`, the `qvalue` production and its three-digit fraction, the case-insensitive `q` parameter name, and what a weight of zero means
 - [RFC 9110 §5.6.1.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1): The list construct — `1#element => element *( OWS "," OWS element )`, and the sender's MUST NOT against an empty element
 - [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits

--- a/lint-http-rules/src/rules/te_header_valid.rs
+++ b/lint-http-rules/src/rules/te_header_valid.rs
@@ -19,6 +19,9 @@ use crate::violations::quoted_string::{
     QUOTED_STRING_DELIMITER_MISSING, QUOTED_STRING_QUOTE_ESCAPE_MISSING, RFC_9110_5_6_4,
 };
 use crate::violations::qvalue::{QVALUE_MALFORMED, RFC_9110_12_4_2};
+use crate::violations::te::{
+    RFC_9110_10_1_4, RFC_9110_A, TE_CONNECTION_OPTION_MISSING, TE_TRAILERS_PARAMETER_FORBIDDEN,
+};
 use crate::violations::token::{
     token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN, TOKEN_EMPTY,
     TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
@@ -44,6 +47,8 @@ use crate::violations::ViolationDef;
 /// of their own.
 static DECLARED: &[&ViolationDef] = &[
     &BWS_FORBIDDEN,
+    &TE_TRAILERS_PARAMETER_FORBIDDEN,
+    &TE_CONNECTION_OPTION_MISSING,
     &FIELD_REQUEST_CONTEXT_MISDIRECTED,
     &QVALUE_MALFORMED,
     &LIST_MEMBER_EMPTY,
@@ -147,11 +152,11 @@ impl TeHeaderValid {
             // cite(RFC 9110 § A): "t-codings = "trailers" / ( transfer-coding [ weight ] )"
             if primary.eq_ignore_ascii_case("trailers") {
                 if let Some(extra) = segments.get(1) {
-                    return violation(format!(
+                    return Some(ctx.report_with(&TE_TRAILERS_PARAMETER_FORBIDDEN, format!(
                         "TE member '{}' hangs '{}' off the 'trailers' keyword; the t-codings alternative that admits a parameter or a weight is the transfer-coding one",
                         member.escape_debug(),
                         extra.escape_debug()
-                    ));
+                    )));
                 }
                 continue;
             }
@@ -208,7 +213,7 @@ impl TeHeaderValid {
     fn check_connection_option(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        severity: crate::lint::Severity,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // The major digit decides whether this version has a `Connection` field
         // to carry the option; `http_version` owns the production that reads it.
@@ -231,14 +236,7 @@ impl TeHeaderValid {
             return None;
         }
 
-        Some(self.violation(
-            severity,
-
-                "Request carries a TE header field without a 'TE' connection option in Connection; \
-                 TE applies to the immediate connection only, and the option is what stops an \
-                 intermediary from forwarding it"
-                    .into(),
-        ))
+        Some(ctx.report(&TE_CONNECTION_OPTION_MISSING))
     }
 
     /// One `transfer-parameter` of one member — or the `weight`, which is not one.
@@ -402,18 +400,6 @@ impl TeHeaderValid {
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_9110_10_1_4: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("10.1.4"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.4",
-    note: "The field: what a member is, the grammar of its parameters, and the connection option a sender of TE must send beside it",
-};
-const RFC_9110_A: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("A"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-A",
-    note: "The collected grammar, where the list construct is expanded for a sender — the form that shows both that the whole value may be empty and that a member may not",
-};
 const RFC_9110_7_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
     section: Some("7.6.1"),
@@ -606,7 +592,7 @@ impl Rule for TeHeaderValid {
                 return Some(v);
             }
 
-            self.check_connection_option(tx, ctx.severity)
+            self.check_connection_option(tx, ctx)
         };
         Vec::from_iter(finding())
     }

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -387,7 +387,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 166;
+        const FLOOR: usize = 168;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/te.rs
+++ b/lint-http-rules/src/violations/te.rs
@@ -29,6 +29,14 @@
 //! version. What is here is the value being *permitted and yet not `trailers`*,
 //! which no other rule asks.
 //!
+//! **Two later entries are the field's for a different reason: they are what
+//! RFC 9110 § 10.1.4 says about `TE` and about nothing else.** The keyword
+//! occupies the whole of its alternative, so a parameter or a weight hung off
+//! it derives from no `t-codings`; and a sender of the field owes a `TE`
+//! connection option beside it, which is a requirement on the *message* rather
+//! than on any value in it. Neither is a production's defect — every
+//! production involved is intact — which is what keeps them here.
+//!
 //! The exception, in the two documents that write it:
 //
 // cite(RFC 9113 § 8.2.2, label: the TE exception): "The only exception to this is the TE header field, which MAY be present in an HTTP/2 request; when it is, it MUST NOT contain any value other than "trailers"."
@@ -45,6 +53,24 @@ pub const RFC_9112_7_4: SpecRef = SpecRef {
     section: Some("7.4"),
     url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.4",
     note: "TE — the codings a client will accept, the `q` pseudo-parameter that ranks them, and the MUST NOT on naming `chunked`",
+};
+
+/// The field's own definition in RFC 9110: what a member is, and the
+/// connection option a sender owes beside it.
+pub const RFC_9110_10_1_4: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.1.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.4",
+    note: "TE — what a member states, the grammar of its parameters, and the `TE` connection option a sender of the field MUST also send",
+};
+
+/// The collected grammar, where `t-codings` is written out as the alternation
+/// the keyword occupies half of.
+pub const RFC_9110_A: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("A"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-A",
+    note: "The collected grammar, where the list construct is expanded for a sender and `t-codings` is written out — the alternation that gives the `trailers` keyword neither a parameter nor a weight",
 };
 
 defects! {
@@ -93,6 +119,56 @@ defects! {
         message: "A client must not send the chunked transfer coding name in TE; chunked is always acceptable for HTTP/1.1 recipients",
         default_severity: Severity::Warn,
         spec: Some(RFC_9112_7_4),
+    }
+
+    /// A parameter or a weight written on the `trailers` keyword. The
+    /// alternation gives the keyword the whole of its first alternative, and
+    /// the alternative that admits either of those is the other one — so
+    /// `TE: trailers;q=0.5` derives from neither, however ordinary it looks.
+    ///
+    /// **The nearest thing to a real reading behind it**: a weight ranks
+    /// codings a client is willing to receive, and the keyword is not a coding.
+    /// There is nothing for a preference to be *between*, which is why the
+    /// grammar puts them in different alternatives rather than making the
+    /// weight optional everywhere.
+    ///
+    /// The entry is the field's because `t-codings` is: no other field writes
+    /// this alternation, and the coding half of it answers to
+    /// [`transfer_coding`](crate::violations::transfer_coding) as it does
+    /// everywhere else.
+    ///
+    // cite(RFC 9110 § A, label: t-codings): "t-codings = "trailers" / ( transfer-coding [ weight ] )"
+    TE_TRAILERS_PARAMETER_FORBIDDEN = {
+        id: "te_trailers_parameter_forbidden",
+        title: "TE hangs a parameter or a weight off the trailers keyword",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_A),
+    }
+
+    /// A request carrying `TE` and no `TE` connection option in `Connection`.
+    /// The field applies to one hop; the option is what tells an intermediary
+    /// not to forward it. Without the option a proxy that does not implement
+    /// the field passes it on, and a server two hops away reads a statement
+    /// about a connection it is not on.
+    ///
+    /// **Asked only of the versions that have a `Connection` field**, which is
+    /// the rule's reading and not this entry's: over HTTP/2 and HTTP/3 the
+    /// option cannot be sent at all, so an entry demanding it would ask a
+    /// sender to make its own message malformed.
+    ///
+    /// `warn` rather than `error` despite the MUST: nothing about this message
+    /// is unreadable, and the defect is a guard that was not set rather than a
+    /// statement that is wrong. What it risks is a *later* hop being misled,
+    /// which no recipient of this message can detect.
+    ///
+    // cite(RFC 9110 § 10.1.4): "A sender of TE MUST also send a "TE" connection option within the Connection header field (Section 7.6.1) to inform intermediaries not to forward this field."
+    TE_CONNECTION_OPTION_MISSING = {
+        id: "te_connection_option_missing",
+        title: "TE is sent without a TE connection option beside it",
+        message: "Request carries a TE header field without a 'TE' connection option in Connection; TE applies to the immediate connection only, and the option is what stops an intermediary from forwarding it",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_10_1_4),
     }
 }
 

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -4785,9 +4785,9 @@ sources:
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
       line: 238
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 130
+      line: 135
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 321
+      line: 319
   - label: accept_encoding_parameter_valid (3)
     section: § 12.5.3
     snippet: 'Accept-Encoding  = #( codings [ weight ] ) codings          = content-coding / "identity" / "*"'
@@ -4887,7 +4887,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 413
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 332
+      line: 330
   - label: accept_header_media_type_syntax (2)
     section: § 12.5.1
     snippet: Each media-range might be followed by optional applicable media type parameters (e.g., charset), followed by an optional "q" parameter for indicating a relative weight (Section 12.4.2).
@@ -5845,9 +5845,9 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 205
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 548
+      line: 534
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 587
+      line: 573
   - label: context_fields_direction (6)
     section: § 10.1.5
     snippet: The "User-Agent" header field contains information about the user agent originating the request
@@ -6759,7 +6759,7 @@ sources:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
       line: 21
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 73
+      line: 78
   - label: lint-http-rules/src/helpers/cache_control.rs (2)
     section: § 5.6.1
     snippet: '#element => [ element ] *( OWS "," OWS [ element ] )'
@@ -7317,7 +7317,7 @@ sources:
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
       line: 233
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 92
+      line: 97
     - file: lint-http-rules/src/rules/upgrade_header_syntax.rs
       line: 218
   - label: lint-http-rules/src/helpers/media_type.rs (2)
@@ -7943,7 +7943,9 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 253
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 147
+      line: 152
+    - file: lint-http-rules/src/violations/te.rs
+      line: 140
   - label: no_connection_specific_fields (2)
     section: § A
     snippet: transfer-parameter = token BWS "=" BWS ( token / quoted-string )
@@ -7951,9 +7953,9 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 254
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 108
+      line: 113
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 246
+      line: 244
   - label: options_method_capabilities
     section: § 10.2.1
     snippet: An origin server MUST generate an Allow header field in a 405 (Method Not Allowed) response and MAY do so in any other response.
@@ -8105,7 +8107,7 @@ sources:
     - file: lint-http-rules/src/rules/proxy_connection_discouraged.rs
       line: 120
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 204
+      line: 209
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
       line: 60
   - label: range_and_content_range_consistent
@@ -9003,13 +9005,15 @@ sources:
     snippet: A sender of TE MUST also send a "TE" connection option within the Connection header field (Section 7.6.1) to inform intermediaries not to forward this field.
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 226
+      line: 231
+    - file: lint-http-rules/src/violations/te.rs
+      line: 165
   - label: te_header_valid (2)
     section: § 10.1.4
     snippet: The TE field value is a list of members, with each member (aside from "trailers") consisting of a transfer coding name token with an optional weight indicating the client's relative preference for that transfer coding (Section 12.4.2) and optional parameters for that transfer coding.
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 74
+      line: 79
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 459
   - label: te_header_valid (3)
@@ -9017,21 +9021,21 @@ sources:
     snippet: The BWS rule is used where the grammar allows optional whitespace only for historical reasons.  A sender MUST NOT generate BWS in messages.  A recipient MUST parse for such bad whitespace and remove it before interpreting the protocol element.
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 278
+      line: 276
   - label: te_header_valid (4)
     section: § A
     snippet: TE = [ t-codings *( OWS "," OWS t-codings ) ]
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 90
+      line: 95
   - label: te_header_valid (5)
     section: § A
     snippet: transfer-coding = token *( OWS ";" OWS transfer-parameter )
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 129
+      line: 134
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 170
+      line: 175
   - label: timing_allow_origin_valid
     section: § 5.6.1.2
     snippet: 'A recipient MUST parse and ignore a reasonable number of empty list elements: enough to handle common mistakes by senders that merge values, but not so much that they could be used as a denial-of-service mechanism'
@@ -10213,19 +10217,19 @@ sources:
     snippet: A client MUST NOT send the chunked transfer coding name in TE; chunked is always acceptable for HTTP/1.1 recipients.
     cited_by:
     - file: lint-http-rules/src/violations/te.rs
-      line: 89
+      line: 115
   - label: te_header_valid
     section: § 7.3
     snippet: The TE header field (Section 10.1.4 of [HTTP]) uses a pseudo-parameter named "q" as the rank value when multiple transfer codings are acceptable.
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 312
+      line: 310
   - label: te_header_valid (2)
     section: § 7.4
     snippet: If the TE field value is empty or if no TE field is present, the only acceptable transfer coding is chunked.
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 91
+      line: 96
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 458
   - label: te_header_valid (3)
@@ -10233,13 +10237,13 @@ sources:
     snippet: Since the TE header field only applies to the immediate connection, a sender of TE MUST also send a "TE" connection option within the Connection header field (Section 7.6.1 of [HTTP]) in order to prevent the TE header field from being forwarded by intermediaries that do not support its semantics.
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 227
+      line: 232
   - label: te_header_valid (4)
     section: § 7.4
     snippet: When multiple transfer codings are acceptable, the client MAY rank the codings by preference using a case-insensitive "q" parameter (similar to the qvalues used in content negotiation fields; see Section 12.4.2 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 313
+      line: 311
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 351
   - label: transfer_coding
@@ -10508,7 +10512,7 @@ sources:
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
       line: 168
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 205
+      line: 210
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
       line: 62
   - label: no_connection_specific_fields
@@ -10554,9 +10558,9 @@ sources:
     snippet: The only exception to this is the TE header field, which MAY be present in an HTTP/2 request; when it is, it MUST NOT contain any value other than "trailers".
     cited_by:
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 206
+      line: 211
     - file: lint-http-rules/src/violations/te.rs
-      line: 34
+      line: 42
 - label: RFC 9114
   url: https://www.rfc-editor.org/rfc/rfc9114.html
   fragments:
@@ -10821,7 +10825,7 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 161
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 207
+      line: 212
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
       line: 64
   - label: no_connection_specific_fields (2)
@@ -10881,7 +10885,7 @@ sources:
     snippet: The only exception to this is the TE header field, which MAY be present in an HTTP/3 request header; when it is, it MUST NOT contain any value other than "trailers".
     cited_by:
     - file: lint-http-rules/src/violations/te.rs
-      line: 35
+      line: 43
 - label: RFC 9218
   url: https://www.rfc-editor.org/rfc/rfc9218.html
   fragments:


### PR DESCRIPTION
Two findings that are the field's rather than any production's: a parameter or a weight hung off the trailers keyword, which occupies the whole of its alternative and leaves the other one to admit either; and a request sending the field with no TE connection option beside it, which is the guard that stops an intermediary forwarding a statement about one hop.

Neither is a grammar defect — every production involved is intact — which is what keeps them in the field's subject. The MUST behind the second ships as warn: nothing here is unreadable, and what it risks is a later hop being misled, which no recipient of this message can detect.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
