### PR TITLE
A cookie attribute someone else already named

### DIFF
--- a/docs/rules/cookie_attribute_consistent.md
+++ b/docs/rules/cookie_attribute_consistent.md
@@ -22,9 +22,13 @@ Validate `Set-Cookie` attributes for syntactic correctness and common security c
 
 - [RFC 6265 §4.1.1](https://www.rfc-editor.org/rfc/rfc6265.html#section-4.1.1): Set-Cookie syntax — the cookie-name/`Secure`/`HttpOnly`/`Expires` grammar this rule checks
 - [RFC 6265 §5.2.2](https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.2): The Max-Age attribute — ignored unless it is a `-`-or-DIGIT first character with an all-DIGIT remainder
+- [RFC 6265 §5.2.3](https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.3): `Domain` attribute processing — an empty value is undefined (the user agent ignores it) and a leading dot is stripped; the value's *format* is § 4.1.1 and RFC 1035
+- [RFC 6265 §5.2.4](https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.4): Path attribute — the user agent replaces an empty or non-`/` Path with the default-path (why those forms are flagged)
 - [draft-ietf-httpbis-rfc6265bis](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis): `SameSite` value grammar and the `SameSite=None` requires `Secure` rule. No section: a draft renumbers between revisions
 - [MDN Set-Cookie](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie): SameSite cookies (SameSite=None should be Secure) — browser compatibility guidance on `SameSite` usage
 - [RFC 9110 §5.6.7](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.7): Date/Time Formats — `HTTP-date = IMF-fixdate / obs-date`, the recipient's MUST to accept all three, and the sender's MUST to generate only the first
+- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
+- [RFC 1035 §2.3.1](https://www.rfc-editor.org/rfc/rfc1035.html#section-2.3.1): Preferred name syntax — labels start with a letter, end with a letter or digit, hold only letters, digits and hyphen, and run to 63 characters
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/cookie_attribute_consistent.rs
+++ b/lint-http-rules/src/rules/cookie_attribute_consistent.rs
@@ -4,22 +4,46 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::cookie::{
+    COOKIE_DOMAIN_EMPTY, COOKIE_DOMAIN_MISSING, COOKIE_PATH_LEADING_SLASH_MISSING,
+    COOKIE_PATH_MISSING, RFC_6265_5_2_3, RFC_6265_5_2_4,
+};
+use crate::violations::domain::{DOMAIN_NAME_WHITESPACE_OR_CONTROL_FORBIDDEN, RFC_1035_2_3_1};
 use crate::violations::http_date::{HTTP_DATE_MALFORMED, RFC_9110_5_6_7};
+use crate::violations::token::{
+    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN, TOKEN_EMPTY,
+    TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+};
 use crate::violations::ViolationDef;
 
 pub struct CookieAttributeConsistent;
 
-/// The one attribute this rule reads through a production another field
-/// already owns. `sane-cookie-date` is RFC 6265's name for the timestamp RFC
-/// 9110 § 5.6.7 writes, so a `Expires` a recipient cannot read is the same
-/// defect a `Date` or a `Sunset` a recipient cannot read is — and the rule
-/// keeps every other finding of its own, because the rest of a `cookie-av` is
-/// the cookie's grammar and nothing else's.
+/// What this rule reports that another reading already named.
 ///
-/// The remaining sixteen sites are not converted: the cookie-pair, the
-/// `Max-Age` integer and the `SameSite` values are subjects nothing has
-/// written, and the non-UTF-8 line is the family open question 1 refuses.
-static DECLARED: &[&ViolationDef] = &[&HTTP_DATE_MALFORMED];
+/// Three imports, each for a different reason. `sane-cookie-date` is RFC
+/// 6265's name for the timestamp RFC 9110 § 5.6.7 writes, so an `Expires` a
+/// recipient cannot read is the same defect a `Date` or a `Sunset` a recipient
+/// cannot read is. `cookie-name = token` imports the HTTP production by name,
+/// so a name that is empty or holds a delimiter answers to `token` — the
+/// alphabets are not merely similar, they are the same set. And `Path` and
+/// `Domain` were read out by `cookie_path_valid` and `cookie_domain_valid`
+/// first: this rule asks a coarser question of the same two attributes, so it
+/// reports what they report rather than a second name for it.
+///
+/// What is left in the rule's own words is the shape of the field line and the
+/// attributes nothing else reads — `SameSite`, `Max-Age`, the two flags, and
+/// the pairing that makes a `SameSite=None` cookie disappear.
+static DECLARED: &[&ViolationDef] = &[
+    &HTTP_DATE_MALFORMED,
+    &TOKEN_EMPTY,
+    &TOKEN_CHARACTER_FORBIDDEN,
+    &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+    &COOKIE_PATH_MISSING,
+    &COOKIE_PATH_LEADING_SLASH_MISSING,
+    &COOKIE_DOMAIN_MISSING,
+    &COOKIE_DOMAIN_EMPTY,
+    &DOMAIN_NAME_WHITESPACE_OR_CONTROL_FORBIDDEN,
+];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -70,15 +94,17 @@ impl CookieAttributeConsistent {
             return Some(self.violation(severity, "Set-Cookie header missing cookie-pair".into()));
         }
 
+        // The name is a `token` by import rather than by resemblance -- § 4.1.1
+        // writes `cookie-name = token` and takes the production from the HTTP
+        // document -- so both of its defects are that production's.
+        // cite(RFC 6265 § 4.1.1): "cookie-pair       = cookie-name "=" cookie-value cookie-name       = token"
         let name = pair.split('=').next().unwrap_or("").trim();
         if name.is_empty() {
-            return Some(self.violation(severity, "Set-Cookie cookie name is empty".into()));
+            return Some(ctx.report_with(&TOKEN_EMPTY, "Set-Cookie cookie name is empty".into()));
         }
-        // cite(RFC 6265 § 4.1.1): "cookie-pair       = cookie-name "=" cookie-value cookie-name       = token"
         if let Some(c) = crate::helpers::token::find_invalid_token_char(name) {
-            return Some(self.cited(
-                &RFC_6265_4_1_1,
-                severity,
+            return Some(ctx.report_with(
+                token_character(c),
                 format!("Set-Cookie cookie-name contains invalid character: '{}'", c),
             ));
         }
@@ -210,16 +236,18 @@ impl CookieAttributeConsistent {
             });
         }
 
+        // `Path` and `Domain` are read here as far as their presence and their
+        // first character, and in full by `cookie_path_valid` and
+        // `cookie_domain_valid`. The coarser reading reports the same ids: what
+        // an operator silences is the defect, not which of the two rules noticed
+        // it first.
         if attribute.is("Path") {
             let Some(value) = attribute.value else {
-                return Some(self.violation(
-                    severity,
-                    "Set-Cookie attribute 'Path' requires a value".into(),
-                ));
+                return Some(ctx.report(&COOKIE_PATH_MISSING));
             };
             return (!value.starts_with('/')).then(|| {
-                self.violation(
-                    severity,
+                ctx.report_with(
+                    &COOKIE_PATH_LEADING_SLASH_MISSING,
                     format!(
                         "Set-Cookie attribute 'Path' should start with '/': '{}'",
                         value
@@ -230,20 +258,20 @@ impl CookieAttributeConsistent {
 
         if attribute.is("Domain") {
             let Some(value) = attribute.value else {
-                return Some(self.violation(
-                    severity,
-                    "Set-Cookie attribute 'Domain' requires a value".into(),
-                ));
+                return Some(ctx.report(&COOKIE_DOMAIN_MISSING));
             };
             if value.is_empty() {
-                return Some(self.violation(
-                    severity,
+                return Some(ctx.report_with(
+                    &COOKIE_DOMAIN_EMPTY,
                     "Set-Cookie attribute 'Domain' must not be empty".into(),
                 ));
             }
+            // A space inside a host name is the *name's* defect and not the
+            // attribute's: the same octet in a `Host`, a `Forwarded` host or a
+            // `From` mailbox reports under this id already.
             return value.contains(' ').then(|| {
-                self.violation(
-                    severity,
+                ctx.report_with(
+                    &DOMAIN_NAME_WHITESPACE_OR_CONTROL_FORBIDDEN,
                     format!(
                         "Set-Cookie attribute 'Domain' must not contain spaces: '{}'",
                         value
@@ -275,9 +303,13 @@ severity = "warn"
         &[
             RFC_6265_4_1_1,
             RFC_6265_5_2_2,
+            RFC_6265_5_2_3,
+            RFC_6265_5_2_4,
             DRAFT_IETF_HTTPBIS_RFC6265BIS,
             MDN_SET_COOKIE,
             RFC_9110_5_6_7,
+            RFC_9110_5_6_2,
+            RFC_1035_2_3_1,
         ]
     }
 

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1312,7 +1312,7 @@ severity = "warn"
         /// directive list, and neither says anything about an encoding. Each
         /// field's octet is now `token`'s, under an id the rule already
         /// declared.
-        const FLOOR: usize = 129;
+        const FLOOR: usize = 128;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -731,13 +731,13 @@ sources:
     snippet: samesite-value = "Strict" / "Lax" / "None"
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 148
+      line: 174
   - label: cookie_attribute_consistent (2)
     section: § 5.7
     snippet: If the cookie's "same-site-flag" is "None", abort this algorithm and ignore the cookie entirely unless the cookie's secure-only-flag is true.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 104
+      line: 130
   - label: cookie_same_site_enforced
     section: § 4.1.2.7
     snippet: If the "SameSite" attribute's value is "Strict", the cookie will only be sent along with "same-site" requests.
@@ -2171,43 +2171,43 @@ sources:
     snippet: cookie-pair       = cookie-name "=" cookie-value cookie-name       = token
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 77
+      line: 100
   - label: cookie_attribute_consistent (2)
     section: § 4.1.1
     snippet: expires-av        = "Expires=" sane-cookie-date
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 201
+      line: 227
   - label: cookie_attribute_consistent (3)
     section: § 4.1.1
     snippet: extension-av      = <any CHAR except CTLs or ";">
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 118
+      line: 144
   - label: cookie_attribute_consistent (4)
     section: § 4.1.1
     snippet: httponly-av       = "HttpOnly"
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 128
+      line: 154
   - label: cookie_attribute_consistent (5)
     section: § 4.1.1
     snippet: secure-av         = "Secure"
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 127
+      line: 153
   - label: cookie_attribute_consistent (6)
     section: § 5.2.2
     snippet: If the first character of the attribute-value is not a DIGIT or a "-" character, ignore the cookie-av.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 175
+      line: 201
   - label: cookie_attribute_consistent (7)
     section: § 5.2.2
     snippet: If the remainder of attribute-value contains a non-DIGIT character, ignore the cookie-av.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 176
+      line: 202
   - label: cookie_domain_matching
     section: § 5.4
     snippet: 'Let cookie-list be the set of cookies from the cookie store that meets all of the following requirements:'


### PR DESCRIPTION
Seven findings of the Set-Cookie reader stop being its own. The name is a token by import rather than by resemblance — §4.1.1 writes cookie-name = token and takes the production from the HTTP document — so an empty name and a delimiter in one answer there. Path and Domain were read out in full by two other rules first, and this coarser reading reports the same ids: what an operator silences is the defect, not which rule noticed it. A space inside a host name is the name's defect, under the id a Host, a Forwarded host and a From mailbox already report.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
