### PR TITLE
Attributes a user agent quietly discards

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1287,6 +1287,18 @@ severity = "info"
 # Set-Cookie Domain attribute carries no value
 severity = "warn"
 
+[violations.cookie_expires_missing]
+# Set-Cookie Expires attribute carries no value
+severity = "warn"
+
+[violations.cookie_max_age_malformed]
+# Set-Cookie Max-Age is not a number a user agent will read
+severity = "warn"
+
+[violations.cookie_max_age_missing]
+# Set-Cookie Max-Age attribute carries no value
+severity = "warn"
+
 [violations.cookie_path_control_character_forbidden]
 # Set-Cookie Path attribute holds a control character
 severity = "error"
@@ -1310,6 +1322,14 @@ severity = "warn"
 [violations.cookie_path_whitespace_invalid]
 # Set-Cookie Path attribute holds unencoded whitespace
 severity = "info"
+
+[violations.cookie_same_site_invalid]
+# Set-Cookie SameSite names no policy the grammar defines
+severity = "warn"
+
+[violations.cookie_same_site_missing]
+# Set-Cookie SameSite attribute carries no value
+severity = "warn"
 
 [violations.credentials_control_character_forbidden]
 # Credentials hold a control character

--- a/docs/rules/cookie_attribute_consistent.md
+++ b/docs/rules/cookie_attribute_consistent.md
@@ -20,7 +20,7 @@ Validate `Set-Cookie` attributes for syntactic correctness and common security c
 
 ## Specifications
 
-- [RFC 6265 §4.1.1](https://www.rfc-editor.org/rfc/rfc6265.html#section-4.1.1): Set-Cookie syntax — the cookie-name/`Secure`/`HttpOnly`/`Expires` grammar this rule checks
+- [RFC 6265 §4.1.1](https://www.rfc-editor.org/rfc/rfc6265.html#section-4.1.1): Set-Cookie syntax — servers SHOULD NOT send a non-conforming Set-Cookie; the `cookie-av` list, where each attribute is written with or without a value, and the `path-value` that excludes control characters and `;`
 - [RFC 6265 §5.2.2](https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.2): The Max-Age attribute — ignored unless it is a `-`-or-DIGIT first character with an all-DIGIT remainder
 - [RFC 6265 §5.2.3](https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.3): `Domain` attribute processing — an empty value is undefined (the user agent ignores it) and a leading dot is stripped; the value's *format* is § 4.1.1 and RFC 1035
 - [RFC 6265 §5.2.4](https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.4): Path attribute — the user agent replaces an empty or non-`/` Path with the default-path (why those forms are flagged)

--- a/docs/rules/cookie_path_valid.md
+++ b/docs/rules/cookie_path_valid.md
@@ -13,7 +13,7 @@ Validate the `Path` attribute in `Set-Cookie` header fields. The `Path` attribut
 ## Specifications
 
 - [RFC 3986 §2.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1): Percent-Encoding — `pct-encoded = "%" HEXDIG HEXDIG`, the two digits every `%` still owes
-- [RFC 6265 §4.1.1](https://www.rfc-editor.org/rfc/rfc6265.html#section-4.1.1): Set-Cookie syntax — servers SHOULD NOT send a non-conforming Set-Cookie; `path-value` excludes control characters and `;`
+- [RFC 6265 §4.1.1](https://www.rfc-editor.org/rfc/rfc6265.html#section-4.1.1): Set-Cookie syntax — servers SHOULD NOT send a non-conforming Set-Cookie; the `cookie-av` list, where each attribute is written with or without a value, and the `path-value` that excludes control characters and `;`
 - [RFC 6265 §5.2](https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2): The Set-Cookie header parsing algorithm — where the `;` split, the WSP trim and the case-insensitive `Path` match come from
 - [RFC 6265 §5.2.4](https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.4): Path attribute — the user agent replaces an empty or non-`/` Path with the default-path (why those forms are flagged)
 - [RFC 9110 §5.6.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3): Whitespace — rationale for being conservative about whitespace in header fields; this rule adopts a stricter profile by disallowing unencoded whitespace in cookie paths

--- a/lint-http-rules/src/rules/cookie_attribute_consistent.rs
+++ b/lint-http-rules/src/rules/cookie_attribute_consistent.rs
@@ -4,9 +4,12 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::cookie::DRAFT_IETF_HTTPBIS_RFC6265BIS;
 use crate::violations::cookie::{
-    COOKIE_DOMAIN_EMPTY, COOKIE_DOMAIN_MISSING, COOKIE_PATH_LEADING_SLASH_MISSING,
-    COOKIE_PATH_MISSING, RFC_6265_5_2_3, RFC_6265_5_2_4,
+    COOKIE_DOMAIN_EMPTY, COOKIE_DOMAIN_MISSING, COOKIE_EXPIRES_MISSING, COOKIE_MAX_AGE_MALFORMED,
+    COOKIE_MAX_AGE_MISSING, COOKIE_PATH_LEADING_SLASH_MISSING, COOKIE_PATH_MISSING,
+    COOKIE_SAME_SITE_INVALID, COOKIE_SAME_SITE_MISSING, RFC_6265_4_1_1, RFC_6265_5_2_2,
+    RFC_6265_5_2_3, RFC_6265_5_2_4,
 };
 use crate::violations::domain::{DOMAIN_NAME_WHITESPACE_OR_CONTROL_FORBIDDEN, RFC_1035_2_3_1};
 use crate::violations::http_date::{HTTP_DATE_MALFORMED, RFC_9110_5_6_7};
@@ -35,6 +38,11 @@ pub struct CookieAttributeConsistent;
 /// the pairing that makes a `SameSite=None` cookie disappear.
 static DECLARED: &[&ViolationDef] = &[
     &HTTP_DATE_MALFORMED,
+    &COOKIE_SAME_SITE_MISSING,
+    &COOKIE_SAME_SITE_INVALID,
+    &COOKIE_MAX_AGE_MISSING,
+    &COOKIE_MAX_AGE_MALFORMED,
+    &COOKIE_EXPIRES_MISSING,
     &TOKEN_EMPTY,
     &TOKEN_CHARACTER_FORBIDDEN,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
@@ -48,25 +56,6 @@ static DECLARED: &[&ViolationDef] = &[
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_6265_4_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 6265",
-    section: Some("4.1.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-4.1.1",
-    note:
-        "Set-Cookie syntax — the cookie-name/`Secure`/`HttpOnly`/`Expires` grammar this rule checks",
-};
-const RFC_6265_5_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 6265",
-    section: Some("5.2.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.2",
-    note: "The Max-Age attribute — ignored unless it is a `-`-or-DIGIT first character with an all-DIGIT remainder",
-};
-const DRAFT_IETF_HTTPBIS_RFC6265BIS: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "draft-ietf-httpbis-rfc6265bis",
-    section: None,
-    url: "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis",
-    note: "`SameSite` value grammar and the `SameSite=None` requires `Secure` rule. No section: a draft renumbers between revisions",
-};
 const MDN_SET_COOKIE: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "MDN Set-Cookie",
     section: None,
@@ -166,18 +155,14 @@ impl CookieAttributeConsistent {
 
         if attribute.is("SameSite") {
             let Some(value) = attribute.value else {
-                return Some(self.violation(
-                    severity,
-                    "Set-Cookie attribute 'SameSite' requires a value".into(),
-                ));
+                return Some(ctx.report(&COOKIE_SAME_SITE_MISSING));
             };
-            // cite(draft-ietf-httpbis-rfc6265bis § 4.1.1): "samesite-value = "Strict" / "Lax" / "None""
             let known = ["strict", "lax", "none"]
                 .iter()
                 .any(|known| value.eq_ignore_ascii_case(known));
             return (!known).then(|| {
-                self.violation(
-                    severity,
+                ctx.report_with(
+                    &COOKIE_SAME_SITE_INVALID,
                     format!(
                         "Set-Cookie attribute 'SameSite' has invalid value: '{}'",
                         value
@@ -188,10 +173,7 @@ impl CookieAttributeConsistent {
 
         if attribute.is("Max-Age") {
             let Some(value) = attribute.value else {
-                return Some(self.violation(
-                    severity,
-                    "Set-Cookie attribute 'Max-Age' requires a numeric value".into(),
-                ));
+                return Some(ctx.report(&COOKIE_MAX_AGE_MISSING));
             };
             // A leading "-" is accepted on purpose: the ABNF says non-zero-digit
             // *DIGIT, but the parsing algorithm the ABNF is a summary of admits a
@@ -199,11 +181,9 @@ impl CookieAttributeConsistent {
             // `parse::<i64>` enforces both of §5.2.2's processing gates: a
             // valid first character *and* an all-DIGIT remainder.
             // cite(RFC 6265 § 5.2.2): "If the first character of the attribute-value is not a DIGIT or a "-" character, ignore the cookie-av."
-            // cite(RFC 6265 § 5.2.2): "If the remainder of attribute-value contains a non-DIGIT character, ignore the cookie-av."
             return value.parse::<i64>().is_err().then(|| {
-                self.cited(
-                    &RFC_6265_5_2_2,
-                    severity,
+                ctx.report_with(
+                    &COOKIE_MAX_AGE_MALFORMED,
                     format!(
                         "Set-Cookie attribute 'Max-Age' is not a valid integer: '{}'",
                         value
@@ -214,10 +194,7 @@ impl CookieAttributeConsistent {
 
         if attribute.is("Expires") {
             let Some(value) = attribute.value else {
-                return Some(self.violation(
-                    severity,
-                    "Set-Cookie attribute 'Expires' requires a HTTP-date value".into(),
-                ));
+                return Some(ctx.report(&COOKIE_EXPIRES_MISSING));
             };
             // `sane-cookie-date` is the timestamp § 5.6.7 writes, under RFC
             // 6265's name for it, so what is wrong with an unreadable `Expires`

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1312,7 +1312,7 @@ severity = "warn"
         /// directive list, and neither says anything about an encoding. Each
         /// field's octet is now `token`'s, under an id the rule already
         /// declared.
-        const FLOOR: usize = 128;
+        const FLOOR: usize = 127;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/violations/cookie.rs
+++ b/lint-http-rules/src/violations/cookie.rs
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: ISC
 
-//! Cookie defects — the ways a `Set-Cookie` attribute is wrong, `Path` and
-//! `Domain` so far.
+//! Cookie defects — the ways a `Set-Cookie` attribute is wrong.
 //!
 //! The subject is the attribute, not the rule that reads it: `cookie_path_*`
 //! names what a server wrote, so a second rule that parses `Set-Cookie` reports
@@ -12,6 +11,15 @@
 //! every field that carries one, and those defects live in
 //! [`crate::violations::domain`] where a rule reading a `From` mailbox can
 //! report the same ones.
+//!
+//! **The `SameSite`, `Max-Age` and `Expires` entries are a third kind, and
+//! they are why this subject cannot be filed under "syntax".** Each of those
+//! attributes has a processing algorithm that *discards* what it cannot read: a
+//! `Max-Age` with a stray character is ignored and the cookie silently becomes
+//! a session cookie, an unknown `SameSite` falls back to the default policy,
+//! an `Expires` naming no instant expires nothing. The server asked for
+//! something and got something else, with no error anywhere in the exchange —
+//! which is the whole argument for reporting them at all.
 //!
 //! Three of the `Path` defects are not syntax errors at all. RFC 6265 § 5.2.4 has the user
 //! agent replace an empty or unrooted `Path` with the default-path, so the
@@ -39,7 +47,7 @@ pub const RFC_6265_4_1_1: SpecRef = SpecRef {
     spec: "RFC 6265",
     section: Some("4.1.1"),
     url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-4.1.1",
-    note: "Set-Cookie syntax — servers SHOULD NOT send a non-conforming Set-Cookie; `path-value` excludes control characters and `;`",
+    note: "Set-Cookie syntax — servers SHOULD NOT send a non-conforming Set-Cookie; the `cookie-av` list, where each attribute is written with or without a value, and the `path-value` that excludes control characters and `;`",
 };
 
 /// What a user agent does with a `Path` it cannot use — the sentence behind
@@ -219,7 +227,105 @@ defects! {
         default_severity: Severity::Warn,
         spec: Some(RFC_6265_5_1_3),
     }
+
+    /// `SameSite` written as a bare attribute. The attribute is the whole of
+    /// its policy — there is no default it selects by being present — so a
+    /// server that wrote it with no value asked for nothing and got the
+    /// behaviour it would have had without the attribute at all.
+    ///
+    // cite(draft-ietf-httpbis-rfc6265bis § 4.1.1): "samesite-value = "Strict" / "Lax" / "None""
+    COOKIE_SAME_SITE_MISSING = {
+        id: "cookie_same_site_missing",
+        title: "Set-Cookie SameSite attribute carries no value",
+        message: "Set-Cookie attribute 'SameSite' requires a value",
+        default_severity: Severity::Warn,
+        spec: Some(DRAFT_IETF_HTTPBIS_RFC6265BIS),
+    }
+
+    /// A `SameSite` value that is none of the three the grammar lists. It is
+    /// `_invalid` rather than `_malformed` because the value is a perfectly
+    /// good token and what it is not is a *member of a closed list* — and the
+    /// consequence is the one that makes this worth reporting: an unknown value
+    /// does not fail loudly, it falls back to the user agent's default policy,
+    /// so a server asking for one thing quietly receives another.
+    ///
+    /// The comparison folds case, which is the grammar's doing: the three
+    /// alternatives are ABNF string literals.
+    ///
+    // cite(draft-ietf-httpbis-rfc6265bis § 4.1.1): "samesite-value = "Strict" / "Lax" / "None""
+    COOKIE_SAME_SITE_INVALID = {
+        id: "cookie_same_site_invalid",
+        title: "Set-Cookie SameSite names no policy the grammar defines",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(DRAFT_IETF_HTTPBIS_RFC6265BIS),
+    }
+
+    /// `Max-Age` written as a bare attribute, with no number after it.
+    ///
+    // cite(RFC 6265 § 4.1.1, label: cookie-av alternatives): "max-age-av        = "Max-Age=" non-zero-digit *DIGIT"
+    COOKIE_MAX_AGE_MISSING = {
+        id: "cookie_max_age_missing",
+        title: "Set-Cookie Max-Age attribute carries no value",
+        message: "Set-Cookie attribute 'Max-Age' requires a numeric value",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_6265_4_1_1),
+    }
+
+    /// A `Max-Age` a user agent will not read a number out of. § 5.2.2 states
+    /// the two gates — a first character that is a DIGIT or `-`, and a
+    /// remainder that is all DIGITs — and tells the user agent to ignore the
+    /// attribute when either fails, which is why this matters more than a
+    /// mistyped number usually would: the cookie does not get a bad lifetime,
+    /// it gets *no* lifetime and becomes a session cookie.
+    ///
+    /// A leading `-` is not this defect. The ABNF summary writes
+    /// `non-zero-digit *DIGIT` and the processing algorithm admits the sign,
+    /// and a negative `Max-Age` is how a cookie is deleted — the algorithm is
+    /// what a user agent runs, so it is what the entry measures.
+    ///
+    // cite(RFC 6265 § 5.2.2): "If the remainder of attribute-value contains a non-DIGIT character, ignore the cookie-av."
+    COOKIE_MAX_AGE_MALFORMED = {
+        id: "cookie_max_age_malformed",
+        title: "Set-Cookie Max-Age is not a number a user agent will read",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_6265_5_2_2),
+    }
+
+    /// `Expires` written as a bare attribute. The timestamp itself is
+    /// [`http_date`](crate::violations::http_date)'s — `sane-cookie-date` is
+    /// RFC 6265's name for the same production — so what is left here is the
+    /// attribute having no value for that production to read.
+    ///
+    // cite(RFC 6265 § 4.1.1, label: expires-av): "expires-av        = "Expires=" sane-cookie-date"
+    COOKIE_EXPIRES_MISSING = {
+        id: "cookie_expires_missing",
+        title: "Set-Cookie Expires attribute carries no value",
+        message: "Set-Cookie attribute 'Expires' requires a HTTP-date value",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_6265_4_1_1),
+    }
 }
+
+/// The `Max-Age` processing algorithm: the two gates a value passes before a
+/// user agent reads a number out of it, and the instruction to drop the
+/// attribute when it does not.
+pub const RFC_6265_5_2_2: SpecRef = SpecRef {
+    spec: "RFC 6265",
+    section: Some("5.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.2",
+    note: "The Max-Age attribute — ignored unless it is a `-`-or-DIGIT first character with an all-DIGIT remainder",
+};
+
+/// The `SameSite` attribute, in the draft that defines it. No section: a draft
+/// renumbers between revisions, and the value list has moved once already.
+pub const DRAFT_IETF_HTTPBIS_RFC6265BIS: SpecRef = SpecRef {
+    spec: "draft-ietf-httpbis-rfc6265bis",
+    section: None,
+    url: "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis",
+    note: "`SameSite` value grammar and the `SameSite=None` requires `Secure` rule. No section: a draft renumbers between revisions",
+};
 
 /// The defect a parsed [`CookiePathDefect`] reports as.
 ///

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -387,7 +387,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 170;
+        const FLOOR: usize = 175;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -726,18 +726,20 @@ sources:
   url: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis
   type: text/html
   fragments:
-  - label: cookie_attribute_consistent
+  - label: cookie
     section: § 4.1.1
     snippet: samesite-value = "Strict" / "Lax" / "None"
     cited_by:
-    - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 174
-  - label: cookie_attribute_consistent (2)
+    - file: lint-http-rules/src/violations/cookie.rs
+      line: 236
+    - file: lint-http-rules/src/violations/cookie.rs
+      line: 255
+  - label: cookie_attribute_consistent
     section: § 5.7
     snippet: If the cookie's "same-site-flag" is "None", abort this algorithm and ignore the cookie entirely unless the cookie's secure-only-flag is true.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 130
+      line: 119
   - label: cookie_same_site_enforced
     section: § 4.1.2.7
     snippet: If the "SameSite" attribute's value is "Strict", the cookie will only be sent along with "same-site" requests.
@@ -2144,70 +2146,78 @@ sources:
 - label: RFC 6265
   url: https://www.rfc-editor.org/rfc/rfc6265.html
   fragments:
+  - label: cookie-av alternatives
+    section: § 4.1.1
+    snippet: max-age-av        = "Max-Age=" non-zero-digit *DIGIT
+    cited_by:
+    - file: lint-http-rules/src/violations/cookie.rs
+      line: 266
   - label: cookie
     section: § 5.1.3
     snippet: The string is a host name (i.e., not an IP address).
     cited_by:
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 201
+      line: 209
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 214
+      line: 222
   - label: cookie (2)
+    section: § 5.2.2
+    snippet: If the remainder of attribute-value contains a non-DIGIT character, ignore the cookie-av.
+    cited_by:
+    - file: lint-http-rules/src/violations/cookie.rs
+      line: 287
+  - label: cookie (3)
     section: § 5.2.3
     snippet: If the attribute-value is empty, the behavior is undefined.
     cited_by:
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 157
-  - label: cookie (3)
+      line: 165
+  - label: cookie (4)
     section: § 5.2.3
     snippet: Let cookie-domain be the attribute-value without the leading %x2E (".") character.
     cited_by:
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 172
+      line: 180
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 187
+      line: 195
   - label: cookie_attribute_consistent
     section: § 4.1.1
     snippet: cookie-pair       = cookie-name "=" cookie-value cookie-name       = token
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 100
-  - label: cookie_attribute_consistent (2)
+      line: 89
+  - label: expires-av
     section: § 4.1.1
     snippet: expires-av        = "Expires=" sane-cookie-date
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 227
-  - label: cookie_attribute_consistent (3)
+      line: 204
+    - file: lint-http-rules/src/violations/cookie.rs
+      line: 301
+  - label: cookie_attribute_consistent (2)
     section: § 4.1.1
     snippet: extension-av      = <any CHAR except CTLs or ";">
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 144
-  - label: cookie_attribute_consistent (4)
+      line: 133
+  - label: cookie_attribute_consistent (3)
     section: § 4.1.1
     snippet: httponly-av       = "HttpOnly"
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 154
-  - label: cookie_attribute_consistent (5)
+      line: 143
+  - label: cookie_attribute_consistent (4)
     section: § 4.1.1
     snippet: secure-av         = "Secure"
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 153
-  - label: cookie_attribute_consistent (6)
+      line: 142
+  - label: cookie_attribute_consistent (5)
     section: § 5.2.2
     snippet: If the first character of the attribute-value is not a DIGIT or a "-" character, ignore the cookie-av.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 201
-  - label: cookie_attribute_consistent (7)
-    section: § 5.2.2
-    snippet: If the remainder of attribute-value contains a non-DIGIT character, ignore the cookie-av.
-    cited_by:
-    - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 202
+      line: 183
   - label: cookie_domain_matching
     section: § 5.4
     snippet: 'Let cookie-list be the set of cookies from the cookie store that meets all of the following requirements:'
@@ -2271,9 +2281,9 @@ sources:
     - file: lint-http-rules/src/helpers/cookie.rs
       line: 99
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 118
+      line: 126
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 131
+      line: 139
   - label: lint-http-rules/src/helpers/cookie.rs (2)
     section: § 4.1.1
     snippet: cookie-av         = expires-av / max-age-av / domain-av / path-av / secure-av / httponly-av / extension-av
@@ -2335,11 +2345,11 @@ sources:
     - file: lint-http-rules/src/helpers/cookie.rs
       line: 348
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 82
+      line: 90
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 93
+      line: 101
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 106
+      line: 114
   - label: lint-http-rules/src/helpers/cookie.rs (9)
     section: § 5.3
     snippet: Set the cookie's host-only-flag to true.


### PR DESCRIPTION
SameSite, Max-Age and Expires get their own entries, and the argument for reporting them is the same in all three: each has a processing algorithm that throws away what it cannot read. A stray character in a Max-Age is not a bad lifetime, it is no lifetime and a session cookie; an unknown SameSite falls back to the default policy instead of failing. The server asked for one thing and quietly received another, with no error anywhere in the exchange.

The SameSite value is _invalid and not _malformed: it is a perfectly good token that is not a member of a closed list.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
