### PR TITLE
When the cookie is lost, not an attribute

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1291,6 +1291,10 @@ severity = "warn"
 # Set-Cookie Expires attribute carries no value
 severity = "warn"
 
+[violations.cookie_flag_value_forbidden]
+# Set-Cookie writes a value on a flag attribute
+severity = "warn"
+
 [violations.cookie_max_age_malformed]
 # Set-Cookie Max-Age is not a number a user agent will read
 severity = "warn"
@@ -1298,6 +1302,10 @@ severity = "warn"
 [violations.cookie_max_age_missing]
 # Set-Cookie Max-Age attribute carries no value
 severity = "warn"
+
+[violations.cookie_pair_missing]
+# Set-Cookie carries no cookie-pair
+severity = "error"
 
 [violations.cookie_path_control_character_forbidden]
 # Set-Cookie Path attribute holds a control character
@@ -1330,6 +1338,10 @@ severity = "warn"
 [violations.cookie_same_site_missing]
 # Set-Cookie SameSite attribute carries no value
 severity = "warn"
+
+[violations.cookie_secure_missing]
+# A SameSite=None cookie is not Secure
+severity = "error"
 
 [violations.credentials_control_character_forbidden]
 # Credentials hold a control character

--- a/lint-http-rules/src/rules/cookie_attribute_consistent.rs
+++ b/lint-http-rules/src/rules/cookie_attribute_consistent.rs
@@ -6,10 +6,11 @@ use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
 use crate::violations::cookie::DRAFT_IETF_HTTPBIS_RFC6265BIS;
 use crate::violations::cookie::{
-    COOKIE_DOMAIN_EMPTY, COOKIE_DOMAIN_MISSING, COOKIE_EXPIRES_MISSING, COOKIE_MAX_AGE_MALFORMED,
-    COOKIE_MAX_AGE_MISSING, COOKIE_PATH_LEADING_SLASH_MISSING, COOKIE_PATH_MISSING,
-    COOKIE_SAME_SITE_INVALID, COOKIE_SAME_SITE_MISSING, RFC_6265_4_1_1, RFC_6265_5_2_2,
-    RFC_6265_5_2_3, RFC_6265_5_2_4,
+    COOKIE_DOMAIN_EMPTY, COOKIE_DOMAIN_MISSING, COOKIE_EXPIRES_MISSING,
+    COOKIE_FLAG_VALUE_FORBIDDEN, COOKIE_MAX_AGE_MALFORMED, COOKIE_MAX_AGE_MISSING,
+    COOKIE_PAIR_MISSING, COOKIE_PATH_LEADING_SLASH_MISSING, COOKIE_PATH_MISSING,
+    COOKIE_SAME_SITE_INVALID, COOKIE_SAME_SITE_MISSING, COOKIE_SECURE_MISSING, RFC_6265_4_1_1,
+    RFC_6265_5_2_2, RFC_6265_5_2_3, RFC_6265_5_2_4,
 };
 use crate::violations::domain::{DOMAIN_NAME_WHITESPACE_OR_CONTROL_FORBIDDEN, RFC_1035_2_3_1};
 use crate::violations::http_date::{HTTP_DATE_MALFORMED, RFC_9110_5_6_7};
@@ -38,6 +39,9 @@ pub struct CookieAttributeConsistent;
 /// the pairing that makes a `SameSite=None` cookie disappear.
 static DECLARED: &[&ViolationDef] = &[
     &HTTP_DATE_MALFORMED,
+    &COOKIE_PAIR_MISSING,
+    &COOKIE_FLAG_VALUE_FORBIDDEN,
+    &COOKIE_SECURE_MISSING,
     &COOKIE_SAME_SITE_MISSING,
     &COOKIE_SAME_SITE_INVALID,
     &COOKIE_MAX_AGE_MISSING,
@@ -75,12 +79,9 @@ impl CookieAttributeConsistent {
         line: &str,
         ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        // The unconverted branches read the rule's own severity, exactly as
-        // they did before the context was threaded through.
-        let severity = ctx.severity;
         let (pair, attributes) = crate::helpers::cookie::split_set_cookie(line);
         if pair.is_empty() {
-            return Some(self.violation(severity, "Set-Cookie header missing cookie-pair".into()));
+            return Some(ctx.report(&COOKIE_PAIR_MISSING));
         }
 
         // The name is a `token` by import rather than by resemblance -- § 4.1.1
@@ -118,10 +119,7 @@ impl CookieAttributeConsistent {
         // a suggestion.
         // cite(draft-ietf-httpbis-rfc6265bis § 5.7): "If the cookie's "same-site-flag" is "None", abort this algorithm and ignore the cookie entirely unless the cookie's secure-only-flag is true."
         if same_site.as_deref() == Some("none") && !secure_present {
-            return Some(self.violation(
-                severity,
-                "Set-Cookie with 'SameSite=None' must also set 'Secure'".into(),
-            ));
+            return Some(ctx.report(&COOKIE_SECURE_MISSING));
         }
         None
     }
@@ -136,7 +134,6 @@ impl CookieAttributeConsistent {
         attribute: &crate::helpers::cookie::Attribute<'_>,
         ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let severity = ctx.severity;
         // The two flag attributes: the grammar admits no "=", so the attribute
         // is its own presence and a value written after it is a defect.
         // cite(RFC 6265 § 4.1.1): "secure-av         = "Secure""
@@ -144,9 +141,8 @@ impl CookieAttributeConsistent {
         for flag in ["Secure", "HttpOnly"] {
             if attribute.is(flag) {
                 return attribute.has_value().then(|| {
-                    self.cited(
-                        &RFC_6265_4_1_1,
-                        severity,
+                    ctx.report_with(
+                        &COOKIE_FLAG_VALUE_FORBIDDEN,
                         format!("Set-Cookie attribute '{}' must not have a value", flag),
                     )
                 });

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1312,7 +1312,7 @@ severity = "warn"
         /// directive list, and neither says anything about an encoding. Each
         /// field's octet is now `token`'s, under an id the rule already
         /// declared.
-        const FLOOR: usize = 127;
+        const FLOOR: usize = 126;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/violations/cookie.rs
+++ b/lint-http-rules/src/violations/cookie.rs
@@ -12,6 +12,16 @@
 //! [`crate::violations::domain`] where a rule reading a `From` mailbox can
 //! report the same ones.
 //!
+//! **Two entries are ranked above the rest, and one line separates them from
+//! it: whether the *cookie* is lost or an attribute is.** A `Set-Cookie` with
+//! no cookie-pair sets nothing, and a `SameSite=None` without `Secure` is
+//! thrown away entirely by the user agent — in both cases the server believes
+//! it stored state and did not. Everything else here costs an attribute: a
+//! discarded `Max-Age`, a `Path` replaced by the default-path, a `SameSite`
+//! that falls back. That is the difference between `error` and `warn` in this
+//! subject, and it is a property of the processing algorithm rather than a
+//! judgment about how much any of it matters.
+//!
 //! **The `SameSite`, `Max-Age` and `Expires` entries are a third kind, and
 //! they are why this subject cannot be filed under "syntax".** Each of those
 //! attributes has a processing algorithm that *discards* what it cannot read: a
@@ -291,6 +301,62 @@ defects! {
         message: "",
         default_severity: Severity::Warn,
         spec: Some(RFC_6265_5_2_2),
+    }
+
+    /// A `Set-Cookie` field line with no cookie-pair on it: nothing before the
+    /// first `;`, or a line that is attributes from the start. The line sets no
+    /// cookie — the pair is the cookie, and the attributes only describe one —
+    /// so a server that wrote this believes it stored state and stored none.
+    ///
+    /// `error`, with the pairing entry below and for the same reason: what is
+    /// lost is the whole cookie rather than one of its attributes.
+    ///
+    // cite(RFC 6265 § 4.1.1, label: set-cookie-string): "set-cookie-header = "Set-Cookie:" SP set-cookie-string set-cookie-string = cookie-pair *( ";" SP cookie-av )"
+    COOKIE_PAIR_MISSING = {
+        id: "cookie_pair_missing",
+        title: "Set-Cookie carries no cookie-pair",
+        message: "Set-Cookie header missing cookie-pair",
+        default_severity: Severity::Error,
+        spec: Some(RFC_6265_4_1_1),
+    }
+
+    /// A value written on `Secure` or `HttpOnly`. Both attributes are their own
+    /// presence — the grammar is the bare word, with no `=` in it — so
+    /// `Secure=true` and `Secure=false` are the same attribute, and a server
+    /// writing the second has switched nothing off.
+    ///
+    /// `warn`: a user agent reads the attribute by name and the cookie keeps
+    /// the protection either way, so what is wrong is the sender's belief about
+    /// what it wrote rather than the state it stored.
+    ///
+    // cite(RFC 6265 § 4.1.1, label: the flag attributes): "secure-av         = "Secure" httponly-av       = "HttpOnly""
+    COOKIE_FLAG_VALUE_FORBIDDEN = {
+        id: "cookie_flag_value_forbidden",
+        title: "Set-Cookie writes a value on a flag attribute",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_6265_4_1_1),
+    }
+
+    /// `SameSite=None` on a cookie that is not `Secure`. The two attributes are
+    /// each unremarkable and the pairing is what fails: a user agent asked to
+    /// send a cookie cross-site over an insecure connection ignores the cookie
+    /// entirely.
+    ///
+    /// **The id names the missing attribute rather than the pair**, because
+    /// that is what a server fixes: `Secure` is what is absent, and
+    /// `SameSite=None` is the condition that makes its absence fatal. An id
+    /// spelled for the pairing would have to be read backwards to act on.
+    ///
+    /// `error`, with the entry above: the cookie is discarded, not weakened.
+    ///
+    // cite(draft-ietf-httpbis-rfc6265bis § 5.7): "If the cookie's "same-site-flag" is "None", abort this algorithm and ignore the cookie entirely unless the cookie's secure-only-flag is true."
+    COOKIE_SECURE_MISSING = {
+        id: "cookie_secure_missing",
+        title: "A SameSite=None cookie is not Secure",
+        message: "Set-Cookie with 'SameSite=None' must also set 'Secure'",
+        default_severity: Severity::Error,
+        spec: Some(DRAFT_IETF_HTTPBIS_RFC6265BIS),
     }
 
     /// `Expires` written as a bare attribute. The timestamp itself is

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -387,7 +387,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 175;
+        const FLOOR: usize = 178;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -731,15 +731,17 @@ sources:
     snippet: samesite-value = "Strict" / "Lax" / "None"
     cited_by:
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 236
+      line: 246
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 255
+      line: 265
   - label: cookie_attribute_consistent
     section: § 5.7
     snippet: If the cookie's "same-site-flag" is "None", abort this algorithm and ignore the cookie entirely unless the cookie's secure-only-flag is true.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 119
+      line: 120
+    - file: lint-http-rules/src/violations/cookie.rs
+      line: 353
   - label: cookie_same_site_enforced
     section: § 4.1.2.7
     snippet: If the "SameSite" attribute's value is "Strict", the cookie will only be sent along with "same-site" requests.
@@ -2151,73 +2153,85 @@ sources:
     snippet: max-age-av        = "Max-Age=" non-zero-digit *DIGIT
     cited_by:
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 266
+      line: 276
+  - label: the flag attributes
+    section: § 4.1.1
+    snippet: secure-av         = "Secure" httponly-av       = "HttpOnly"
+    cited_by:
+    - file: lint-http-rules/src/violations/cookie.rs
+      line: 332
+  - label: set-cookie-string
+    section: § 4.1.1
+    snippet: set-cookie-header = "Set-Cookie:" SP set-cookie-string set-cookie-string = cookie-pair *( ";" SP cookie-av )
+    cited_by:
+    - file: lint-http-rules/src/violations/cookie.rs
+      line: 314
   - label: cookie
     section: § 5.1.3
     snippet: The string is a host name (i.e., not an IP address).
     cited_by:
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 209
+      line: 219
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 222
+      line: 232
   - label: cookie (2)
     section: § 5.2.2
     snippet: If the remainder of attribute-value contains a non-DIGIT character, ignore the cookie-av.
     cited_by:
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 287
+      line: 297
   - label: cookie (3)
     section: § 5.2.3
     snippet: If the attribute-value is empty, the behavior is undefined.
     cited_by:
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 165
+      line: 175
   - label: cookie (4)
     section: § 5.2.3
     snippet: Let cookie-domain be the attribute-value without the leading %x2E (".") character.
     cited_by:
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 180
+      line: 190
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 195
+      line: 205
   - label: cookie_attribute_consistent
     section: § 4.1.1
     snippet: cookie-pair       = cookie-name "=" cookie-value cookie-name       = token
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 89
+      line: 90
   - label: expires-av
     section: § 4.1.1
     snippet: expires-av        = "Expires=" sane-cookie-date
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 204
+      line: 200
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 301
+      line: 367
   - label: cookie_attribute_consistent (2)
     section: § 4.1.1
     snippet: extension-av      = <any CHAR except CTLs or ";">
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 133
+      line: 131
   - label: cookie_attribute_consistent (3)
     section: § 4.1.1
     snippet: httponly-av       = "HttpOnly"
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 143
+      line: 140
   - label: cookie_attribute_consistent (4)
     section: § 4.1.1
     snippet: secure-av         = "Secure"
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 142
+      line: 139
   - label: cookie_attribute_consistent (5)
     section: § 5.2.2
     snippet: If the first character of the attribute-value is not a DIGIT or a "-" character, ignore the cookie-av.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 183
+      line: 179
   - label: cookie_domain_matching
     section: § 5.4
     snippet: 'Let cookie-list be the set of cookies from the cookie store that meets all of the following requirements:'
@@ -2281,9 +2295,9 @@ sources:
     - file: lint-http-rules/src/helpers/cookie.rs
       line: 99
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 126
+      line: 136
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 139
+      line: 149
   - label: lint-http-rules/src/helpers/cookie.rs (2)
     section: § 4.1.1
     snippet: cookie-av         = expires-av / max-age-av / domain-av / path-av / secure-av / httponly-av / extension-av
@@ -2345,11 +2359,11 @@ sources:
     - file: lint-http-rules/src/helpers/cookie.rs
       line: 348
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 90
+      line: 100
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 101
+      line: 111
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 114
+      line: 124
   - label: lint-http-rules/src/helpers/cookie.rs (9)
     section: § 5.3
     snippet: Set the cookie's host-only-flag to true.


### PR DESCRIPTION
The last three findings of the Set-Cookie reader: a line with no cookie-pair on it, a value written on a flag whose grammar is the bare word, and a SameSite=None cookie that is not Secure. The rule converts whole.

Two of them rank above everything else in the subject, and one line separates them from it — whether the cookie is lost or an attribute is. A line with no pair sets nothing and a SameSite=None without Secure is ignored entirely, while a discarded Max-Age or a replaced Path costs one attribute. The pairing entry names the missing attribute rather than the pair, because Secure is what a server adds to fix it.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
