### PR TITLE
The field a 101 owes its client

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1755,6 +1755,14 @@ severity = "warn"
 # A coding is applied in transit that the representation already carries
 severity = "info"
 
+[violations.upgrade_empty]
+# A 101 response names no protocol on its Upgrade field
+severity = "error"
+
+[violations.upgrade_missing]
+# A 101 response carries no Upgrade field
+severity = "error"
+
 [violations.uri_character_forbidden]
 # Value holds a character no URI is written with
 severity = "warn"

--- a/docs/rules/status_101_switching_protocols.md
+++ b/docs/rules/status_101_switching_protocols.md
@@ -17,7 +17,7 @@ Validates that `101 Switching Protocols` responses follow correct HTTP upgrade s
 
 ## Specifications
 
-- [RFC 9110 §15.2.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.2.2): 101 Switching Protocols
+- [RFC 9110 §15.2.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.2.2): 101 Switching Protocols — the response MUST generate an `Upgrade` field naming the protocol(s) in effect after it
 - [RFC 9110 §7.8](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8): Upgrade
 - [RFC 9113 §8.6](https://www.rfc-editor.org/rfc/rfc9113.html#section-8.6): The Upgrade Header Field (HTTP/2 forbids 101)
 - [RFC 9114 §4.5](https://www.rfc-editor.org/rfc/rfc9114.html#section-4.5): HTTP Upgrade — the only place RFC 9114 mentions 101; forbids it alongside the Upgrade mechanism

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1312,7 +1312,7 @@ severity = "warn"
         /// directive list, and neither says anything about an encoding. Each
         /// field's octet is now `token`'s, under an id the rule already
         /// declared.
-        const FLOOR: usize = 126;
+        const FLOOR: usize = 124;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/rules/status_101_switching_protocols.rs
+++ b/lint-http-rules/src/rules/status_101_switching_protocols.rs
@@ -4,6 +4,8 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::upgrade::{RFC_9110_15_2_2, UPGRADE_EMPTY, UPGRADE_MISSING};
+use crate::violations::ViolationDef;
 
 /// Validate 101 Switching Protocols responses follow correct upgrade semantics.
 ///
@@ -23,12 +25,12 @@ pub struct Status101SwitchingProtocols;
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_9110_15_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("15.2.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.2.2",
-    note: "101 Switching Protocols",
-};
+/// The `Upgrade` field a 101 owes, and the two ways it is not there. The rest
+/// of what this rule says is about the status code itself — a version that has
+/// no upgrade mechanism, a protocol nobody offered, traffic after the switch —
+/// and each of those is a reading of its own.
+static DECLARED: &[&ViolationDef] = &[&UPGRADE_MISSING, &UPGRADE_EMPTY];
+
 const RFC_9110_7_8: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
     section: Some("7.8"),
@@ -65,6 +67,10 @@ severity = "warn"
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[RFC_9110_15_2_2, RFC_9110_7_8, RFC_9113_8_6, RFC_9114_4_5]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -217,16 +223,14 @@ impl Rule for Status101SwitchingProtocols {
             let req_upgrade_val = req_upgrade_combined.unwrap();
 
             // ── Check: 101 response missing Upgrade header ──
-            // cite(RFC 9110 § 15.2.2): "The server MUST generate an Upgrade header field in the response that indicates which protocol(s) will be in effect after this response."
             let resp_upgrade_combined =
                 crate::helpers::headers::get_all_header_values(&resp.headers, "upgrade");
             if resp_upgrade_combined.is_none() {
                 return Some(
-                    self.cited(
-                        &RFC_9110_15_2_2,
-                        ctx.severity,
+                    ctx.report_with(
+                        &UPGRADE_MISSING,
                         "101 Switching Protocols response missing required Upgrade header \
-                         (RFC 9110 §15.2.2)"
+                     (RFC 9110 §15.2.2)"
                             .into(),
                     ),
                 );
@@ -261,15 +265,14 @@ impl Rule for Status101SwitchingProtocols {
             }
 
             // An empty chosen list is a response Upgrade that indicates no protocol —
-            // the same MUST-generate obligation as the missing-header check above.
-            // cite(RFC 9110 § 15.2.2): "The server MUST generate an Upgrade header field in the response that indicates which protocol(s) will be in effect after this response."
+            // the same MUST-generate obligation as the missing-header check above, and
+            // the entry beside it.
             if chosen_list.is_empty() {
                 return Some(
-                    self.cited(
-                        &RFC_9110_15_2_2,
-                        ctx.severity,
+                    ctx.report_with(
+                        &UPGRADE_EMPTY,
                         "101 Switching Protocols response Upgrade header contains no protocol \
-                         tokens (RFC 9110 §15.2.2)"
+                     tokens (RFC 9110 §15.2.2)"
                             .into(),
                     ),
                 );

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -66,6 +66,7 @@ pub mod token;
 pub mod token68;
 pub mod transfer_coding;
 pub mod transfer_encoding;
+pub mod upgrade;
 pub mod uri;
 
 /// One reportable defect.
@@ -387,7 +388,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 178;
+        const FLOOR: usize = 180;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/upgrade.rs
+++ b/lint-http-rules/src/violations/upgrade.rs
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `Upgrade` defects — the field a `101` owes, and what is on it.
+//!
+//! A `101 (Switching Protocols)` is a connection changing hands: everything
+//! after the response's empty line is spoken in another protocol. The status
+//! code says the change happened and the `Upgrade` field says *what to*, which
+//! is why RFC 9110 § 15.2.2 requires the field of the response rather than
+//! merely recommending it — a client that has stopped speaking HTTP and does
+//! not know what it is now speaking has no way to continue and no way to ask.
+//!
+//! **The subject is the field even though the requirement is written into a
+//! status code's section**, which is the line `content_range` draws for the
+//! same shape: the sentence is addressed to the field's presence, and it is the
+//! field an operator would look for in the message. What the status code owes
+//! *about itself* — that it may not be sent at all over a version with no
+//! upgrade mechanism, that it may not switch to something nobody offered —
+//! belongs to [`status`](crate::violations::status).
+//!
+//! Both entries are `error`, and it is the same argument in two halves: the
+//! response has already ended the HTTP conversation, so there is no later
+//! message in which the omission can be repaired.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// The status code's section, where the requirement on the field is written.
+pub const RFC_9110_15_2_2: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.2.2",
+    note: "101 Switching Protocols — the response MUST generate an `Upgrade` field naming the protocol(s) in effect after it",
+};
+
+defects! {
+    /// A `101` response with no `Upgrade` field on it at all. The connection
+    /// has changed protocol and the message that changed it does not say to
+    /// what.
+    ///
+    // cite(RFC 9110 § 15.2.2): "The server MUST generate an Upgrade header field in the response that indicates which protocol(s) will be in effect after this response."
+    UPGRADE_MISSING = {
+        id: "upgrade_missing",
+        title: "A 101 response carries no Upgrade field",
+        message: "",
+        default_severity: Severity::Error,
+        spec: Some(RFC_9110_15_2_2),
+    }
+
+    /// The field written, and no protocol name on it: an empty value, or one
+    /// made of nothing but the commas of a list.
+    ///
+    /// Separated from the absent field the way `docs/development.md` requires,
+    /// and here the two senders really are different: a field that is not there
+    /// is a server that never learned the requirement, while `Upgrade:` with
+    /// nothing after it is a server that built the value from a list and found
+    /// the list empty. The recipient is equally stuck either way, which is why
+    /// the two rank the same.
+    ///
+    // cite(RFC 9110 § 15.2.2): "The server MUST generate an Upgrade header field in the response that indicates which protocol(s) will be in effect after this response."
+    UPGRADE_EMPTY = {
+        id: "upgrade_empty",
+        title: "A 101 response names no protocol on its Upgrade field",
+        message: "",
+        default_severity: Severity::Error,
+        spec: Some(RFC_9110_15_2_2),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The pair `docs/development.md` keeps apart everywhere: never written
+    /// against written blank. They rank together because the *recipient* is in
+    /// the same position for both — the conversation has already left HTTP.
+    #[test]
+    fn the_absent_field_and_the_blank_one_are_two_ids_of_one_rank() {
+        assert_eq!(UPGRADE_MISSING.id, "upgrade_missing");
+        assert_eq!(UPGRADE_EMPTY.id, "upgrade_empty");
+        assert_eq!(UPGRADE_MISSING.default_severity, Severity::Error);
+        assert_eq!(UPGRADE_EMPTY.default_severity, Severity::Error);
+    }
+}

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -8749,37 +8749,29 @@ sources:
     snippet: The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field (Section 7.8), for a change in the application protocol being used on this connection.
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 130
+      line: 136
   - label: status_101_switching_protocols (2)
-    section: § 15.2.2
-    snippet: The server MUST generate an Upgrade header field in the response that indicates which protocol(s) will be in effect after this response.
-    cited_by:
-    - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 220
-    - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 265
-  - label: status_101_switching_protocols (3)
     section: § 7.8
     snippet: A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field.
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 205
+      line: 211
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 250
+      line: 254
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 281
-  - label: status_101_switching_protocols (4)
+      line: 284
+  - label: status_101_switching_protocols (3)
     section: § 7.8
     snippet: A server that receives an Upgrade header field in an HTTP/1.0 request MUST ignore that Upgrade field.
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 155
-  - label: status_101_switching_protocols (5)
+      line: 161
+  - label: status_101_switching_protocols (4)
     section: § 7.8
     snippet: Although protocol names are registered with a preferred case, recipients SHOULD use case-insensitive comparison when matching each protocol-name to supported protocols.
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 239
+      line: 243
   - label: status_103_early_hints_before_final
     section: § 15.2
     snippet: Since HTTP/1.0 did not define any 1xx status codes, a server MUST NOT send a 1xx response to an HTTP/1.0 client.
@@ -9160,6 +9152,14 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 350
+  - label: upgrade
+    section: § 15.2.2
+    snippet: The server MUST generate an Upgrade header field in the response that indicates which protocol(s) will be in effect after this response.
+    cited_by:
+    - file: lint-http-rules/src/violations/upgrade.rs
+      line: 43
+    - file: lint-http-rules/src/violations/upgrade.rs
+      line: 62
   - label: upgrade_and_connection_consistent
     section: § 7.6.1
     snippet: In contrast, a connection-specific field received without a corresponding connection option usually indicates that the field has been improperly forwarded by an intermediary and ought to be ignored by the recipient.
@@ -10580,7 +10580,7 @@ sources:
     snippet: HTTP/2 does not support the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 170
+      line: 176
   - label: the TE exception
     section: § 8.2.2
     snippet: The only exception to this is the TE header field, which MAY be present in an HTTP/2 request; when it is, it MUST NOT contain any value other than "trailers".
@@ -10769,7 +10769,7 @@ sources:
     - file: lint-http-rules/src/rules/http3_status_code_valid.rs
       line: 125
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 186
+      line: 192
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
       line: 169
   - label: lint-http-core/src/http_version.rs


### PR DESCRIPTION
A 101 is a connection changing hands: everything after the empty line is spoken in another protocol, and the Upgrade field is what says which one. So a response that omits it, or writes it with nothing on it, leaves a client that has stopped speaking HTTP with no way to continue and no way to ask — which is why both entries are error and why they rank together despite being the missing/empty pair.

The subject is the field though the requirement is written into a status code's section, the line Content-Range already draws: the sentence is addressed to the field's presence. What the status owes about itself stays with the status.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
