### PR TITLE
When two documents state one defect

### DIFF
--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -176,13 +176,24 @@ impl<'a> RuleContext<'a> {
     /// The common half: everything but the message comes from the def and the
     /// context, so the two entry points differ only in where the message came
     /// from.
+    ///
+    /// A finding is cited when its def names exactly one sentence. A def
+    /// naming several names them because no one of them governs — the
+    /// requirement is written once per protocol version — and picking one here
+    /// would put an HTTP/2 reference on an HTTP/3 finding half the time. Such a
+    /// finding says which section governs it in its own message, which is what
+    /// it did while the entry carried no reference at all; the references are
+    /// on the def for the catalogue and the docs to read.
     fn finding(&self, def: &'static ViolationDef, message: String) -> Violation {
         Violation {
             rule: self.rule_id.into(),
             violation: def.id.into(),
             severity: self.severity_for(def),
             message,
-            cite: def.spec.as_ref().map(SpecRef::citation),
+            cite: match def.spec {
+                [only] => Some(only.citation()),
+                _ => None,
+            },
         }
     }
 
@@ -1860,12 +1871,12 @@ severity = "warn"
         title: "A defect with one wording",
         message: "the fixture is malformed",
         default_severity: crate::lint::Severity::Warn,
-        spec: Some(SpecRef {
+        spec: &[SpecRef {
             spec: "RFC 0000",
             section: Some("1"),
             url: "https://example.com/",
             note: "",
-        }),
+        }],
     };
 
     /// A defect whose wording names what caused it, so the message is formatted
@@ -1875,7 +1886,7 @@ severity = "warn"
         title: "A defect that names its value",
         message: "",
         default_severity: crate::lint::Severity::Error,
-        spec: None,
+        spec: &[],
     };
 
     /// What a rule's `violations()` returns: a named `static`, because an
@@ -1954,7 +1965,7 @@ severity = "warn"
             title: "A defect belonging to some other rule",
             message: "not this rule's to report",
             default_severity: crate::lint::Severity::Warn,
-            spec: None,
+            spec: &[],
         };
         let resolved = unit_resolved();
         let severities = [crate::lint::Severity::Warn, crate::lint::Severity::Warn];

--- a/lint-http-rules/src/rules/no_connection_specific_fields.rs
+++ b/lint-http-rules/src/rules/no_connection_specific_fields.rs
@@ -5,7 +5,7 @@
 use crate::helpers::headers::combined_field_value_as_written;
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
-use crate::violations::field::FIELD_CONNECTION_SPECIFIC_FORBIDDEN;
+use crate::violations::field::{FIELD_CONNECTION_SPECIFIC_FORBIDDEN, RFC_9113_8_2_2, RFC_9114_4_2};
 use crate::violations::te::TE_MEMBER_FORBIDDEN;
 use crate::violations::ViolationDef;
 
@@ -154,11 +154,8 @@ impl NoConnectionSpecificFields {
         // documents forbid is generating a message that *contains* the field.
         // Whether the value derives from the field's own production is the
         // question of the rule that owns that field, and it is a question about
-        // a message this one has already called malformed.
-        //
-        // cite(RFC 9113 § 8.2.2): "An endpoint MUST NOT generate an HTTP/2 message containing connection-specific header fields."
-        // cite(RFC 9113 § 8.2.2): "Any message containing connection-specific header fields MUST be treated as malformed (Section 8.1.1)."
-        // cite(RFC 9114 § 4.2): "An endpoint MUST NOT generate an HTTP/3 field section containing connection-specific fields; any message containing connection-specific fields MUST be treated as malformed."
+        // a message this one has already called malformed. Both prohibitions
+        // are quoted on the entry, which names both sections.
         for &name in CONNECTION_SPECIFIC_FIELDS {
             if headers.contains_key(name) {
                 return Some(ctx.report_with(
@@ -274,20 +271,10 @@ impl NoConnectionSpecificFields {
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_9113_8_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9113",
-    section: Some("8.2.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.2.2",
-    note: "Connection-Specific Header Fields — HTTP/2's prohibition, and the one \
-           sentence of the two that closes the list of names",
-};
-const RFC_9114_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9114",
-    section: Some("4.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.2",
-    note: "HTTP Fields — HTTP/3's prohibition, which enumerates nothing and defers \
-           to RFC 9110 §7.6.1",
-};
+///
+/// The two version documents are not among them: both defects this rule
+/// reports name *both* of those sections, so the references live on the entries
+/// in `violations/field.rs` and are imported back here for `specifications()`.
 const RFC_9110_7_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
     section: Some("7.6.1"),

--- a/lint-http-rules/src/violations/alpn.rs
+++ b/lint-http-rules/src/violations/alpn.rs
@@ -56,7 +56,7 @@ defects! {
         title: "ALPN protocol name is longer than the vector that carries it",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_7301_3_1),
+        spec: &[RFC_7301_3_1],
     }
 
     /// A well-formed name that this deployment does not serve. The sixth
@@ -79,7 +79,7 @@ defects! {
         title: "ALPN protocol name is not one this deployment serves",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_7838_2),
+        spec: &[RFC_7838_2],
     }
 }
 
@@ -92,8 +92,8 @@ mod tests {
     /// membership is a fact about a deployment.
     #[test]
     fn the_length_entry_is_the_one_that_needs_no_list() {
-        assert_eq!(ALPN_PROTOCOL_NAME_LENGTH_INVALID.spec, Some(RFC_7301_3_1));
-        assert_eq!(ALPN_PROTOCOL_NAME_UNREGISTERED.spec, Some(RFC_7838_2));
+        assert_eq!(ALPN_PROTOCOL_NAME_LENGTH_INVALID.spec, [RFC_7301_3_1]);
+        assert_eq!(ALPN_PROTOCOL_NAME_UNREGISTERED.spec, [RFC_7838_2]);
         assert_eq!(
             ALPN_PROTOCOL_NAME_LENGTH_INVALID.default_severity,
             Severity::Warn

--- a/lint-http-rules/src/violations/auth_scheme.rs
+++ b/lint-http-rules/src/violations/auth_scheme.rs
@@ -54,7 +54,7 @@ defects! {
         title: "Authentication scheme holds a character outside token",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_11_2),
+        spec: &[RFC_9110_11_2],
     }
 
     /// A scheme name that is a perfectly good `token` and is not one the
@@ -80,6 +80,6 @@ defects! {
         title: "Authentication scheme is not one the deployment recognises",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_11_1),
+        spec: &[RFC_9110_11_1],
     }
 }

--- a/lint-http-rules/src/violations/base64.rs
+++ b/lint-http-rules/src/violations/base64.rs
@@ -74,7 +74,7 @@ defects! {
         title: "Value is not a base64 encoding",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_4648_3_3),
+        spec: &[RFC_4648_3_3],
     }
 
     /// An octet the sixty-four characters do not hold. The finer half of
@@ -89,7 +89,7 @@ defects! {
         title: "Value holds an octet outside the base64 alphabet",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_4648_3_3),
+        spec: &[RFC_4648_3_3],
     }
 
     /// Every character is one the alphabet holds, and the sequence of them is
@@ -106,7 +106,7 @@ defects! {
         title: "Value is not a whole number of base64 groups",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_4648_4),
+        spec: &[RFC_4648_4],
     }
 
     /// A final symbol carrying bits a conforming encoder sets to zero. The
@@ -133,7 +133,7 @@ defects! {
         title: "Final base64 symbol carries bits a conforming encoder zeroes",
         message: "",
         default_severity: Severity::Info,
-        spec: Some(RFC_4648_3_5),
+        spec: &[RFC_4648_3_5],
     }
 }
 

--- a/lint-http-rules/src/violations/basic_credentials.rs
+++ b/lint-http-rules/src/violations/basic_credentials.rs
@@ -48,7 +48,7 @@ defects! {
         title: "Basic credentials hold no ':' separator",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_7617_2),
+        spec: &[RFC_7617_2],
     }
 
     /// A control octet in the user-id or in the password. One def for both
@@ -63,7 +63,7 @@ defects! {
         title: "Basic credentials hold a control character",
         message: "",
         default_severity: Severity::Error,
-        spec: Some(RFC_7617_2),
+        spec: &[RFC_7617_2],
     }
 }
 

--- a/lint-http-rules/src/violations/boundary.rs
+++ b/lint-http-rules/src/violations/boundary.rs
@@ -48,7 +48,7 @@ defects! {
         title: "A multipart media type carries no boundary parameter",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_2046_5_1_1),
+        spec: &[RFC_2046_5_1_1],
     }
 
     /// A character the delimiter set does not hold. The set is small and
@@ -64,7 +64,7 @@ defects! {
         title: "Boundary holds a character outside the delimiter set",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_2046_5_1_1),
+        spec: &[RFC_2046_5_1_1],
     }
 
     /// A boundary of no characters, or of more than seventy. The production
@@ -80,7 +80,7 @@ defects! {
         title: "Boundary is empty or longer than seventy characters",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_2046_5_1_1),
+        spec: &[RFC_2046_5_1_1],
     }
 
     /// A boundary whose last character is a space. SP is a `bchar` everywhere
@@ -99,7 +99,7 @@ defects! {
         title: "Boundary ends with a space",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_2046_5_1_1),
+        spec: &[RFC_2046_5_1_1],
     }
 }
 
@@ -119,7 +119,7 @@ mod tests {
             &BOUNDARY_LENGTH_INVALID,
             &BOUNDARY_TRAILING_SPACE_FORBIDDEN,
         ] {
-            assert_eq!(def.spec, Some(RFC_2046_5_1_1), "{}", def.id);
+            assert_eq!(def.spec, [RFC_2046_5_1_1], "{}", def.id);
         }
     }
 }

--- a/lint-http-rules/src/violations/bws.rs
+++ b/lint-http-rules/src/violations/bws.rs
@@ -65,7 +65,7 @@ defects! {
         title: "Whitespace written where the grammar admits BWS",
         message: "",
         default_severity: Severity::Info,
-        spec: Some(RFC_9110_5_6_3),
+        spec: &[RFC_9110_5_6_3],
     }
 }
 
@@ -89,12 +89,12 @@ mod tests {
             BWS_FORBIDDEN.default_severity,
             PARAMETER_EQUALS_WHITESPACE_FORBIDDEN.default_severity,
         );
-        assert_ne!(
-            BWS_FORBIDDEN.spec.expect("a sentence").section,
-            PARAMETER_EQUALS_WHITESPACE_FORBIDDEN
-                .spec
-                .expect("a sentence")
-                .section,
-        );
+        let [bws] = BWS_FORBIDDEN.spec else {
+            panic!("one sentence")
+        };
+        let [parameter] = PARAMETER_EQUALS_WHITESPACE_FORBIDDEN.spec else {
+            panic!("one sentence")
+        };
+        assert_ne!(bws.section, parameter.section);
     }
 }

--- a/lint-http-rules/src/violations/challenge.rs
+++ b/lint-http-rules/src/violations/challenge.rs
@@ -64,7 +64,7 @@ defects! {
         title: "Authentication challenge is empty",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_11_3),
+        spec: &[RFC_9110_11_3],
     }
 
     /// An empty member of the field's `#challenge` list — a doubled comma, or
@@ -78,7 +78,7 @@ defects! {
         title: "Authentication challenge list has an empty member",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_11_6_1),
+        spec: &[RFC_9110_11_6_1],
     }
 
     /// An `auth-param` where the list has not had an `auth-scheme` yet. The
@@ -91,7 +91,7 @@ defects! {
         title: "Authentication parameter arrives before any scheme",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_11_3),
+        spec: &[RFC_9110_11_3],
     }
 
     /// A single bare word after the scheme: `token68` by the grammar, and an
@@ -106,7 +106,7 @@ defects! {
         title: "Authentication token68 is indistinguishable from a parameter",
         message: "",
         default_severity: Severity::Info,
-        spec: None,
+        spec: &[],
     }
 
     /// An empty member of a challenge's `#auth-param` list.
@@ -117,7 +117,7 @@ defects! {
         title: "Authentication challenge has an empty parameter",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_11_3),
+        spec: &[RFC_9110_11_3],
     }
 
     /// A parameter whose name is empty — `=x`, which has a value and nothing
@@ -129,7 +129,7 @@ defects! {
         title: "Authentication parameter has an empty name",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_11_2),
+        spec: &[RFC_9110_11_2],
     }
 
     /// An `auth-param` with no value. The production writes the `"="` and both
@@ -142,7 +142,7 @@ defects! {
         title: "Authentication parameter has no value",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_11_2),
+        spec: &[RFC_9110_11_2],
     }
 
     /// A non-`tchar` octet in an `auth-param` name. The same complaint as
@@ -156,7 +156,7 @@ defects! {
         title: "Authentication parameter name holds a character outside token",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_11_2),
+        spec: &[RFC_9110_11_2],
     }
 
     /// A non-`tchar` octet in an unquoted `auth-param` value. The value has a
@@ -170,7 +170,7 @@ defects! {
         title: "Authentication parameter value holds a character outside token",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_11_2),
+        spec: &[RFC_9110_11_2],
     }
 }
 
@@ -261,7 +261,7 @@ mod tests {
     /// reporting all of them at one severity could never have said.
     #[test]
     fn the_heuristic_is_the_one_without_a_spec() {
-        assert!(CHALLENGE_TOKEN68_INVALID.spec.is_none());
+        assert!(CHALLENGE_TOKEN68_INVALID.spec.is_empty());
         assert_eq!(CHALLENGE_TOKEN68_INVALID.default_severity, Severity::Info);
         assert_eq!(CHALLENGE_EMPTY.default_severity, Severity::Warn);
     }

--- a/lint-http-rules/src/violations/charset.rs
+++ b/lint-http-rules/src/violations/charset.rs
@@ -51,7 +51,7 @@ defects! {
         title: "Charset parameter carries no name",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_8_3_2),
+        spec: &[RFC_9110_8_3_2],
     }
 
     /// A charset name the deployment does not recognise. Matched
@@ -70,7 +70,7 @@ defects! {
         title: "Charset name is not one the deployment recognises",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_8_3_2),
+        spec: &[RFC_9110_8_3_2],
     }
 }
 
@@ -85,7 +85,7 @@ mod tests {
     fn the_empty_name_is_not_the_empty_parameter_value() {
         assert_eq!(CHARSET_EMPTY.id, "charset_empty");
         assert_ne!(CHARSET_EMPTY.id, "parameter_value_empty");
-        assert_eq!(CHARSET_EMPTY.spec, Some(RFC_9110_8_3_2));
-        assert_eq!(CHARSET_UNREGISTERED.spec, Some(RFC_9110_8_3_2));
+        assert_eq!(CHARSET_EMPTY.spec, [RFC_9110_8_3_2]);
+        assert_eq!(CHARSET_UNREGISTERED.spec, [RFC_9110_8_3_2]);
     }
 }

--- a/lint-http-rules/src/violations/comment.rs
+++ b/lint-http-rules/src/violations/comment.rs
@@ -48,7 +48,7 @@ defects! {
         title: "Comment is never closed",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_5_6_5),
+        spec: &[RFC_9110_5_6_5],
     }
 
     /// An octet `ctext` does not admit — a control character, DEL — where the
@@ -69,7 +69,7 @@ defects! {
         title: "Comment holds a character ctext does not admit",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_5_6_5),
+        spec: &[RFC_9110_5_6_5],
     }
 }
 

--- a/lint-http-rules/src/violations/content_coding.rs
+++ b/lint-http-rules/src/violations/content_coding.rs
@@ -69,7 +69,7 @@ defects! {
         title: "The Accept-Encoding wildcard is written where a coding belongs",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_12_5_3),
+        spec: &[RFC_9110_12_5_3],
     }
 
     /// `identity` written where a coding that was actually applied belongs. It
@@ -83,7 +83,7 @@ defects! {
         title: "The identity coding is named where a coding belongs",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_8_4),
+        spec: &[RFC_9110_8_4],
     }
 
     /// One coding named twice in one field: `Content-Encoding: gzip, gzip`.
@@ -104,7 +104,7 @@ defects! {
         title: "One coding is named twice in one field",
         message: "",
         default_severity: Severity::Info,
-        spec: Some(RFC_9110_8_4),
+        spec: &[RFC_9110_8_4],
     }
 
     /// A coding name the deployment does not recognise, matched
@@ -122,7 +122,7 @@ defects! {
         title: "Content coding is not one the deployment recognises",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_8_4_1),
+        spec: &[RFC_9110_8_4_1],
     }
 }
 
@@ -137,11 +137,8 @@ mod tests {
     /// against itself.
     #[test]
     fn each_vocabulary_entry_quotes_the_field_that_admits_the_word() {
-        assert_eq!(
-            CONTENT_CODING_WILDCARD_FORBIDDEN.spec,
-            Some(RFC_9110_12_5_3)
-        );
-        assert_eq!(CONTENT_CODING_IDENTITY_FORBIDDEN.spec, Some(RFC_9110_8_4));
-        assert_eq!(CONTENT_CODING_UNREGISTERED.spec, Some(RFC_9110_8_4_1));
+        assert_eq!(CONTENT_CODING_WILDCARD_FORBIDDEN.spec, [RFC_9110_12_5_3]);
+        assert_eq!(CONTENT_CODING_IDENTITY_FORBIDDEN.spec, [RFC_9110_8_4]);
+        assert_eq!(CONTENT_CODING_UNREGISTERED.spec, [RFC_9110_8_4_1]);
     }
 }

--- a/lint-http-rules/src/violations/content_length.rs
+++ b/lint-http-rules/src/violations/content_length.rs
@@ -78,7 +78,7 @@ defects! {
         title: "Content-Length disagrees with the octets received",
         message: "",
         default_severity: Severity::Error,
-        spec: Some(RFC_9112_6_2),
+        spec: &[RFC_9112_6_2],
     }
 
     /// The field written at all, in a message a transfer coding is already
@@ -105,7 +105,7 @@ defects! {
         title: "Content-Length is sent in a message that is transfer-coded",
         message: "Both Content-Length and Transfer-Encoding present",
         default_severity: Severity::Error,
-        spec: Some(RFC_9112_6_2),
+        spec: &[RFC_9112_6_2],
     }
 
     /// A field line carrying no digit at all: an empty value, or one written as
@@ -119,7 +119,7 @@ defects! {
         title: "Content-Length declares no length",
         message: "",
         default_severity: Severity::Error,
-        spec: Some(RFC_9110_8_6),
+        spec: &[RFC_9110_8_6],
     }
 
     /// An octet in the value that `DIGIT` does not admit — the sign of `-1`,
@@ -136,7 +136,7 @@ defects! {
         title: "Content-Length value holds an octet DIGIT does not admit",
         message: "",
         default_severity: Severity::Error,
-        spec: Some(RFC_9110_8_6),
+        spec: &[RFC_9110_8_6],
     }
 
     /// A numeral that *is* `1*DIGIT` and is larger than a reader can hold. It
@@ -150,7 +150,7 @@ defects! {
         title: "Content-Length numeral is too large to represent",
         message: "",
         default_severity: Severity::Warn,
-        spec: None,
+        spec: &[],
     }
 
     /// Two lengths declared in one message that are not the same number.
@@ -165,7 +165,7 @@ defects! {
         title: "Content-Length is declared twice with different numbers",
         message: "",
         default_severity: Severity::Error,
-        spec: Some(RFC_9112_6_3),
+        spec: &[RFC_9112_6_3],
     }
 }
 
@@ -212,7 +212,7 @@ mod tests {
             CONTENT_LENGTH_NUMERAL_INVALID.default_severity,
             Severity::Warn
         );
-        assert!(CONTENT_LENGTH_NUMERAL_INVALID.spec.is_none());
+        assert!(CONTENT_LENGTH_NUMERAL_INVALID.spec.is_empty());
     }
 
     /// Four ways the field fails, four ids — the mapping is the catalogue's

--- a/lint-http-rules/src/violations/content_range.rs
+++ b/lint-http-rules/src/violations/content_range.rs
@@ -87,7 +87,7 @@ defects! {
         title: "Content-Range is empty",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_14_4),
+        spec: &[RFC_9110_14_4],
     }
 
     /// A `range-unit` that is not a `token`. Not a unit this parser fails to
@@ -100,7 +100,7 @@ defects! {
         title: "Content-Range unit is not a token",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_14_1),
+        spec: &[RFC_9110_14_1],
     }
 
     /// A value that is a `range-unit` and then stops. The production is the
@@ -112,7 +112,7 @@ defects! {
         title: "Content-Range has no range after its unit",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_14_4),
+        spec: &[RFC_9110_14_4],
     }
 
     /// Whitespace inside the part after the space. The production holds exactly
@@ -124,7 +124,7 @@ defects! {
         title: "Content-Range holds whitespace after its single space",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_14_4),
+        spec: &[RFC_9110_14_4],
     }
 
     /// No `/`. Both forms the field can take have one.
@@ -135,7 +135,7 @@ defects! {
         title: "Content-Range has no '/'",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_14_4),
+        spec: &[RFC_9110_14_4],
     }
 
     /// Something before the `/` that opens with `*` and is not exactly `*`.
@@ -148,7 +148,7 @@ defects! {
         title: "Content-Range writes something other than '*' before its '/'",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_14_4),
+        spec: &[RFC_9110_14_4],
     }
 
     /// An `incl-range` that is not two positions around a `-`: the dash
@@ -161,7 +161,7 @@ defects! {
         title: "Content-Range range is not first-pos '-' last-pos",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_14_4),
+        spec: &[RFC_9110_14_4],
     }
 
     /// A numeral that is not `1*DIGIT` — whichever of the three it was, which
@@ -173,7 +173,7 @@ defects! {
         title: "Content-Range numeral is not 1*DIGIT",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_14_4),
+        spec: &[RFC_9110_14_4],
     }
 
     /// A numeral that *is* `1*DIGIT` and is larger than a reader can hold. It
@@ -189,7 +189,7 @@ defects! {
         title: "Content-Range numeral is too large to represent",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_14_1_2),
+        spec: &[RFC_9110_14_1_2],
     }
 
     /// `last-pos` below `first-pos`. The first of § 14.4's two invalidity
@@ -204,7 +204,7 @@ defects! {
         title: "Content-Range first-pos is greater than its last-pos",
         message: "",
         default_severity: Severity::Error,
-        spec: Some(RFC_9110_14_4),
+        spec: &[RFC_9110_14_4],
     }
 
     /// `complete-length` at or below `last-pos`. The second condition, and the
@@ -219,7 +219,7 @@ defects! {
         title: "Content-Range complete-length does not exceed its last-pos",
         message: "",
         default_severity: Severity::Error,
-        spec: Some(RFC_9110_14_4),
+        spec: &[RFC_9110_14_4],
     }
 
     /// A response that has a range to describe and no field describing it: a
@@ -246,7 +246,7 @@ defects! {
         title: "Content-Range is absent from a response whose range it would describe",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_15_3_7_1),
+        spec: &[RFC_9110_15_3_7_1],
     }
 
     /// The field written in the header section of a multipart 206, where each
@@ -261,7 +261,7 @@ defects! {
         title: "Content-Range is written in the header section of a multipart 206",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_15_3_7_2),
+        spec: &[RFC_9110_15_3_7_2],
     }
 
     /// The wrong one of the field's two forms for the status carrying it. A 206
@@ -282,7 +282,7 @@ defects! {
         title: "Content-Range uses the form belonging to the other status code",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_14_4),
+        spec: &[RFC_9110_14_4],
     }
 
     /// The range described and the length declared are not the same number of
@@ -308,7 +308,7 @@ defects! {
         title: "Content-Range describes a range that is not the declared Content-Length",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_15_3_7),
+        spec: &[RFC_9110_15_3_7],
     }
 }
 

--- a/lint-http-rules/src/violations/cookie.rs
+++ b/lint-http-rules/src/violations/cookie.rs
@@ -103,7 +103,7 @@ defects! {
         title: "Set-Cookie Path attribute carries no value",
         message: "Set-Cookie attribute 'Path' requires a value",
         default_severity: Severity::Warn,
-        spec: Some(RFC_6265_5_2_4),
+        spec: &[RFC_6265_5_2_4],
     }
 
     /// `Path=` with nothing after the `=`.
@@ -114,7 +114,7 @@ defects! {
         title: "Set-Cookie Path attribute is empty",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_6265_5_2_4),
+        spec: &[RFC_6265_5_2_4],
     }
 
     /// A `Path` that does not start with `/`, which the user agent discards in
@@ -127,7 +127,7 @@ defects! {
         title: "Set-Cookie Path attribute is not rooted at `/`",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_6265_5_2_4),
+        spec: &[RFC_6265_5_2_4],
     }
 
     /// A byte at or above %x80. `path-value` is built on `CHAR` = %x01-7F, so
@@ -139,7 +139,7 @@ defects! {
         title: "Set-Cookie Path attribute holds a raw non-ASCII character",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_6265_4_1_1),
+        spec: &[RFC_6265_4_1_1],
     }
 
     /// A `CTL`, which `path-value` excludes by name. The most serious of the seven
@@ -152,7 +152,7 @@ defects! {
         title: "Set-Cookie Path attribute holds a control character",
         message: "",
         default_severity: Severity::Error,
-        spec: Some(RFC_6265_4_1_1),
+        spec: &[RFC_6265_4_1_1],
     }
 
     /// A space, which `CHAR` admits and this crate refuses anyway — the one defect
@@ -165,7 +165,7 @@ defects! {
         title: "Set-Cookie Path attribute holds unencoded whitespace",
         message: "",
         default_severity: Severity::Info,
-        spec: None,
+        spec: &[],
     }
 
     /// `Domain` written with no value, or with one that is empty before
@@ -178,7 +178,7 @@ defects! {
         title: "Set-Cookie Domain attribute carries no value",
         message: "Set-Cookie attribute 'Domain' requires a value",
         default_severity: Severity::Warn,
-        spec: Some(RFC_6265_5_2_3),
+        spec: &[RFC_6265_5_2_3],
     }
 
     /// A `Domain` that is empty once the tolerated leading dot comes off —
@@ -193,7 +193,7 @@ defects! {
         title: "Set-Cookie Domain attribute is empty",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_6265_5_2_3),
+        spec: &[RFC_6265_5_2_3],
     }
 
     /// A leading `.`, which is not a syntax error: the user agent strips it,
@@ -208,7 +208,7 @@ defects! {
         title: "Set-Cookie Domain attribute keeps the obsolete leading dot",
         message: "Set-Cookie 'Domain' attribute uses a leading '.' which is deprecated; prefer the registry form without leading dot",
         default_severity: Severity::Info,
-        spec: Some(RFC_6265_5_2_3),
+        spec: &[RFC_6265_5_2_3],
     }
 
     /// A dotted-quad where a host name goes. The cookie is not thereby
@@ -222,7 +222,7 @@ defects! {
         title: "Set-Cookie Domain attribute is an IPv4 address",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_6265_5_1_3),
+        spec: &[RFC_6265_5_1_3],
     }
 
     /// A bracketed IPv6 literal, for the same reason as the IPv4 form — kept
@@ -235,7 +235,7 @@ defects! {
         title: "Set-Cookie Domain attribute is an IPv6 literal",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_6265_5_1_3),
+        spec: &[RFC_6265_5_1_3],
     }
 
     /// `SameSite` written as a bare attribute. The attribute is the whole of
@@ -249,7 +249,7 @@ defects! {
         title: "Set-Cookie SameSite attribute carries no value",
         message: "Set-Cookie attribute 'SameSite' requires a value",
         default_severity: Severity::Warn,
-        spec: Some(DRAFT_IETF_HTTPBIS_RFC6265BIS),
+        spec: &[DRAFT_IETF_HTTPBIS_RFC6265BIS],
     }
 
     /// A `SameSite` value that is none of the three the grammar lists. It is
@@ -268,7 +268,7 @@ defects! {
         title: "Set-Cookie SameSite names no policy the grammar defines",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(DRAFT_IETF_HTTPBIS_RFC6265BIS),
+        spec: &[DRAFT_IETF_HTTPBIS_RFC6265BIS],
     }
 
     /// `Max-Age` written as a bare attribute, with no number after it.
@@ -279,7 +279,7 @@ defects! {
         title: "Set-Cookie Max-Age attribute carries no value",
         message: "Set-Cookie attribute 'Max-Age' requires a numeric value",
         default_severity: Severity::Warn,
-        spec: Some(RFC_6265_4_1_1),
+        spec: &[RFC_6265_4_1_1],
     }
 
     /// A `Max-Age` a user agent will not read a number out of. § 5.2.2 states
@@ -300,7 +300,7 @@ defects! {
         title: "Set-Cookie Max-Age is not a number a user agent will read",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_6265_5_2_2),
+        spec: &[RFC_6265_5_2_2],
     }
 
     /// A `Set-Cookie` field line with no cookie-pair on it: nothing before the
@@ -317,7 +317,7 @@ defects! {
         title: "Set-Cookie carries no cookie-pair",
         message: "Set-Cookie header missing cookie-pair",
         default_severity: Severity::Error,
-        spec: Some(RFC_6265_4_1_1),
+        spec: &[RFC_6265_4_1_1],
     }
 
     /// A value written on `Secure` or `HttpOnly`. Both attributes are their own
@@ -335,7 +335,7 @@ defects! {
         title: "Set-Cookie writes a value on a flag attribute",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_6265_4_1_1),
+        spec: &[RFC_6265_4_1_1],
     }
 
     /// `SameSite=None` on a cookie that is not `Secure`. The two attributes are
@@ -356,7 +356,7 @@ defects! {
         title: "A SameSite=None cookie is not Secure",
         message: "Set-Cookie with 'SameSite=None' must also set 'Secure'",
         default_severity: Severity::Error,
-        spec: Some(DRAFT_IETF_HTTPBIS_RFC6265BIS),
+        spec: &[DRAFT_IETF_HTTPBIS_RFC6265BIS],
     }
 
     /// `Expires` written as a bare attribute. The timestamp itself is
@@ -370,7 +370,7 @@ defects! {
         title: "Set-Cookie Expires attribute carries no value",
         message: "Set-Cookie attribute 'Expires' requires a HTTP-date value",
         default_severity: Severity::Warn,
-        spec: Some(RFC_6265_4_1_1),
+        spec: &[RFC_6265_4_1_1],
     }
 }
 

--- a/lint-http-rules/src/violations/credentials.rs
+++ b/lint-http-rules/src/violations/credentials.rs
@@ -55,7 +55,7 @@ defects! {
         title: "Credentials are empty",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_11_6_2),
+        spec: &[RFC_9110_11_6_2],
     }
 
     /// A scheme with nothing after it. § 11.4's grammar makes the second half
@@ -70,7 +70,7 @@ defects! {
         title: "Credentials are absent after the scheme",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_11_6_2),
+        spec: &[RFC_9110_11_6_2],
     }
 
     /// A control octet in the credentials. `error` by default, for the reason
@@ -85,7 +85,7 @@ defects! {
         title: "Credentials hold a control character",
         message: "",
         default_severity: Severity::Error,
-        spec: Some(RFC_9110_11_4),
+        spec: &[RFC_9110_11_4],
     }
 }
 

--- a/lint-http-rules/src/violations/delta_seconds.rs
+++ b/lint-http-rules/src/violations/delta_seconds.rs
@@ -48,7 +48,7 @@ defects! {
         title: "A time in seconds is stated with no digits",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9111_1_2_2),
+        spec: &[RFC_9111_1_2_2],
     }
 
     /// An octet the production does not admit: the sign of `-1` or `+5`, the
@@ -68,7 +68,7 @@ defects! {
         title: "A time in seconds holds an octet DIGIT does not admit",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9111_1_2_2),
+        spec: &[RFC_9111_1_2_2],
     }
 }
 
@@ -85,7 +85,7 @@ mod tests {
         assert_ne!(DELTA_SECONDS_EMPTY.id, DELTA_SECONDS_CHARACTER_FORBIDDEN.id);
         for def in [&DELTA_SECONDS_EMPTY, &DELTA_SECONDS_CHARACTER_FORBIDDEN] {
             assert_eq!(def.default_severity, Severity::Warn, "{}", def.id);
-            assert_eq!(def.spec, Some(RFC_9111_1_2_2), "{}", def.id);
+            assert_eq!(def.spec, [RFC_9111_1_2_2], "{}", def.id);
         }
     }
 }

--- a/lint-http-rules/src/violations/domain.rs
+++ b/lint-http-rules/src/violations/domain.rs
@@ -51,7 +51,7 @@ defects! {
         title: "Domain name is longer than 255 octets",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_1035_2_3_4),
+        spec: &[RFC_1035_2_3_4],
     }
 
     /// Whitespace or a control character anywhere in the name — checked over
@@ -64,7 +64,7 @@ defects! {
         title: "Domain name holds whitespace or a control character",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_1035_2_3_1),
+        spec: &[RFC_1035_2_3_1],
     }
 
     /// A `.` with nothing between it and its neighbour: `a..example` or a name
@@ -76,7 +76,7 @@ defects! {
         title: "Domain name has an empty label",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_1035_2_3_1),
+        spec: &[RFC_1035_2_3_1],
     }
 
     /// One label over 63 characters, in a name that may be inside its own
@@ -88,7 +88,7 @@ defects! {
         title: "Domain label is longer than 63 characters",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_1035_2_3_1),
+        spec: &[RFC_1035_2_3_1],
     }
 
     /// A label opening or closing on `-`. Only the hyphen is checked at the
@@ -101,7 +101,7 @@ defects! {
         title: "Domain label starts or ends with a hyphen",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_1035_2_3_1),
+        spec: &[RFC_1035_2_3_1],
     }
 
     /// A label octet outside letters, digits and hyphen — an underscore, most
@@ -113,7 +113,7 @@ defects! {
         title: "Domain label holds a character outside letters, digits and hyphen",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_1035_2_3_1),
+        spec: &[RFC_1035_2_3_1],
     }
 }
 

--- a/lint-http-rules/src/violations/etag.rs
+++ b/lint-http-rules/src/violations/etag.rs
@@ -50,7 +50,7 @@ defects! {
         title: "Weakness indicator is not written W/",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_8_8_3),
+        spec: &[RFC_9110_8_8_3],
     }
 
     /// No opening DQUOTE, or nothing closing it.
@@ -66,7 +66,7 @@ defects! {
         title: "Entity-tag is not quoted",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_8_8_3),
+        spec: &[RFC_9110_8_8_3],
     }
 
     /// A character `etagc` does not admit.
@@ -85,7 +85,7 @@ defects! {
         title: "Entity-tag holds a character etagc does not admit",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_8_8_3),
+        spec: &[RFC_9110_8_8_3],
     }
 }
 

--- a/lint-http-rules/src/violations/field.rs
+++ b/lint-http-rules/src/violations/field.rs
@@ -41,10 +41,11 @@
 //! where it landed. No sentence in either section forbids it — the split is how
 //! the document says what each field is *about*, not a prohibition — so both
 //! entries are `info`, and the word for them is neither `_forbidden` nor
-//! `_invalid`. They are two entries rather than one because the two sections
-//! are two sentences and a def carries one quote, and because the senders are
+//! `_invalid`. They are two entries rather than one because the senders are
 //! two: a client leaking a server's field and a server echoing a client's are
-//! different mistakes with different fixes.
+//! different mistakes with different fixes. **Being two sentences is no longer
+//! part of that argument** — the entry above them holds two — and what is left
+//! is the only reason that was ever load-bearing.
 
 use crate::lint::Severity;
 use crate::rules::SpecRef;
@@ -68,6 +69,28 @@ pub const RFC_9110_5_3: SpecRef = SpecRef {
     note: "Field Order — a sender MUST NOT write multiple field lines of one name, in the \
            headers or the trailers, unless at least one alternative of the field's definition \
            allows the lines to be recombined as a comma-separated list",
+};
+
+/// HTTP/2's prohibition on connection-specific fields, and one half of the
+/// pair [`FIELD_CONNECTION_SPECIFIC_FORBIDDEN`] holds. It lives here rather
+/// than in the rule because the entry names it, and an entry's references are
+/// the catalogue's.
+pub const RFC_9113_8_2_2: SpecRef = SpecRef {
+    spec: "RFC 9113",
+    section: Some("8.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.2.2",
+    note: "Connection-Specific Header Fields — HTTP/2's prohibition, and the one \
+           sentence of the two that closes the list of names",
+};
+
+/// The other half, and the reason the pair exists: HTTP/3 states the same
+/// requirement in its own document, enumerating nothing.
+pub const RFC_9114_4_2: SpecRef = SpecRef {
+    spec: "RFC 9114",
+    section: Some("4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.2",
+    note: "HTTP Fields — HTTP/3's prohibition, which enumerates nothing and defers \
+           to RFC 9110 §7.6.1",
 };
 
 /// The request context fields, and what the section says they are about. The
@@ -110,7 +133,7 @@ defects! {
         title: "A field is written on more lines than its definition allows",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_5_3),
+        spec: &[RFC_9110_5_3],
     }
 
     /// A field stating hop-by-hop control — `Connection` and the fields it
@@ -122,28 +145,31 @@ defects! {
     /// `error`, because malformed is the word the documents use and a recipient
     /// is entitled to reject the message rather than repair it.
     ///
-    /// **This is the first entry in the catalogue with no `spec`, whose
-    /// sentence exists.** The requirement is stated once per version — RFC 9113
-    /// § 8.2.2 for HTTP/2, RFC 9114 § 4.2 for HTTP/3 — and the two are not
-    /// copies of one another: HTTP/2 closes the list of names in the sentence
-    /// after its MUST NOT, HTTP/3 enumerates nothing and defers to RFC 9110
-    /// § 7.6.1, whose own list is open. A `ViolationDef` carries one `SpecRef`,
-    /// so naming either document here would put an HTTP/2 citation on an HTTP/3
-    /// finding half the time — the wrong-document trap, arrived at from the
-    /// other side. **The defect is one and the sentence is two**, so the
-    /// citation stays where the version is known: at the rule's sites, and in
-    /// the finding's own message, which names the governing section.
+    /// **This is the entry that made `spec` a slice.** The requirement is
+    /// stated once per version — RFC 9113 § 8.2.2 for HTTP/2, RFC 9114 § 4.2
+    /// for HTTP/3 — and the two are not copies of one another: HTTP/2 closes
+    /// the list of names in the sentence after its MUST NOT, HTTP/3 enumerates
+    /// nothing and defers to RFC 9110 § 7.6.1, whose own list is open. Naming
+    /// either one alone would put an HTTP/2 citation on an HTTP/3 finding half
+    /// the time — the wrong-document trap, arrived at from the other side.
+    /// **The defect is one and the sentence is two**, so the entry holds both
+    /// and no finding carries either: the version is known at the rule's sites,
+    /// and the message names the governing section there.
     ///
     /// Splitting the entry per version was the alternative and it is refused:
     /// an operator silencing this is silencing a defect, not a document, and
     /// two ids for one defect is the duplication this whole campaign exists to
     /// remove.
+    ///
+    // cite(RFC 9113 § 8.2.2): "An endpoint MUST NOT generate an HTTP/2 message containing connection-specific header fields."
+    // cite(RFC 9113 § 8.2.2): "Any message containing connection-specific header fields MUST be treated as malformed (Section 8.1.1)."
+    // cite(RFC 9114 § 4.2): "An endpoint MUST NOT generate an HTTP/3 field section containing connection-specific fields; any message containing connection-specific fields MUST be treated as malformed."
     FIELD_CONNECTION_SPECIFIC_FORBIDDEN = {
         id: "field_connection_specific_forbidden",
         title: "A connection-specific field is written on a version that has none",
         message: "",
         default_severity: Severity::Error,
-        spec: None,
+        spec: &[RFC_9113_8_2_2, RFC_9114_4_2],
     }
 
     /// A field name the deployment does not expect. The seventh registry entry
@@ -169,7 +195,7 @@ defects! {
         title: "Field name is not one the deployment expects",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_5_1),
+        spec: &[RFC_9110_5_1],
     }
 
     /// One of § 10.1's five request context fields — `Expect`, `From`,
@@ -192,18 +218,20 @@ defects! {
         title: "A request context field is written in a response",
         message: "",
         default_severity: Severity::Info,
-        spec: Some(RFC_9110_10_1),
+        spec: &[RFC_9110_10_1],
     }
 
     /// The mirror: one of § 10.2's four response context fields — `Allow`,
     /// `Location`, `Retry-After`, `Server` — written into a request. Same
     /// reading, opposite sender, and the same absent modal.
     ///
-    /// A separate entry rather than a shared one, for two reasons that agree.
-    /// The sentence is § 10.2's and a def carries one quote, so a single entry
-    /// would cite the wrong section for half its findings; and the sender is
-    /// the other party, so an operator watching what its own clients emit is
-    /// watching this entry and not its sibling.
+    /// A separate entry rather than a shared one, and the reason is the
+    /// sender. An operator watching what its own clients emit is watching this
+    /// entry and not its sibling, and the fix for each is somewhere else. The
+    /// two sections *would* both fit on one entry now that `spec` is a slice —
+    /// which is exactly why the shape is worth stating: a pair of sentences is
+    /// a reason to hold two references, never on its own a reason to hold two
+    /// ids.
     ///
     // cite(RFC 9110 § 10.2): "The response header fields below provide additional information about the response, beyond what is implied by the status code, including information about the server, about the target resource, or about related resources."
     FIELD_RESPONSE_CONTEXT_MISDIRECTED = {
@@ -211,7 +239,7 @@ defects! {
         title: "A response context field is written in a request",
         message: "",
         default_severity: Severity::Info,
-        spec: Some(RFC_9110_10_2),
+        spec: &[RFC_9110_10_2],
     }
 }
 
@@ -227,20 +255,23 @@ mod tests {
     fn the_subject_is_the_line_and_not_the_field_that_carried_it() {
         assert_eq!(FIELD_LINE_DUPLICATED.id, "field_line_duplicated");
         assert_eq!(FIELD_LINE_DUPLICATED.default_severity, Severity::Warn);
-        assert_eq!(FIELD_LINE_DUPLICATED.spec, Some(RFC_9110_5_3));
+        assert_eq!(FIELD_LINE_DUPLICATED.spec, [RFC_9110_5_3]);
     }
 
-    /// The entry with no sentence of its own, and the reason is that it has
-    /// two: one per version document. Pinned so that a later commit adding a
-    /// citation here has to answer which version's finding it would be wrong
-    /// for.
+    /// The entry with two sentences and no one of them governing. Pinned in
+    /// both directions: dropping either reference would leave the survivor
+    /// looking like *the* sentence, and a finding would then start carrying it
+    /// — which is wrong on every message the other document governs.
     #[test]
-    fn the_requirement_written_once_per_version_carries_no_single_spec() {
+    fn the_requirement_written_once_per_version_names_both_documents() {
         assert_eq!(
             FIELD_CONNECTION_SPECIFIC_FORBIDDEN.id,
             "field_connection_specific_forbidden"
         );
-        assert_eq!(FIELD_CONNECTION_SPECIFIC_FORBIDDEN.spec, None);
+        assert_eq!(
+            FIELD_CONNECTION_SPECIFIC_FORBIDDEN.spec,
+            [RFC_9113_8_2_2, RFC_9114_4_2]
+        );
         assert_eq!(
             FIELD_CONNECTION_SPECIFIC_FORBIDDEN.default_severity,
             Severity::Error

--- a/lint-http-rules/src/violations/http_date.rs
+++ b/lint-http-rules/src/violations/http_date.rs
@@ -57,7 +57,7 @@ defects! {
         title: "Timestamp derives from no HTTP-date format",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_5_6_7),
+        spec: &[RFC_9110_5_6_7],
     }
 
     /// A timestamp written in RFC 850's or asctime's format. Both parse, both
@@ -76,7 +76,7 @@ defects! {
         title: "Timestamp is written in an obsolete date format",
         message: "",
         default_severity: Severity::Info,
-        spec: Some(RFC_9110_5_6_7),
+        spec: &[RFC_9110_5_6_7],
     }
 
     /// An IMF-fixdate with whitespace around it, inside the value. The
@@ -104,7 +104,7 @@ defects! {
         title: "Timestamp is padded with whitespace the grammar does not print",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_5_6_7),
+        spec: &[RFC_9110_5_6_7],
     }
 }
 

--- a/lint-http-rules/src/violations/language.rs
+++ b/lint-http-rules/src/violations/language.rs
@@ -51,7 +51,7 @@ defects! {
         title: "Language tag is empty",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_5646_2_1),
+        spec: &[RFC_5646_2_1],
     }
 
     /// A control octet or whitespace inside the tag — neither of which any
@@ -66,7 +66,7 @@ defects! {
         title: "Language tag holds whitespace or a control character",
         message: "",
         default_severity: Severity::Error,
-        spec: Some(RFC_5646_2_1),
+        spec: &[RFC_5646_2_1],
     }
 
     /// A visible octet outside the alphanumerics and `-`: the underscore of
@@ -79,7 +79,7 @@ defects! {
         title: "Language tag holds a character outside letters, digits and hyphen",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_5646_2_1),
+        spec: &[RFC_5646_2_1],
     }
 
     /// A leading or trailing `-`. The hyphen separates subtags, so one at
@@ -91,7 +91,7 @@ defects! {
         title: "Language tag starts or ends with a hyphen",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_5646_2_1),
+        spec: &[RFC_5646_2_1],
     }
 
     /// Two adjacent hyphens, which is the same missing subtag as the edge case
@@ -103,7 +103,7 @@ defects! {
         title: "Language tag has an empty subtag",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_5646_2_1),
+        spec: &[RFC_5646_2_1],
     }
 
     /// A first subtag opening on a digit. The one property RFC 5646's
@@ -117,7 +117,7 @@ defects! {
         title: "Language tag does not begin with a letter",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_5646_2_1),
+        spec: &[RFC_5646_2_1],
     }
 
     /// A subtag over eight characters. Every subtag alternative in the grammar
@@ -130,7 +130,7 @@ defects! {
         title: "Language subtag is longer than eight characters",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_5646_2_1),
+        spec: &[RFC_5646_2_1],
     }
 }
 

--- a/lint-http-rules/src/violations/list.rs
+++ b/lint-http-rules/src/violations/list.rs
@@ -75,7 +75,7 @@ defects! {
         title: "List holds an empty element",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_5_6_1_1),
+        spec: &[RFC_9110_5_6_1_1],
     }
 
     /// A list written with a floor under it and nothing above the floor: a
@@ -102,7 +102,7 @@ defects! {
         title: "List with a one-element floor holds no element",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_5_6_1_2),
+        spec: &[RFC_9110_5_6_1_2],
     }
 }
 

--- a/lint-http-rules/src/violations/mailbox.rs
+++ b/lint-http-rules/src/violations/mailbox.rs
@@ -114,7 +114,7 @@ defects! {
         title: "Mailbox field is present with an empty value",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_5322_3_4_1),
+        spec: &[RFC_5322_3_4_1],
     }
 
     /// A comma outside every `quoted-string`, `comment` and `angle-addr`. The
@@ -129,7 +129,7 @@ defects! {
         title: "Mailbox holds a comma where one address goes",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_5322_3_4),
+        spec: &[RFC_5322_3_4],
     }
 
     /// An octet inside a parenthesised `comment` that `ctext` does not admit.
@@ -140,7 +140,7 @@ defects! {
         title: "Mailbox comment holds a character outside ctext",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_5322_3_2_2),
+        spec: &[RFC_5322_3_2_2],
     }
 
     /// A `comment` opened and never closed. The count is the production and
@@ -153,7 +153,7 @@ defects! {
         title: "Mailbox comment is never closed",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_5322_3_2_2),
+        spec: &[RFC_5322_3_2_2],
     }
 
     /// An octet between two DQUOTEs that `qtext` does not admit — and that no
@@ -165,7 +165,7 @@ defects! {
         title: "Mailbox quoted-string holds a character outside qtext",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_5322_3_2_4),
+        spec: &[RFC_5322_3_2_4],
     }
 
     /// A `quoted-string` opened and never closed — the closing DQUOTE is not
@@ -177,7 +177,7 @@ defects! {
         title: "Mailbox quoted-string is never closed",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_5322_3_2_4),
+        spec: &[RFC_5322_3_2_4],
     }
 
     /// A backslash quoting nothing, or quoting an octet that is neither
@@ -190,7 +190,7 @@ defects! {
         title: "Mailbox escape is not a quoted-pair",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_5322_3_2_1),
+        spec: &[RFC_5322_3_2_1],
     }
 
     /// An octet in a `dot-atom` — the `local-part` or the `domain` — that
@@ -205,7 +205,7 @@ defects! {
         title: "Mailbox atom holds a character outside atext",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_5322_3_2_3),
+        spec: &[RFC_5322_3_2_3],
     }
 
     /// A `.` with no `atext` after it: a trailing dot, or two of them in a row.
@@ -218,7 +218,7 @@ defects! {
         title: "Mailbox atom is empty beside a dot",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_5322_3_2_3),
+        spec: &[RFC_5322_3_2_3],
     }
 
     /// The value ends where the `addr-spec` has its `local-part` — the half
@@ -231,7 +231,7 @@ defects! {
         title: "Mailbox has no local-part",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_5322_3_4_1),
+        spec: &[RFC_5322_3_4_1],
     }
 
     /// No `"@"` where the `addr-spec` writes one — the defect a value with no
@@ -244,7 +244,7 @@ defects! {
         title: "Mailbox has no at-sign",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_5322_3_4_1),
+        spec: &[RFC_5322_3_4_1],
     }
 
     /// The value ends where the `addr-spec` has its `domain` — `alice@` and
@@ -256,7 +256,7 @@ defects! {
         title: "Mailbox has no domain",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_5322_3_4_1),
+        spec: &[RFC_5322_3_4_1],
     }
 
     /// An octet inside a bracketed `domain-literal` that `dtext` does not
@@ -270,7 +270,7 @@ defects! {
         title: "Mailbox domain-literal holds a character outside dtext",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_5322_3_4_1),
+        spec: &[RFC_5322_3_4_1],
     }
 
     /// A `domain-literal` opened and never closed: the `]` is missing, so the
@@ -282,7 +282,7 @@ defects! {
         title: "Mailbox domain-literal is never closed",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_5322_3_4_1),
+        spec: &[RFC_5322_3_4_1],
     }
 
     /// Something between the display-name and the `angle-addr` that no `word`
@@ -295,7 +295,7 @@ defects! {
         title: "Mailbox has no angle-addr where the name-addr wants one",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_5322_3_4),
+        spec: &[RFC_5322_3_4],
     }
 
     /// An `angle-addr` opened and never closed — the `>` is missing, or
@@ -307,7 +307,7 @@ defects! {
         title: "Mailbox angle-addr is never closed",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_5322_3_4),
+        spec: &[RFC_5322_3_4],
     }
 
     /// A display-name that was opened and holds no `word` at all. The
@@ -321,7 +321,7 @@ defects! {
         title: "Mailbox display-name holds no word",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_5322_3_2_5),
+        spec: &[RFC_5322_3_2_5],
     }
 
     /// A complete `mailbox` with something after it that is not a comma. One
@@ -334,7 +334,7 @@ defects! {
         title: "Mailbox is followed by something else",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_5322_3_4),
+        spec: &[RFC_5322_3_4],
     }
 }
 

--- a/lint-http-rules/src/violations/media_type.rs
+++ b/lint-http-rules/src/violations/media_type.rs
@@ -58,7 +58,7 @@ defects! {
         title: "Media type is written with nothing in it",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_8_3_1),
+        spec: &[RFC_9110_8_3_1],
     }
 
     /// A value that is not a `type "/" subtype` pair: no `/` anywhere, or a `/`
@@ -78,7 +78,7 @@ defects! {
         title: "Media type is not a type/subtype pair",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_8_3_1),
+        spec: &[RFC_9110_8_3_1],
     }
 
     /// An asterisk in either half of a `Content-Type`. `*` is a `tchar`, so
@@ -99,7 +99,7 @@ defects! {
         title: "A media range is written where one media type belongs",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_12_5_1),
+        spec: &[RFC_9110_12_5_1],
     }
 
     /// A well-formed `type/subtype` that the deployment does not expect. The
@@ -124,7 +124,7 @@ defects! {
         title: "Media type is not one the deployment recognises",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_8_3_1),
+        spec: &[RFC_9110_8_3_1],
     }
 }
 
@@ -171,10 +171,10 @@ mod tests {
     /// is registered.
     #[test]
     fn the_entry_quotes_the_registration_sentence() {
-        assert_eq!(MEDIA_TYPE_UNREGISTERED.spec, Some(RFC_9110_8_3_1));
-        assert_eq!(
-            MEDIA_TYPE_UNREGISTERED.spec.map(|s| s.spec),
-            Some("RFC 9110")
-        );
+        assert_eq!(MEDIA_TYPE_UNREGISTERED.spec, [RFC_9110_8_3_1]);
+        let [only] = MEDIA_TYPE_UNREGISTERED.spec else {
+            panic!("one sentence")
+        };
+        assert_eq!(only.spec, "RFC 9110");
     }
 }

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -13,7 +13,8 @@
 //!
 //! This module holds the second half of that split. A [`ViolationDef`] is a
 //! defect: an id, a title, its default severity, and the specification
-//! sentence it enforces. Defs live in `src/violations/<subject>.rs`, grouped
+//! sentence it enforces — sentences, where a requirement is written once per
+//! protocol version and no one of them governs. Defs live in `src/violations/<subject>.rs`, grouped
 //! by subject the way `helpers/` is, written in a `defects!` block that
 //! self-registers each one into [`REGISTERED_VIOLATIONS`] at link time.
 //! [`VIOLATIONS`] is the sorted view.
@@ -111,14 +112,35 @@ pub struct ViolationDef {
     /// `docs/development.md` §6's no-defaults doctrine is reversed here for
     /// severity alone.
     pub default_severity: Severity,
-    /// The sentence this defect enforces. `None` while the reading has not
-    /// happened yet — the same shape `cite` has on a finding, and for the same
-    /// reason: an unread sentence is carried as absent, never as a guess.
+    /// The sentences this defect enforces. Empty while the reading has not
+    /// happened yet, or when nothing states the requirement — an unread
+    /// sentence is carried as absent, never as a guess.
     ///
     /// This is where a `// cite` comment moves to when its statement becomes a
     /// def. The quote sits beside the reference it quotes, and the rule site
     /// keeps none.
-    pub spec: Option<SpecRef>,
+    ///
+    /// # Why more than one
+    ///
+    /// Almost every entry names exactly one, and the shape to reach for first
+    /// is a single-element slice. What made this a slice instead of an
+    /// `Option` is the requirement written *once per protocol version*: RFC
+    /// 9113 § 8.2.2 and RFC 9114 § 4.2 state the same prohibition about the
+    /// same defect, both in force at the same time, and neither is *the*
+    /// sentence. Holding one would cite the wrong document on half the
+    /// findings; splitting the entry in two would give one defect two ids,
+    /// which is the duplication this catalogue exists to remove. So the entry
+    /// holds both, and [`RuleContext::finding`](crate::rules::RuleContext)
+    /// carries a citation onto a finding only when there is exactly one to
+    /// carry — a message governed by two documents names its own section in
+    /// its own words, as it did while these entries had no reference at all.
+    ///
+    /// This is not a licence to pile on further reading. A second entry means
+    /// the defect genuinely has two governing statements and no way to choose
+    /// between them from the catalogue; anything a rule merely wants a reader
+    /// to know belongs in
+    /// [`specifications()`](crate::rules::RuleMeta::specifications).
+    pub spec: &'static [SpecRef],
 }
 
 /// Define a subject's defects, and register every one of them.
@@ -135,7 +157,7 @@ pub struct ViolationDef {
 ///         title: "Field value does not match the grammar",
 ///         message: "",
 ///         default_severity: Severity::Warn,
-///         spec: Some(RFC_9110_5_5),
+///         spec: &[RFC_9110_5_5],
 ///     }
 /// }
 /// ```
@@ -346,15 +368,16 @@ mod tests {
     fn every_violation_spec_is_declared_by_its_rule() {
         for rule in crate::rules::all_rules() {
             for def in rule.violations() {
-                let Some(spec) = def.spec else { continue };
-                assert!(
-                    rule.specifications().contains(&spec),
-                    "{} reports {}, which cites {} {} — not in the rule's specifications()",
-                    rule.id(),
-                    def.id,
-                    spec.spec,
-                    spec.section.unwrap_or("(whole document)"),
-                );
+                for spec in def.spec {
+                    assert!(
+                        rule.specifications().contains(spec),
+                        "{} reports {}, which cites {} {} — not in the rule's specifications()",
+                        rule.id(),
+                        def.id,
+                        spec.spec,
+                        spec.section.unwrap_or("(whole document)"),
+                    );
+                }
             }
         }
     }
@@ -375,21 +398,26 @@ mod tests {
     /// its production — `1*DIGIT` sets no ceiling — and what refuses it is this
     /// crate's inability to represent it, which no document asked for either.
     ///
-    /// **The third reason is the opposite of the first two: not no sentence,
-    /// but two.** `field_connection_specific_forbidden` and
-    /// `te_member_forbidden` are stated once per version, by RFC 9113 § 8.2.2
-    /// and RFC 9114 § 4.2, and both documents are in force at the same time —
-    /// so a [`ViolationDef`], which holds one [`SpecRef`], would put an HTTP/2
-    /// citation on an HTTP/3 finding half the time. The sentences are quoted in
-    /// the subject file where neither is claimed as *the* one, and each finding
-    /// names its governing section in its own message. Two entries share this
-    /// reason today; a third would be the argument for `spec` becoming a slice,
-    /// which is a schema decision and not something to slide in under a floor.
+    /// **There was a third reason and it is retired.** Two entries —
+    /// `field_connection_specific_forbidden` and `te_member_forbidden` — were
+    /// uncited not because no sentence states them but because two do: RFC 9113
+    /// § 8.2.2 and RFC 9114 § 4.2 write the same requirement once per version,
+    /// both in force at the same time, and a [`ViolationDef`] held a single
+    /// [`SpecRef`], so naming either would have put an HTTP/2 citation on an
+    /// HTTP/3 finding half the time. This docstring recorded a third entry of
+    /// that shape as the threshold at which `spec` should become a slice, and
+    /// the threshold was reached. So `spec` is a slice, both entries name both
+    /// sections, and the count below is of entries with **at least** one.
+    ///
+    /// **What is left uncited is the first two reasons only** — both about
+    /// sentences that do not exist. An entry naming two is still the exception
+    /// rather than a licence: no finding of one carries a citation, because
+    /// none of the sentences governs the message on its own.
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 180;
-        let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
+        const FLOOR: usize = 182;
+        let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,
             "{cited} of {} defs cite a sentence, below the floor of {FLOOR}",

--- a/lint-http-rules/src/violations/multipart_body.rs
+++ b/lint-http-rules/src/violations/multipart_body.rs
@@ -54,7 +54,7 @@ defects! {
         title: "The body carries no delimiter line for its boundary",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_2046_5_1_1),
+        spec: &[RFC_2046_5_1_1],
     }
 
     /// A body whose only delimiter line is the terminating one. The closing
@@ -71,7 +71,7 @@ defects! {
         title: "The only delimiter line is the terminating one",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_2046_5_1_1),
+        spec: &[RFC_2046_5_1_1],
     }
 
     /// A body with parts and no closing delimiter. Nothing tells a recipient
@@ -85,7 +85,7 @@ defects! {
         title: "The body never closes its last part",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_2046_5_1_1),
+        spec: &[RFC_2046_5_1_1],
     }
 }
 
@@ -105,7 +105,7 @@ mod tests {
             &MULTIPART_BODY_TERMINATOR_MISSING,
         ] {
             assert!(def.id.starts_with("multipart_body_"), "{}", def.id);
-            assert_eq!(def.spec, Some(RFC_2046_5_1_1), "{}", def.id);
+            assert_eq!(def.spec, [RFC_2046_5_1_1], "{}", def.id);
             assert!(def.message.is_empty(), "{}", def.id);
         }
     }

--- a/lint-http-rules/src/violations/node.rs
+++ b/lint-http-rules/src/violations/node.rs
@@ -56,7 +56,7 @@ defects! {
         title: "Node identifier holds an IPv6 address without its square brackets",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_7239_6_1),
+        spec: &[RFC_7239_6_1],
     }
 
     /// A `[`-led nodename that never closes. Told apart from a literal whose
@@ -69,7 +69,7 @@ defects! {
         title: "Node identifier opens an IPv6 literal and never closes it",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_7239_6),
+        spec: &[RFC_7239_6],
     }
 
     /// Brackets around something that is not an `IPv6address`. The brackets are
@@ -82,7 +82,7 @@ defects! {
         title: "Node identifier brackets something that is not an IPv6 address",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_7239_6),
+        spec: &[RFC_7239_6],
     }
 
     /// Digits and dots that are not an `IPv4address` — `010.1.2.3`, `1.2.3`,
@@ -95,7 +95,7 @@ defects! {
         title: "Node identifier is digits and dots that are not an IPv4 address",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_7239_6),
+        spec: &[RFC_7239_6],
     }
 
     /// A nodename no alternative of the production generates. The everyday
@@ -108,7 +108,7 @@ defects! {
         title: "Node identifier derives from no alternative of the production",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_7239_6),
+        spec: &[RFC_7239_6],
     }
 
     /// A well-formed `IPv6address` written against §6.1's recommendation —
@@ -123,7 +123,7 @@ defects! {
         title: "Node identifier writes an IPv6 address outside the recommended representation",
         message: "",
         default_severity: Severity::Info,
-        spec: Some(RFC_7239_6_1),
+        spec: &[RFC_7239_6_1],
     }
 
     /// Something after the `:` that is neither `1*5DIGIT` nor an `obfport`.
@@ -136,7 +136,7 @@ defects! {
         title: "Node identifier holds something that is not a node-port",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_7239_6),
+        spec: &[RFC_7239_6],
     }
 }
 

--- a/lint-http-rules/src/violations/origin_agent_cluster.rs
+++ b/lint-http-rules/src/violations/origin_agent_cluster.rs
@@ -63,7 +63,7 @@ defects! {
         title: "Origin-Agent-Cluster is written with no boolean on it",
         message: "Origin-Agent-Cluster is written with no value",
         default_severity: Severity::Warn,
-        spec: Some(HTML_7_1_2),
+        spec: &[HTML_7_1_2],
     }
 
     /// More than one member on the line, where the field's value is a single
@@ -78,7 +78,7 @@ defects! {
         title: "Origin-Agent-Cluster carries a list where a boolean is due",
         message: "Origin-Agent-Cluster must be a single value",
         default_severity: Severity::Warn,
-        spec: Some(HTML_7_1_2),
+        spec: &[HTML_7_1_2],
     }
 
     /// One value, and it is not the true value. `?1` is what requests an
@@ -97,7 +97,7 @@ defects! {
         title: "Origin-Agent-Cluster states a value that is not `?1`",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(HTML_7_1_2),
+        spec: &[HTML_7_1_2],
     }
 }
 

--- a/lint-http-rules/src/violations/parameter.rs
+++ b/lint-http-rules/src/violations/parameter.rs
@@ -72,7 +72,7 @@ defects! {
         title: "Parameter is written without its '='",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_5_6_6),
+        spec: &[RFC_9110_5_6_6],
     }
 
     /// An `=` with nothing after it. Neither alternative of
@@ -94,7 +94,7 @@ defects! {
         title: "Parameter is written with no value after its '='",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_5_6_6),
+        spec: &[RFC_9110_5_6_6],
     }
 
     /// Whitespace beside the `=`. The production writes none — `parameter =
@@ -122,7 +122,7 @@ defects! {
         title: "Parameter writes whitespace beside its '='",
         message: "",
         default_severity: Severity::Info,
-        spec: Some(RFC_9110_5_6_6),
+        spec: &[RFC_9110_5_6_6],
     }
 }
 

--- a/lint-http-rules/src/violations/quoted_pair.rs
+++ b/lint-http-rules/src/violations/quoted_pair.rs
@@ -42,7 +42,7 @@ defects! {
         title: "Escape is not a quoted-pair",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_5_6_4),
+        spec: &[RFC_9110_5_6_4],
     }
 }
 

--- a/lint-http-rules/src/violations/quoted_string.rs
+++ b/lint-http-rules/src/violations/quoted_string.rs
@@ -46,7 +46,7 @@ defects! {
         title: "Quoted-string is missing one of its DQUOTEs",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_5_6_4),
+        spec: &[RFC_9110_5_6_4],
     }
 
     /// A DQUOTE inside the interior that no backslash introduced. The interior
@@ -61,7 +61,7 @@ defects! {
         title: "Quoted-string holds an unescaped DQUOTE",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_5_6_4),
+        spec: &[RFC_9110_5_6_4],
     }
 
     /// A control octet `qdtext` excludes — HTAB is not one of them, since it is
@@ -77,7 +77,7 @@ defects! {
         title: "Quoted-string holds a control character",
         message: "",
         default_severity: Severity::Error,
-        spec: Some(RFC_9110_5_6_4),
+        spec: &[RFC_9110_5_6_4],
     }
 }
 

--- a/lint-http-rules/src/violations/qvalue.rs
+++ b/lint-http-rules/src/violations/qvalue.rs
@@ -64,7 +64,7 @@ defects! {
         title: "Weight is not a qvalue",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_12_4_2),
+        spec: &[RFC_9110_12_4_2],
     }
 
     /// Whitespace beside the weight's `=`: `q =0.5`, `q= 0.5`. The three
@@ -96,7 +96,7 @@ defects! {
         title: "Whitespace is written beside the weight's '='",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_12_4_2),
+        spec: &[RFC_9110_12_4_2],
     }
 }
 

--- a/lint-http-rules/src/violations/status.rs
+++ b/lint-http-rules/src/violations/status.rs
@@ -72,7 +72,7 @@ defects! {
         title: "206 Partial Content answers a request that asked for no range",
         message: "206 Partial Content response received but request did not include a Range header",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_15_3_7),
+        spec: &[RFC_9110_15_3_7],
     }
 
     /// A 416 answering a request that named no range. The status code is the
@@ -92,7 +92,7 @@ defects! {
         title: "416 Range Not Satisfiable answers a request that named no range",
         message: "416 Range Not Satisfiable response sent to a request with no Range header",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_15_5_17),
+        spec: &[RFC_9110_15_5_17],
     }
 
     /// A 206 in its multipart form, answering a request that asked for one
@@ -119,7 +119,7 @@ defects! {
         title: "A multipart 206 answers a request that asked for a single range",
         message: "multipart/byteranges 206 response sent to a request for a single range",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_15_3_7_2),
+        spec: &[RFC_9110_15_3_7_2],
     }
 }
 

--- a/lint-http-rules/src/violations/strict_transport_security.rs
+++ b/lint-http-rules/src/violations/strict_transport_security.rs
@@ -68,7 +68,7 @@ defects! {
         title: "The policy is written with nothing in it",
         message: "Strict-Transport-Security header must not be empty",
         default_severity: Severity::Warn,
-        spec: None,
+        spec: &[],
     }
 
     /// A semicolon with no directive on one side of it. The same optional
@@ -81,7 +81,7 @@ defects! {
         title: "The policy holds a separator with no directive",
         message: "Empty directive in Strict-Transport-Security header",
         default_severity: Severity::Warn,
-        spec: None,
+        spec: &[],
     }
 
     /// The policy does not state how long it lasts. `max-age` is the one
@@ -95,7 +95,7 @@ defects! {
         title: "The policy states no max-age",
         message: "Strict-Transport-Security header missing required 'max-age' directive",
         default_severity: Severity::Warn,
-        spec: Some(RFC_6797_6_1_1),
+        spec: &[RFC_6797_6_1_1],
     }
 
     /// One directive written twice in one field. § 6.1 admits no such thing,
@@ -109,7 +109,7 @@ defects! {
         title: "A directive is written more than once in one policy",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_6797_6_1),
+        spec: &[RFC_6797_6_1],
     }
 
     /// A directive whose definition requires a value, written without one —
@@ -124,7 +124,7 @@ defects! {
         title: "A directive that requires a value carries none",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_6797_6_1_1),
+        spec: &[RFC_6797_6_1_1],
     }
 
     /// A valueless directive carrying a value: `includeSubDomains=1`, or a
@@ -143,7 +143,7 @@ defects! {
         title: "A valueless directive is written with a value",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_6797_6_1_2),
+        spec: &[RFC_6797_6_1_2],
     }
 }
 
@@ -157,15 +157,15 @@ mod tests {
     /// own claim rather than a document's.
     #[test]
     fn the_two_entries_the_grammar_generates_carry_no_sentence() {
-        assert_eq!(STRICT_TRANSPORT_SECURITY_EMPTY.spec, None);
-        assert_eq!(STRICT_TRANSPORT_SECURITY_DIRECTIVE_EMPTY.spec, None);
+        assert!(STRICT_TRANSPORT_SECURITY_EMPTY.spec.is_empty());
+        assert!(STRICT_TRANSPORT_SECURITY_DIRECTIVE_EMPTY.spec.is_empty());
         for def in [
             &STRICT_TRANSPORT_SECURITY_MAX_AGE_MISSING,
             &STRICT_TRANSPORT_SECURITY_DIRECTIVE_DUPLICATED,
             &STRICT_TRANSPORT_SECURITY_DIRECTIVE_VALUE_MISSING,
             &STRICT_TRANSPORT_SECURITY_DIRECTIVE_VALUE_FORBIDDEN,
         ] {
-            assert!(def.spec.is_some(), "{}", def.id);
+            assert!(!def.spec.is_empty(), "{}", def.id);
         }
     }
 }

--- a/lint-http-rules/src/violations/te.rs
+++ b/lint-http-rules/src/violations/te.rs
@@ -36,15 +36,11 @@
 //! connection option beside it, which is a requirement on the *message* rather
 //! than on any value in it. Neither is a production's defect — every
 //! production involved is intact — which is what keeps them here.
-//!
-//! The exception, in the two documents that write it:
-//
-// cite(RFC 9113 § 8.2.2, label: the TE exception): "The only exception to this is the TE header field, which MAY be present in an HTTP/2 request; when it is, it MUST NOT contain any value other than "trailers"."
-// cite(RFC 9114 § 4.2, label: the TE exception): "The only exception to this is the TE header field, which MAY be present in an HTTP/3 request header; when it is, it MUST NOT contain any value other than "trailers"."
 
 use crate::lint::Severity;
 use crate::rules::SpecRef;
 use crate::violations::defects;
+use crate::violations::field::{RFC_9113_8_2_2, RFC_9114_4_2};
 
 /// The field's own section in RFC 9112: what it is for, the ranking `q` it
 /// admits, and the one coding name it may not carry.
@@ -84,21 +80,26 @@ defects! {
     /// documents put this sentence inside the paragraph whose MUST NOT makes
     /// such a message malformed.
     ///
-    /// **No `spec`, for the reason
+    /// **Both sentences, for the reason
     /// [`field_connection_specific_forbidden`](crate::violations::field::FIELD_CONNECTION_SPECIFIC_FORBIDDEN)
-    /// carries none**: the sentence is written once per version, by two
-    /// documents in force at the same time, and an entry holds one reference.
-    /// Both are quoted above the entry instead, where neither is being claimed
-    /// as *the* sentence, and the finding names the governing section itself.
-    /// The comparison against the keyword folds case because `t-codings` writes
-    /// it as an ABNF string, which is RFC 5234 § 2.3's sentence and the rule's
-    /// own reading rather than this defect's.
+    /// holds both**: the exception is written once per version, by two
+    /// documents in force at the same time, and neither is *the* one. They are
+    /// the same two sections that entry names — the exception is a clause of
+    /// the paragraph the prohibition is in — so the references are imported
+    /// from there rather than spelled a second time. No finding carries either;
+    /// each names the governing section in its own message. The comparison
+    /// against the keyword folds case because `t-codings` writes it as an ABNF
+    /// string, which is RFC 5234 § 2.3's sentence and the rule's own reading
+    /// rather than this defect's.
+    ///
+    // cite(RFC 9113 § 8.2.2, label: the TE exception): "The only exception to this is the TE header field, which MAY be present in an HTTP/2 request; when it is, it MUST NOT contain any value other than "trailers"."
+    // cite(RFC 9114 § 4.2, label: the TE exception): "The only exception to this is the TE header field, which MAY be present in an HTTP/3 request header; when it is, it MUST NOT contain any value other than "trailers"."
     TE_MEMBER_FORBIDDEN = {
         id: "te_member_forbidden",
         title: "A request's TE holds a member other than trailers",
         message: "",
         default_severity: Severity::Error,
-        spec: None,
+        spec: &[RFC_9113_8_2_2, RFC_9114_4_2],
     }
 
     /// `chunked` named in a `TE`. The name is a real transfer coding and is
@@ -118,7 +119,7 @@ defects! {
         title: "TE names the chunked coding, which cannot be declined",
         message: "A client must not send the chunked transfer coding name in TE; chunked is always acceptable for HTTP/1.1 recipients",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9112_7_4),
+        spec: &[RFC_9112_7_4],
     }
 
     /// A parameter or a weight written on the `trailers` keyword. The
@@ -143,7 +144,7 @@ defects! {
         title: "TE hangs a parameter or a weight off the trailers keyword",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_A),
+        spec: &[RFC_9110_A],
     }
 
     /// A request carrying `TE` and no `TE` connection option in `Connection`.
@@ -168,7 +169,7 @@ defects! {
         title: "TE is sent without a TE connection option beside it",
         message: "Request carries a TE header field without a 'TE' connection option in Connection; TE applies to the immediate connection only, and the option is what stops an intermediary from forwarding it",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_10_1_4),
+        spec: &[RFC_9110_10_1_4],
     }
 }
 
@@ -183,7 +184,7 @@ mod tests {
     fn one_entry_serves_both_versions_and_neither_names_it() {
         assert_eq!(TE_MEMBER_FORBIDDEN.id, "te_member_forbidden");
         assert!(!TE_MEMBER_FORBIDDEN.id.contains("http"));
-        assert_eq!(TE_MEMBER_FORBIDDEN.spec, None);
+        assert_eq!(TE_MEMBER_FORBIDDEN.spec, [RFC_9113_8_2_2, RFC_9114_4_2]);
         assert_eq!(TE_MEMBER_FORBIDDEN.default_severity, Severity::Error);
     }
 }

--- a/lint-http-rules/src/violations/token.rs
+++ b/lint-http-rules/src/violations/token.rs
@@ -61,7 +61,7 @@ defects! {
         title: "Token holds whitespace or a control character",
         message: "",
         default_severity: Severity::Error,
-        spec: Some(RFC_9110_5_6_2),
+        spec: &[RFC_9110_5_6_2],
     }
 
     /// A token with no characters in it: the `=` of a parameter with nothing
@@ -80,7 +80,7 @@ defects! {
         title: "Token is written with no characters in it",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_5_6_2),
+        spec: &[RFC_9110_5_6_2],
     }
 
     /// A visible octet outside `tchar` — one of the delimiters § 5.6.2 names,
@@ -94,7 +94,7 @@ defects! {
         title: "Token holds a character outside tchar",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_5_6_2),
+        spec: &[RFC_9110_5_6_2],
     }
 }
 

--- a/lint-http-rules/src/violations/token68.rs
+++ b/lint-http-rules/src/violations/token68.rs
@@ -48,7 +48,7 @@ defects! {
         title: "token68 holds whitespace or a control character",
         message: "",
         default_severity: Severity::Error,
-        spec: Some(RFC_9110_11_2),
+        spec: &[RFC_9110_11_2],
     }
 
     /// A visible octet outside the alphabet — the `%` of a value that was
@@ -61,7 +61,7 @@ defects! {
         title: "token68 holds a character outside its alphabet",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_11_2),
+        spec: &[RFC_9110_11_2],
     }
 
     /// Padding and nothing before it. The production is `1*(…)` and then its
@@ -74,7 +74,7 @@ defects! {
         title: "token68 is padding with no body",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_11_2),
+        spec: &[RFC_9110_11_2],
     }
 
     /// Something other than `=` at or after the first `=`. Padding is the only
@@ -88,7 +88,7 @@ defects! {
         title: "token68 padding holds something other than '='",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_11_2),
+        spec: &[RFC_9110_11_2],
     }
 }
 

--- a/lint-http-rules/src/violations/transfer_coding.rs
+++ b/lint-http-rules/src/violations/transfer_coding.rs
@@ -68,7 +68,7 @@ defects! {
         title: "A coding writes a ';' with no parameter after it",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9110_A),
+        spec: &[RFC_9110_A],
     }
 
     /// A parameter hung off a coding that defines none. § 7.2 says so of the
@@ -90,7 +90,7 @@ defects! {
         title: "A coding that defines no parameters carries one",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9112_7_2),
+        spec: &[RFC_9112_7_2],
     }
 
     /// A coding name the deployment does not recognise — the fifth registry
@@ -110,7 +110,7 @@ defects! {
         title: "Transfer coding is not one the deployment recognises",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9112_7),
+        spec: &[RFC_9112_7],
     }
 }
 

--- a/lint-http-rules/src/violations/transfer_encoding.rs
+++ b/lint-http-rules/src/violations/transfer_encoding.rs
@@ -74,7 +74,7 @@ defects! {
         title: "The chunked transfer coding is applied more than once",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9112_6_1),
+        spec: &[RFC_9112_6_1],
     }
 
     /// `chunked` is in the sequence and something is applied after it, so the
@@ -93,7 +93,7 @@ defects! {
         title: "The chunked transfer coding is not the final one",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9112_6_1),
+        spec: &[RFC_9112_6_1],
     }
 
     /// A coding was applied and `chunked` was not, so nothing frames the
@@ -113,7 +113,7 @@ defects! {
         title: "A coding is applied and chunked never is",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_9112_6_1),
+        spec: &[RFC_9112_6_1],
     }
 
     /// A coding applied in transit that the representation already carries:
@@ -139,7 +139,7 @@ defects! {
         title: "A coding is applied in transit that the representation already carries",
         message: "",
         default_severity: Severity::Info,
-        spec: Some(RFC_9112_7_3),
+        spec: &[RFC_9112_7_3],
     }
 }
 
@@ -165,7 +165,7 @@ mod tests {
             );
             assert!(!def.id.contains("request"), "{}", def.id);
             assert!(!def.id.contains("response"), "{}", def.id);
-            assert_eq!(def.spec, Some(RFC_9112_6_1), "{}", def.id);
+            assert_eq!(def.spec, [RFC_9112_6_1], "{}", def.id);
         }
     }
 

--- a/lint-http-rules/src/violations/upgrade.rs
+++ b/lint-http-rules/src/violations/upgrade.rs
@@ -46,7 +46,7 @@ defects! {
         title: "A 101 response carries no Upgrade field",
         message: "",
         default_severity: Severity::Error,
-        spec: Some(RFC_9110_15_2_2),
+        spec: &[RFC_9110_15_2_2],
     }
 
     /// The field written, and no protocol name on it: an empty value, or one
@@ -65,7 +65,7 @@ defects! {
         title: "A 101 response names no protocol on its Upgrade field",
         message: "",
         default_severity: Severity::Error,
-        spec: Some(RFC_9110_15_2_2),
+        spec: &[RFC_9110_15_2_2],
     }
 }
 

--- a/lint-http-rules/src/violations/uri.rs
+++ b/lint-http-rules/src/violations/uri.rs
@@ -108,7 +108,7 @@ defects! {
         title: "Value holds a character no URI is written with",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_3986_2),
+        spec: &[RFC_3986_2],
     }
 
     /// A `%` with fewer than two characters after it, because the value ended.
@@ -121,7 +121,7 @@ defects! {
         title: "Percent-encoding stops before its two hexadecimal digits",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_3986_2_1),
+        spec: &[RFC_3986_2_1],
     }
 
     /// Two characters after the `%` that are not both `HEXDIG` — a literal
@@ -133,7 +133,7 @@ defects! {
         title: "Percent-encoding is not two hexadecimal digits",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_3986_2_1),
+        spec: &[RFC_3986_2_1],
     }
     /// A value whose scheme candidate is empty — the colon with nothing before
     /// it. `ALPHA *( … )` generates nothing empty, so this derives from no
@@ -145,7 +145,7 @@ defects! {
         title: "URI scheme is empty",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_3986_3_1),
+        spec: &[RFC_3986_3_1],
     }
 
     /// A scheme opening on something that is not a letter — a digit, most
@@ -157,7 +157,7 @@ defects! {
         title: "URI scheme does not begin with a letter",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_3986_3_1),
+        spec: &[RFC_3986_3_1],
     }
 
     /// A character after the first that the production does not admit: only
@@ -169,7 +169,7 @@ defects! {
         title: "URI scheme holds a character outside letters, digits, '+', '-' and '.'",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_3986_3_1),
+        spec: &[RFC_3986_3_1],
     }
     /// A host that opens an IP literal and never closes it. The `[` is what
     /// chooses that alternative, so there is no reading of the value in which
@@ -181,7 +181,7 @@ defects! {
         title: "Host opens an IP literal and never closes it",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_3986_3_2_2),
+        spec: &[RFC_3986_3_2_2],
     }
 
     /// Brackets around something that is neither an `IPv6address` nor an
@@ -195,7 +195,7 @@ defects! {
         title: "Host brackets something that is not an IP literal",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_3986_3_2_2),
+        spec: &[RFC_3986_3_2_2],
     }
 
     /// A bracket somewhere other than around an IP literal — a closing one with
@@ -209,7 +209,7 @@ defects! {
         title: "Host holds a square bracket outside an IP literal",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_3986_3_2_2),
+        spec: &[RFC_3986_3_2_2],
     }
 
     /// A character no `reg-name` admits: not `unreserved`, not the `%` that
@@ -224,7 +224,7 @@ defects! {
         title: "Host holds a character outside the registered-name alphabet",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_3986_3_2_2),
+        spec: &[RFC_3986_3_2_2],
     }
 
     /// A character in the port that is not a digit. There is no companion
@@ -238,7 +238,7 @@ defects! {
         title: "Port holds a character that is not a digit",
         message: "",
         default_severity: Severity::Warn,
-        spec: Some(RFC_3986_3_2_3),
+        spec: &[RFC_3986_3_2_3],
     }
 }
 

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1739,7 +1739,7 @@ sources:
     - file: lint-http-rules/src/helpers/validator.rs
       line: 153
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 255
+      line: 252
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
       line: 119
   - label: lint-http-rules/src/helpers/mailbox.rs
@@ -5225,7 +5225,7 @@ sources:
     - file: lint-http-rules/src/rules/redirect_status_and_location_valid.rs
       line: 161
     - file: lint-http-rules/src/violations/field.rs
-      line: 208
+      line: 236
   - label: allow_header_method_tokens_valid (2)
     section: § 10.2.1
     snippet: An empty Allow field value indicates that the resource allows no methods, which might occur in a 405 response if the resource has been temporarily disabled by configuration.
@@ -5837,7 +5837,7 @@ sources:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 237
     - file: lint-http-rules/src/violations/field.rs
-      line: 189
+      line: 215
   - label: context_fields_direction (2)
     section: § 10.1.1
     snippet: The "Expect" header field in a request indicates a certain set of behaviors (expectations) that need to be supported by the server in order to properly handle this request.
@@ -5869,7 +5869,7 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 32
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 205
+      line: 202
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 534
     - file: lint-http-rules/src/rules/te_header_valid.rs
@@ -6089,7 +6089,7 @@ sources:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
       line: 360
     - file: lint-http-rules/src/violations/field.rs
-      line: 166
+      line: 192
   - label: extension_headers_registered (5)
     section: § 5.1
     snippet: Other recipients SHOULD ignore unrecognized header and trailer fields
@@ -6777,7 +6777,7 @@ sources:
     - file: lint-http-rules/src/rules/max_forwards_numeric.rs
       line: 153
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 229
+      line: 226
     - file: lint-http-rules/src/rules/proxy_connection_discouraged.rs
       line: 134
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
@@ -7101,7 +7101,7 @@ sources:
     - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
       line: 120
     - file: lint-http-rules/src/violations/field.rs
-      line: 107
+      line: 130
   - label: lint-http-rules/src/helpers/headers.rs (5)
     section: § 5.5
     snippet: A recipient SHOULD treat other allowed octets in field content (i.e., obs-text) as opaque data.
@@ -7967,17 +7967,17 @@ sources:
     snippet: t-codings = "trailers" / ( transfer-coding [ weight ] )
     cited_by:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 253
+      line: 250
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 157
     - file: lint-http-rules/src/violations/te.rs
-      line: 140
+      line: 141
   - label: no_connection_specific_fields (2)
     section: § A
     snippet: transfer-parameter = token BWS "=" BWS ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 254
+      line: 251
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 115
     - file: lint-http-rules/src/rules/te_header_valid.rs
@@ -9025,7 +9025,7 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 236
     - file: lint-http-rules/src/violations/te.rs
-      line: 165
+      line: 166
   - label: te_header_valid (2)
     section: § 10.1.4
     snippet: The TE field value is a list of members, with each member (aside from "trailers") consisting of a transfer coding name token with an optional weight indicating the client's relative preference for that transfer coding (Section 12.4.2) and optional parameters for that transfer coding.
@@ -10245,7 +10245,7 @@ sources:
     snippet: A client MUST NOT send the chunked transfer coding name in TE; chunked is always acceptable for HTTP/1.1 recipients.
     cited_by:
     - file: lint-http-rules/src/violations/te.rs
-      line: 115
+      line: 116
   - label: te_header_valid
     section: § 7.3
     snippet: The TE header field (Section 10.1.4 of [HTTP]) uses a pseudo-parameter named "q" as the rank value when multiple transfer codings are acceptable.
@@ -10355,6 +10355,12 @@ sources:
 - label: RFC 9113
   url: https://www.rfc-editor.org/rfc/rfc9113.html
   fragments:
+  - label: field
+    section: § 8.2.2
+    snippet: Any message containing connection-specific header fields MUST be treated as malformed (Section 8.1.1).
+    cited_by:
+    - file: lint-http-rules/src/violations/field.rs
+      line: 165
   - label: header_field_names_token_valid
     section: § 8.2.1
     snippet: HTTP/2 implementations SHOULD validate field names and values according to their definitions in Sections 5.1 and 5.5 of [HTTP], respectively, and treat messages that contain prohibited characters as malformed
@@ -10534,15 +10540,15 @@ sources:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
       line: 307
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 159
-    - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 388
+      line: 375
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
       line: 168
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 215
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
       line: 62
+    - file: lint-http-rules/src/violations/field.rs
+      line: 164
   - label: no_connection_specific_fields
     section: § 8.2.2
     snippet: An intermediary transforming an HTTP/1.x message to HTTP/2 MUST remove connection-specific header fields as discussed in Section 7.6.1 of [HTTP], or their messages will be treated by other HTTP/2 endpoints as malformed (Section 8.1.1).
@@ -10550,12 +10556,6 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 144
   - label: no_connection_specific_fields (2)
-    section: § 8.2.2
-    snippet: Any message containing connection-specific header fields MUST be treated as malformed (Section 8.1.1).
-    cited_by:
-    - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 160
-  - label: no_connection_specific_fields (3)
     section: § 8.2.2
     snippet: HTTP/2 does not use the Connection header field (Section 7.6.1 of [HTTP]) to indicate connection-specific header fields; in this protocol, connection-specific metadata is conveyed by other means.
     cited_by:
@@ -10588,7 +10588,7 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 216
     - file: lint-http-rules/src/violations/te.rs
-      line: 42
+      line: 95
 - label: RFC 9114
   url: https://www.rfc-editor.org/rfc/rfc9114.html
   fragments:
@@ -10848,21 +10848,11 @@ sources:
       line: 308
   - label: no_connection_specific_fields
     section: § 4.2
-    snippet: An endpoint MUST NOT generate an HTTP/3 field section containing connection-specific fields; any message containing connection-specific fields MUST be treated as malformed.
-    cited_by:
-    - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 161
-    - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 217
-    - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
-      line: 64
-  - label: no_connection_specific_fields (2)
-    section: § 4.2
     snippet: An intermediary transforming an HTTP/1.x message to HTTP/3 MUST remove connection-specific header fields as discussed in Section 7.6.1 of [HTTP], or their messages will be treated by other HTTP/3 endpoints as malformed.
     cited_by:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 145
-  - label: no_connection_specific_fields (3)
+  - label: no_connection_specific_fields (2)
     section: § 4.2
     snippet: HTTP/3 does not use the Connection header field to indicate connection-specific fields; in this protocol, connection-specific metadata is conveyed by other means.
     cited_by:
@@ -10913,7 +10903,17 @@ sources:
     snippet: The only exception to this is the TE header field, which MAY be present in an HTTP/3 request header; when it is, it MUST NOT contain any value other than "trailers".
     cited_by:
     - file: lint-http-rules/src/violations/te.rs
-      line: 43
+      line: 96
+  - label: te_header_valid
+    section: § 4.2
+    snippet: An endpoint MUST NOT generate an HTTP/3 field section containing connection-specific fields; any message containing connection-specific fields MUST be treated as malformed.
+    cited_by:
+    - file: lint-http-rules/src/rules/te_header_valid.rs
+      line: 217
+    - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
+      line: 64
+    - file: lint-http-rules/src/violations/field.rs
+      line: 166
 - label: RFC 9218
   url: https://www.rfc-editor.org/rfc/rfc9218.html
   fragments:

--- a/xtask/src/genconfig.rs
+++ b/xtask/src/genconfig.rs
@@ -221,7 +221,7 @@ mod tests {
             title: "Example field is present but empty",
             message: "Example field is present but empty",
             default_severity: lint_http_rules::lint::Severity::Error,
-            spec: None,
+            spec: &[],
         };
         assert_eq!(
             violation_section(&def),


### PR DESCRIPTION
`ViolationDef::spec` becomes `&'static [SpecRef]`. Almost every entry names exactly one sentence and now spells it as a one-element slice; what the slice is for is the requirement written once per protocol version.

Two entries had been carrying no reference at all for that reason: `field_connection_specific_forbidden` and `te_member_forbidden` are stated by RFC 9113 §8.2.2 and RFC 9114 §4.2, both in force at once, and naming either alone would have put an HTTP/2 citation on an HTTP/3 finding half the time. Both now name both, and the quotes move onto the entries from the rule site and from the subject's module doc. That leaves the catalogue's uncited entries to the two reasons that are about sentences which do not exist.

A finding is cited when its def names exactly one sentence. A def naming several names them because no one of them governs the message, so picking one here would be the same wrong-document trap from the inside; such a finding names its governing section in its own message, which is what it did while the entry had no reference.

The two `SpecRef` consts move out of `no_connection_specific_fields` and into `violations/field.rs`, where the entries that name them live, and are imported back for `specifications()` — the gate that pairs the two now checks every reference on an entry rather than the first.

Floor: 182 of 187 entries cite a sentence.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
