### PR TITLE
A 101 no version could have invited

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1647,6 +1647,10 @@ severity = "warn"
 # Weight is not a qvalue
 severity = "warn"
 
+[violations.status_101_unsolicited]
+# 101 Switching Protocols is sent on a version with no upgrade mechanism
+severity = "warn"
+
 [violations.status_206_multipart_forbidden]
 # A multipart 206 answers a request that asked for a single range
 severity = "warn"

--- a/docs/rules/status_101_switching_protocols.md
+++ b/docs/rules/status_101_switching_protocols.md
@@ -18,9 +18,9 @@ Validates that `101 Switching Protocols` responses follow correct HTTP upgrade s
 ## Specifications
 
 - [RFC 9110 §15.2.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.2.2): 101 Switching Protocols — the response MUST generate an `Upgrade` field naming the protocol(s) in effect after it
-- [RFC 9110 §7.8](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8): Upgrade
-- [RFC 9113 §8.6](https://www.rfc-editor.org/rfc/rfc9113.html#section-8.6): The Upgrade Header Field (HTTP/2 forbids 101)
-- [RFC 9114 §4.5](https://www.rfc-editor.org/rfc/rfc9114.html#section-4.5): HTTP Upgrade — the only place RFC 9114 mentions 101; forbids it alongside the Upgrade mechanism
+- [RFC 9110 §7.8](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8): Upgrade — the mechanism a 101 answers, the MUST NOT on switching to a protocol the client did not indicate, and the MUST that a server ignore an `Upgrade` received in an HTTP/1.0 request
+- [RFC 9113 §8.6](https://www.rfc-editor.org/rfc/rfc9113.html#section-8.6): The Upgrade Header Field — HTTP/2 does not support the 101 status code, and says why: its semantics are not applicable to a multiplexed protocol
+- [RFC 9114 §4.5](https://www.rfc-editor.org/rfc/rfc9114.html#section-4.5): HTTP Upgrade — the only place RFC 9114 mentions 101, withholding the upgrade mechanism and the status code together
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1323,7 +1323,14 @@ severity = "warn"
         /// directive list, and neither says anything about an encoding. Each
         /// field's octet is now `token`'s, under an id the rule already
         /// declared.
-        const FLOOR: usize = 124;
+        ///
+        /// **Three sites can also leave together where one entry names all
+        /// three sentences.** `status_101_switching_protocols` cited RFC 9110
+        /// § 7.8, RFC 9113 § 8.6 and RFC 9114 § 4.5 at three version gates
+        /// reporting one defect; `status_101_unsolicited` names all three, so
+        /// the count of *sentences read* is unchanged and the count of sites
+        /// naming one fell by three.
+        const FLOOR: usize = 121;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/rules/status_101_switching_protocols.rs
+++ b/lint-http-rules/src/rules/status_101_switching_protocols.rs
@@ -4,6 +4,7 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::status::{RFC_9110_7_8, RFC_9113_8_6, RFC_9114_4_5, STATUS_101_UNSOLICITED};
 use crate::violations::upgrade::{RFC_9110_15_2_2, UPGRADE_EMPTY, UPGRADE_MISSING};
 use crate::violations::ViolationDef;
 
@@ -22,33 +23,17 @@ use crate::violations::ViolationDef;
 ///   should appear (the connection has been handed off to the upgraded protocol).
 pub struct Status101SwitchingProtocols;
 
-/// The specification references this rule declares, each named so a finding
-/// site can cite the one it enforces. `specifications()` below is built from
-/// exactly these, so the docs and the citations cannot name different text.
-/// The `Upgrade` field a 101 owes, and the two ways it is not there. The rest
-/// of what this rule says is about the status code itself — a version that has
-/// no upgrade mechanism, a protocol nobody offered, traffic after the switch —
-/// and each of those is a reading of its own.
-static DECLARED: &[&ViolationDef] = &[&UPGRADE_MISSING, &UPGRADE_EMPTY];
-
-const RFC_9110_7_8: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("7.8"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8",
-    note: "Upgrade",
-};
-const RFC_9113_8_6: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9113",
-    section: Some("8.6"),
-    url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.6",
-    note: "The Upgrade Header Field (HTTP/2 forbids 101)",
-};
-const RFC_9114_4_5: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9114",
-    section: Some("4.5"),
-    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.5",
-    note: "HTTP Upgrade — the only place RFC 9114 mentions 101; forbids it alongside the Upgrade mechanism",
-};
+/// The `Upgrade` field a 101 owes, the two ways it is not there, and the status
+/// code sent on a version that has no upgrade mechanism to answer.
+///
+/// **This rule declares no `SpecRef` of its own any more.** Every sentence it
+/// names is on one of the entries above, in `violations/upgrade.rs` and
+/// `violations/status.rs`, and `specifications()` is assembled from those — the
+/// three sections the version entry holds among them, since one entry naming
+/// three documents is what a per-version const would otherwise have split.
+/// What is left unconverted is a protocol nobody offered and traffic after the
+/// switch, each a reading of its own.
+static DECLARED: &[&ViolationDef] = &[&UPGRADE_MISSING, &UPGRADE_EMPTY, &STATUS_101_UNSOLICITED];
 
 impl RuleMeta for Status101SwitchingProtocols {
     fn id(&self) -> &'static str {
@@ -151,51 +136,48 @@ impl Rule for Status101SwitchingProtocols {
                 return None;
             }
 
-            // ── Check: 101 on HTTP/1.0 ──
-            // A 101 is the server acting on the client's Upgrade request; in HTTP/1.0 it
-            // must ignore Upgrade, so it can never legitimately send a 101. This branch
-            // fires on any 101 over HTTP/1.0; the cited sentence literally covers the
-            // Upgrade-present case (the RFC's only "HTTP/1.0 doesn't do Upgrade" statement),
-            // and a bare 101 with no Upgrade at all is illegitimate a fortiori — a 101
-            // presupposes an Upgrade exchange HTTP/1.0 cannot have had.
-            // cite(RFC 9110 § 7.8): "A server that receives an Upgrade header field in an HTTP/1.0 request MUST ignore that Upgrade field."
-            // Both digits, not the string: this is the one gate here that needs the
-            // minor version too, since HTTP/1.1 is the version that does support
-            // Upgrade. Reading the digits is the same move as the two gates below,
-            // which would otherwise be arguing with this line.
+            // ── Check: 101 on a version with no upgrade mechanism ──
+            // One entry for all three versions, and the message is where the
+            // governing section goes: the entry names three sections, so a
+            // finding of it carries no citation and the version is what decides
+            // which sentence it broke. The quotes are on the entry.
+            //
+            // HTTP/1.0 needs both digits, and it is the only one here that does:
+            // HTTP/1.1 is the version that *does* support Upgrade, so the minor
+            // digit is the whole difference. A 101 over HTTP/1.0 is reported
+            // whether or not the request carried an `Upgrade` — the sentence
+            // covers the field being present, and a 101 with no request field at
+            // all is illegitimate a fortiori, since a 101 presupposes an
+            // exchange HTTP/1.0 cannot have had.
+            //
+            // The other two read the major digit only. Two spellings of HTTP/2
+            // were once listed here because the value is one a writer chose —
+            // this version carries no version field of its own — and neither
+            // enumerating them nor guessing which arrives is the question.
+            //
+            // RFC 9114 § 4.5 is the only place that document mentions 101 at
+            // all, and `http3_status_code_valid` reports the same message from
+            // the status code's own side.
             if matches!(
                 crate::http_version::parse(&tx.request.version),
                 Ok(crate::http_version::HttpVersion { major: 1, minor: 0 })
             ) {
-                return Some(self.cited(&RFC_9110_7_8, ctx.severity, "101 Switching Protocols must not be sent in response to an HTTP/1.0 request; \
-                         Upgrade is not supported in HTTP/1.0 (RFC 9110 §7.8)"
-                            .into()));
+                let message = "101 Switching Protocols must not be sent in response to an \
+                     HTTP/1.0 request; a server that receives an Upgrade field in an HTTP/1.0 \
+                     request must ignore it (RFC 9110 §7.8)";
+                return Some(ctx.report_with(&STATUS_101_UNSOLICITED, message.into()));
             }
 
-            // ── Check: 101 on HTTP/2 ──
-            // cite(RFC 9113 § 8.6): "HTTP/2 does not support the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP])."
-            // Two spellings were listed here because the value is one a writer chose
-            // — this version carries no version field — and neither listing them nor
-            // guessing which one arrives is the question. The major digit is.
             if crate::http_version::is_major(&tx.request.version, 2) {
-                return Some(self.cited(
-                    &RFC_9113_8_6,
-                    ctx.severity,
-                    "101 Switching Protocols must not be sent over HTTP/2 (RFC 9113 §8.6)".into(),
-                ));
+                let message = "101 Switching Protocols must not be sent over HTTP/2, which \
+                     does not support the status code (RFC 9113 §8.6)";
+                return Some(ctx.report_with(&STATUS_101_UNSOLICITED, message.into()));
             }
 
-            // ── Check: 101 on HTTP/3 ──
-            // §4.5 is the only place RFC 9114 mentions 101 at all (the message said §4.1,
-            // whose subject is HTTP Message Framing). Also enforced by
-            // `http3_status_code_valid`; checked here for completeness.
-            // cite(RFC 9114 § 4.5): "HTTP/3 does not support the HTTP Upgrade mechanism (Section 7.8 of [HTTP]) or the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP])."
             if crate::http_version::is_major(&tx.request.version, 3) {
-                return Some(self.cited(
-                    &RFC_9114_4_5,
-                    ctx.severity,
-                    "101 Switching Protocols must not be sent over HTTP/3 (RFC 9114 §4.5)".into(),
-                ));
+                let message = "101 Switching Protocols must not be sent over HTTP/3, which \
+                     does not support the status code or the upgrade mechanism (RFC 9114 §4.5)";
+                return Some(ctx.report_with(&STATUS_101_UNSOLICITED, message.into()));
             }
 
             // ── Check: unsolicited 101 (no Upgrade in request) ──

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -416,7 +416,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 182;
+        const FLOOR: usize = 183;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/status.rs
+++ b/lint-http-rules/src/violations/status.rs
@@ -25,10 +25,19 @@
 //! sentence prohibits the message, the entry is `_forbidden`; `_unsolicited` is
 //! for the ones no sentence prohibits and the exchange refutes.
 //!
-//! All three default to `warn`, which is the severity the rule reporting them
-//! had already chosen for itself: a client handed a response it did not ask
-//! for, or cannot parse, has to notice that on its own, and only one of the
-//! three documents a prohibition.
+//! **The fourth widens what "the other message" can be evidence of.** A `101`
+//! is read against the request's *version*, not against a field on it: three
+//! documents each say their version has no place for the code, and none of them
+//! prohibits it in so many words. So the word is `_unsolicited` for the same
+//! reason the first two carry it — what refutes the response is the exchange —
+//! and the piece of the exchange doing the refuting is control data on the
+//! request line rather than a header field. **A version that withholds the
+//! mechanism a client would ask with is a client that could not have asked.**
+//!
+//! All four default to `warn`, which is the severity the rules reporting them
+//! had already chosen for themselves: a client handed a response it did not ask
+//! for, or cannot parse, has to notice that on its own, and only one of the four
+//! documents a prohibition.
 
 use crate::lint::Severity;
 use crate::rules::SpecRef;
@@ -51,6 +60,32 @@ pub const RFC_9110_15_5_17: SpecRef = SpecRef {
     section: Some("15.5.17"),
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.17",
     note: "416 Range Not Satisfiable: the status code is the rejection of the ranges in the request's `Range` field; a server answering a *byte*-range request SHOULD include `Content-Range: bytes */<complete-length>`",
+};
+
+/// The `Upgrade` mechanism, and the one sentence in it about HTTP/1.0: the
+/// version that has the field and may not act on it.
+pub const RFC_9110_7_8: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.8"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8",
+    note: "Upgrade — the mechanism a 101 answers, the MUST NOT on switching to a protocol the client did not indicate, and the MUST that a server ignore an `Upgrade` received in an HTTP/1.0 request",
+};
+
+/// HTTP/2's account of the field and the status code: neither is part of the
+/// version.
+pub const RFC_9113_8_6: SpecRef = SpecRef {
+    spec: "RFC 9113",
+    section: Some("8.6"),
+    url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.6",
+    note: "The Upgrade Header Field — HTTP/2 does not support the 101 status code, and says why: its semantics are not applicable to a multiplexed protocol",
+};
+
+/// HTTP/3's, which withholds the mechanism and the code in one sentence.
+pub const RFC_9114_4_5: SpecRef = SpecRef {
+    spec: "RFC 9114",
+    section: Some("4.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.5",
+    note: "HTTP Upgrade — the only place RFC 9114 mentions 101, withholding the upgrade mechanism and the status code together",
 };
 
 defects! {
@@ -121,6 +156,48 @@ defects! {
         default_severity: Severity::Warn,
         spec: &[RFC_9110_15_3_7_2],
     }
+
+    /// A `101` carried by a version that has no upgrade mechanism to answer.
+    /// The status code announces a connection changing protocol *via the
+    /// `Upgrade` field*, and each of the three versions below takes one of the
+    /// two halves away: HTTP/1.0 has the field and requires a server to ignore
+    /// it, HTTP/2 keeps the mechanism out and says the code's semantics do not
+    /// apply to a multiplexed protocol, HTTP/3 withholds both in one sentence.
+    /// Whatever such a request wrote, it could not have invited this answer.
+    ///
+    /// **Three documents, one defect, and this is the entry that argued for
+    /// `spec` being a slice.** All three sections are named and no finding
+    /// carries any of them: the version is known at the site, which names its
+    /// own governing section in the message. Splitting the entry per version
+    /// would give one defect three ids for an operator to silence separately,
+    /// which is the duplication this catalogue exists to remove — and the ids
+    /// would name the versions rather than the defect.
+    ///
+    /// **`_unsolicited` rather than `_forbidden`, and the sentences are the
+    /// reason.** Only the HTTP/1.0 one carries a keyword at all, and its MUST is
+    /// addressed to what a server does with a *field* rather than to the status
+    /// code; the other two state that a version does not support the code, which
+    /// is a definition withheld and not a prohibition. That is the test
+    /// `status_206_unsolicited` was written against and
+    /// `status_206_multipart_forbidden` fails: where a sentence prohibits the
+    /// message the entry is `_forbidden`, and here none does.
+    ///
+    /// `warn`, with the rest of the subject. A `101` is an interim response, and
+    /// a recipient of a 1xx it does not expect is entitled to read past it and
+    /// wait for the final one — so an exchange carrying this defect is confused
+    /// rather than stuck, which is the line the `upgrade_*` entries sit on the
+    /// other side of.
+    ///
+    // cite(RFC 9110 § 7.8): "A server that receives an Upgrade header field in an HTTP/1.0 request MUST ignore that Upgrade field."
+    // cite(RFC 9113 § 8.6): "HTTP/2 does not support the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP])."
+    // cite(RFC 9114 § 4.5): "HTTP/3 does not support the HTTP Upgrade mechanism (Section 7.8 of [HTTP]) or the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP])."
+    STATUS_101_UNSOLICITED = {
+        id: "status_101_unsolicited",
+        title: "101 Switching Protocols is sent on a version with no upgrade mechanism",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_9110_7_8, RFC_9113_8_6, RFC_9114_4_5],
+    }
 }
 
 #[cfg(test)]
@@ -137,9 +214,28 @@ mod tests {
             &STATUS_206_UNSOLICITED,
             &STATUS_416_UNSOLICITED,
             &STATUS_206_MULTIPART_FORBIDDEN,
+            &STATUS_101_UNSOLICITED,
         ] {
             assert!(def.id.starts_with("status_"), "{} is not a status", def.id);
             assert!(!def.id.contains("range"), "{} names a field", def.id);
+        }
+    }
+
+    /// One defect stated by three documents: the id names none of the versions,
+    /// because the same server sending the same response over any of them has
+    /// made one mistake and an operator silencing it silences one thing.
+    #[test]
+    fn the_version_entry_names_three_sections_and_no_version() {
+        assert_eq!(
+            STATUS_101_UNSOLICITED.spec,
+            [RFC_9110_7_8, RFC_9113_8_6, RFC_9114_4_5]
+        );
+        for word in ["http", "1_0", "2", "3"] {
+            assert!(
+                !STATUS_101_UNSOLICITED.id.contains(word),
+                "{} names a version",
+                STATUS_101_UNSOLICITED.id,
+            );
         }
     }
 
@@ -150,24 +246,36 @@ mod tests {
     #[test]
     fn only_the_entry_a_sentence_prohibits_is_the_forbidden_one() {
         assert!(STATUS_206_MULTIPART_FORBIDDEN.id.ends_with("_forbidden"));
-        for def in [&STATUS_206_UNSOLICITED, &STATUS_416_UNSOLICITED] {
+        for def in [
+            &STATUS_206_UNSOLICITED,
+            &STATUS_416_UNSOLICITED,
+            &STATUS_101_UNSOLICITED,
+        ] {
             assert!(def.id.ends_with("_unsolicited"), "{}", def.id);
         }
     }
 
-    /// Every entry carries its whole message, which is the shape of the defect
-    /// rather than a convenience: what is wrong here is the pairing of two
-    /// messages and never a value one of them wrote, so there is nothing for a
-    /// site to interpolate and no wording that varies between one finding and
-    /// the next.
+    /// The range entries carry their whole message, which is the shape of the
+    /// defect rather than a convenience: what is wrong there is the pairing of
+    /// two messages and never a value one of them wrote, so there is nothing for
+    /// a site to interpolate and no wording that varies between findings.
+    ///
+    /// **The 101 entry is the exception and its reason is the slice.** It names
+    /// three sections, so its findings carry no citation and the message has to
+    /// say which version's sentence governs — a value the request line did
+    /// write. An entry naming one sentence has nothing to interpolate; an entry
+    /// naming several always does.
     #[test]
-    fn no_entry_leaves_its_message_to_the_site() {
+    fn only_the_entry_with_several_sentences_leaves_its_message_to_the_site() {
         for def in [
             &STATUS_206_UNSOLICITED,
             &STATUS_416_UNSOLICITED,
             &STATUS_206_MULTIPART_FORBIDDEN,
         ] {
+            assert_eq!(def.spec.len(), 1, "{}", def.id);
             assert!(!def.message.is_empty(), "{} holds no message", def.id);
         }
+        assert!(STATUS_101_UNSOLICITED.spec.len() > 1);
+        assert!(STATUS_101_UNSOLICITED.message.is_empty());
     }
 }

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -5147,7 +5147,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
       line: 118
     - file: lint-http-rules/src/violations/status.rs
-      line: 69
+      line: 104
   - label: accept_ranges_on_partial_content
     section: § 14.2
     snippet: A server MUST ignore a Range header field received with a request method that is unrecognized or for which range handling is not defined.
@@ -8737,41 +8737,41 @@ sources:
     snippet: A server MUST NOT generate a multipart response to a request for a single range, since a client that does not request multiple parts might not support multipart responses.
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 116
+      line: 151
   - label: status (2)
     section: § 15.5.17
     snippet: The 416 (Range Not Satisfiable) status code indicates that the set of ranges in the request's Range header field (Section 14.2) has been rejected either because none of the requested ranges are satisfiable or because the client has requested an excessive number of small or overlapping ranges (a potential denial of service attack).
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 89
+      line: 124
+  - label: status (3)
+    section: § 7.8
+    snippet: A server that receives an Upgrade header field in an HTTP/1.0 request MUST ignore that Upgrade field.
+    cited_by:
+    - file: lint-http-rules/src/violations/status.rs
+      line: 191
   - label: status_101_switching_protocols
     section: § 15.2.2
     snippet: The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field (Section 7.8), for a change in the application protocol being used on this connection.
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 136
+      line: 121
   - label: status_101_switching_protocols (2)
     section: § 7.8
     snippet: A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field.
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 211
+      line: 193
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 254
+      line: 236
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 284
+      line: 266
   - label: status_101_switching_protocols (3)
-    section: § 7.8
-    snippet: A server that receives an Upgrade header field in an HTTP/1.0 request MUST ignore that Upgrade field.
-    cited_by:
-    - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 161
-  - label: status_101_switching_protocols (4)
     section: § 7.8
     snippet: Although protocol names are registered with a preferred case, recipients SHOULD use case-insensitive comparison when matching each protocol-name to supported protocols.
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 243
+      line: 225
   - label: status_103_early_hints_before_final
     section: § 15.2
     snippet: Since HTTP/1.0 did not define any 1xx status codes, a server MUST NOT send a 1xx response to an HTTP/1.0 client.
@@ -10575,12 +10575,12 @@ sources:
       line: 209
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
       line: 160
-  - label: status_101_switching_protocols
+  - label: status
     section: § 8.6
     snippet: HTTP/2 does not support the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP]).
     cited_by:
-    - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 176
+    - file: lint-http-rules/src/violations/status.rs
+      line: 192
   - label: the TE exception
     section: § 8.2.2
     snippet: The only exception to this is the TE header field, which MAY be present in an HTTP/2 request; when it is, it MUST NOT contain any value other than "trailers".
@@ -10768,10 +10768,10 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/http3_status_code_valid.rs
       line: 125
-    - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 192
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
       line: 169
+    - file: lint-http-rules/src/violations/status.rs
+      line: 193
   - label: lint-http-core/src/http_version.rs
     section: § 4.3.1
     snippet: HTTP/3 does not define a way to carry the version identifier that is included in the HTTP/1.1 request line.


### PR DESCRIPTION
`status_101_unsolicited` joins the `status` subject and takes the rule's three version gates: a 101 answering an HTTP/1.0 request, one over HTTP/2, one over HTTP/3. One defect, three documents — RFC 9110 §7.8, RFC 9113 §8.6, RFC 9114 §4.5 — so the entry names all three sections and its findings carry none of them, each naming the governing one in its own message.

`_unsolicited` rather than `_forbidden`, and the sentences are why. Only the HTTP/1.0 one carries a keyword, and its MUST is addressed to what a server does with a *field*; the other two say a version does not support the code, which is a definition withheld and not a prohibition. What refutes the response is the exchange — and the piece of it doing the refuting is the request's version rather than a field on it, which is new for a subject whose evidence has so far been the other message's headers. A version that withholds the mechanism a client would ask with is a client that could not have asked.

The three `SpecRef` consts move onto the subject, and this rule now declares none of its own: every sentence it names lives on an entry. It is also the first entry in the subject to leave its message to the site, because an entry naming several sentences always must.

Floors: 183 of 188 entries cite a sentence; citation 124 → 121, three sites for an unchanged count of sentences.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
