### PR TITLE
Three faces of one prohibition

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1647,6 +1647,10 @@ severity = "warn"
 # Weight is not a qvalue
 severity = "warn"
 
+[violations.status_101_protocol_forbidden]
+# A 101 switches to a protocol the client did not indicate
+severity = "error"
+
 [violations.status_101_unsolicited]
 # 101 Switching Protocols is sent on a version with no upgrade mechanism
 severity = "warn"

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1329,8 +1329,10 @@ severity = "warn"
         /// § 7.8, RFC 9113 § 8.6 and RFC 9114 § 4.5 at three version gates
         /// reporting one defect; `status_101_unsolicited` names all three, so
         /// the count of *sentences read* is unchanged and the count of sites
-        /// naming one fell by three.
-        const FLOOR: usize = 121;
+        /// naming one fell by three. **Three more of that rule's went the
+        /// ordinary way** — the faces of § 7.8's MUST NOT, which had quoted one
+        /// sentence at three sites and now report one entry.
+        const FLOOR: usize = 118;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/rules/status_101_switching_protocols.rs
+++ b/lint-http-rules/src/rules/status_101_switching_protocols.rs
@@ -4,7 +4,9 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
-use crate::violations::status::{RFC_9110_7_8, RFC_9113_8_6, RFC_9114_4_5, STATUS_101_UNSOLICITED};
+use crate::violations::status::{
+    RFC_9110_7_8, RFC_9113_8_6, RFC_9114_4_5, STATUS_101_PROTOCOL_FORBIDDEN, STATUS_101_UNSOLICITED,
+};
 use crate::violations::upgrade::{RFC_9110_15_2_2, UPGRADE_EMPTY, UPGRADE_MISSING};
 use crate::violations::ViolationDef;
 
@@ -33,7 +35,12 @@ pub struct Status101SwitchingProtocols;
 /// three documents is what a per-version const would otherwise have split.
 /// What is left unconverted is a protocol nobody offered and traffic after the
 /// switch, each a reading of its own.
-static DECLARED: &[&ViolationDef] = &[&UPGRADE_MISSING, &UPGRADE_EMPTY, &STATUS_101_UNSOLICITED];
+static DECLARED: &[&ViolationDef] = &[
+    &UPGRADE_MISSING,
+    &UPGRADE_EMPTY,
+    &STATUS_101_UNSOLICITED,
+    &STATUS_101_PROTOCOL_FORBIDDEN,
+];
 
 impl RuleMeta for Status101SwitchingProtocols {
     fn id(&self) -> &'static str {
@@ -187,17 +194,16 @@ impl Rule for Status101SwitchingProtocols {
             let req_upgrade_combined =
                 crate::helpers::headers::get_all_header_values(&tx.request.headers, "upgrade");
             // No request Upgrade at all: the client indicated no protocol, so the switch
-            // the 101 announces is one it never invited. Same governing sentence as the
-            // empty-token and protocol-mismatch checks below — the three faces of "not
-            // indicated by the client" (nothing / malformed / a different protocol).
-            // cite(RFC 9110 § 7.8): "A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field."
+            // the 101 announces is one it never invited. Same entry as the empty-token
+            // and protocol-mismatch checks below — the three faces of "not indicated by
+            // the client" (nothing / malformed / a different protocol), and the sentence
+            // is quoted once, on the entry.
             if req_upgrade_combined.is_none() {
                 return Some(
-                    self.cited(
-                        &RFC_9110_7_8,
-                        ctx.severity,
+                    ctx.report_with(
+                        &STATUS_101_PROTOCOL_FORBIDDEN,
                         "Server sent 101 Switching Protocols but the request did not include an \
-                         Upgrade header (RFC 9110 §7.8)"
+                     Upgrade header (RFC 9110 §7.8)"
                             .into(),
                     ),
                 );
@@ -233,14 +239,12 @@ impl Rule for Status101SwitchingProtocols {
                 .collect();
 
             // Upgrade present but no valid tokens (e.g. " , , "): still nothing indicated.
-            // cite(RFC 9110 § 7.8): "A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field."
             if offered.is_empty() {
                 return Some(
-                    self.cited(
-                        &RFC_9110_7_8,
-                        ctx.severity,
+                    ctx.report_with(
+                        &STATUS_101_PROTOCOL_FORBIDDEN,
                         "Server sent 101 Switching Protocols but the request Upgrade header \
-                         contains no protocol tokens (RFC 9110 §7.8)"
+                     contains no protocol tokens (RFC 9110 §7.8)"
                             .into(),
                     ),
                 );
@@ -262,14 +266,13 @@ impl Rule for Status101SwitchingProtocols {
 
             // The server may choose one or more of the offered protocols, but every
             // chosen protocol must have been offered — `all` fails on the first that
-            // was not, which is exactly "switch to a protocol not indicated".
-            // cite(RFC 9110 § 7.8): "A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field."
+            // was not, which is exactly "switch to a protocol not indicated" and the
+            // third face of the entry's sentence.
             let all_matched = chosen_list.iter().all(|c| offered.contains(c));
 
             if !all_matched {
-                return Some(self.cited(
-                    &RFC_9110_7_8,
-                    ctx.severity,
+                return Some(ctx.report_with(
+                    &STATUS_101_PROTOCOL_FORBIDDEN,
                     format!(
                         "101 response Upgrade '{}' was not offered by the client's Upgrade '{}' \
                          (RFC 9110 §7.8)",

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -416,7 +416,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 183;
+        const FLOOR: usize = 184;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/status.rs
+++ b/lint-http-rules/src/violations/status.rs
@@ -34,10 +34,20 @@
 //! request line rather than a header field. **A version that withholds the
 //! mechanism a client would ask with is a client that could not have asked.**
 //!
-//! All four default to `warn`, which is the severity the rules reporting them
-//! had already chosen for themselves: a client handed a response it did not ask
-//! for, or cannot parse, has to notice that on its own, and only one of the four
-//! documents a prohibition.
+//! **The fifth is the first entry here that ranks above the rule reporting it**,
+//! and the line it draws is worth having: a `101` that switches to a protocol
+//! the client never named is not a status code describing an exchange wrongly —
+//! it is a connection that has *left HTTP* for something the client cannot
+//! speak. There is no later message to repair it in, which is the argument
+//! `upgrade_missing` and `upgrade_empty` already make for `error`.
+//!
+//! So four of the five default to `warn`, which is the severity the rules
+//! reporting them had already chosen for themselves: a client handed a response
+//! it did not ask for, or cannot parse, has to notice that on its own, and the
+//! exchange carries on around it. **The question that separates the levels is
+//! not how strong the sentence is but whether the exchange can continue** — two
+//! of the five quote a prohibition, and only one of those two ends the
+//! conversation.
 
 use crate::lint::Severity;
 use crate::rules::SpecRef;
@@ -198,6 +208,41 @@ defects! {
         default_severity: Severity::Warn,
         spec: &[RFC_9110_7_8, RFC_9113_8_6, RFC_9114_4_5],
     }
+
+    /// A `101` switching to a protocol the client did not name. The version has
+    /// the mechanism and the exchange used it; what is wrong is *which* protocol
+    /// the connection now speaks.
+    ///
+    /// **One entry for three faces of one sentence**, which is how the rule
+    /// reporting it already described them: the request carried no `Upgrade`
+    /// field at all, or carried one with no protocol on it, or named protocols
+    /// and the response chose a different one. In all three the response's
+    /// protocol is one the request did not indicate, which is the whole of the
+    /// MUST NOT — and an operator silencing this is silencing a server that
+    /// switches to protocols of its own choosing, not three separate policies.
+    ///
+    /// `_forbidden`, because § 7.8 states it as a MUST NOT addressed to the
+    /// server. That is the line
+    /// [`STATUS_101_UNSOLICITED`] sits on the other side of: there, three
+    /// documents withhold a definition and none prohibits the message.
+    ///
+    /// **`error`, one level above the rule that reports it**, and the reason is
+    /// not the strength of the sentence. A `101` hands the connection over:
+    /// everything after the response's empty line is spoken in the new protocol,
+    /// so a client that never named it has nothing to say and nothing to wait
+    /// for. That is the same argument
+    /// [`upgrade_missing`](crate::violations::upgrade::UPGRADE_MISSING) makes,
+    /// and it is what separates this entry from the four `warn`s beside it,
+    /// where the exchange survives the defect.
+    ///
+    // cite(RFC 9110 § 7.8): "A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field."
+    STATUS_101_PROTOCOL_FORBIDDEN = {
+        id: "status_101_protocol_forbidden",
+        title: "A 101 switches to a protocol the client did not indicate",
+        message: "",
+        default_severity: Severity::Error,
+        spec: &[RFC_9110_7_8],
+    }
 }
 
 #[cfg(test)]
@@ -215,9 +260,11 @@ mod tests {
             &STATUS_416_UNSOLICITED,
             &STATUS_206_MULTIPART_FORBIDDEN,
             &STATUS_101_UNSOLICITED,
+            &STATUS_101_PROTOCOL_FORBIDDEN,
         ] {
             assert!(def.id.starts_with("status_"), "{} is not a status", def.id);
             assert!(!def.id.contains("range"), "{} names a field", def.id);
+            assert!(!def.id.contains("upgrade"), "{} names a field", def.id);
         }
     }
 
@@ -246,6 +293,7 @@ mod tests {
     #[test]
     fn only_the_entry_a_sentence_prohibits_is_the_forbidden_one() {
         assert!(STATUS_206_MULTIPART_FORBIDDEN.id.ends_with("_forbidden"));
+        assert!(STATUS_101_PROTOCOL_FORBIDDEN.id.ends_with("_forbidden"));
         for def in [
             &STATUS_206_UNSOLICITED,
             &STATUS_416_UNSOLICITED,
@@ -277,5 +325,25 @@ mod tests {
         }
         assert!(STATUS_101_UNSOLICITED.spec.len() > 1);
         assert!(STATUS_101_UNSOLICITED.message.is_empty());
+    }
+
+    /// The level is decided by whether the exchange can continue, and not by
+    /// which entries quote a prohibition. Two of the five do; one of those two
+    /// hands the connection to a protocol the client cannot speak, and it is the
+    /// only `error` here.
+    #[test]
+    fn the_entry_that_ends_the_conversation_is_the_only_error() {
+        assert_eq!(
+            STATUS_101_PROTOCOL_FORBIDDEN.default_severity,
+            Severity::Error
+        );
+        for def in [
+            &STATUS_206_UNSOLICITED,
+            &STATUS_416_UNSOLICITED,
+            &STATUS_206_MULTIPART_FORBIDDEN,
+            &STATUS_101_UNSOLICITED,
+        ] {
+            assert_eq!(def.default_severity, Severity::Warn, "{}", def.id);
+        }
     }
 }

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -5147,7 +5147,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
       line: 118
     - file: lint-http-rules/src/violations/status.rs
-      line: 104
+      line: 114
   - label: accept_ranges_on_partial_content
     section: § 14.2
     snippet: A server MUST ignore a Range header field received with a request method that is unrecognized or for which range handling is not defined.
@@ -8737,41 +8737,37 @@ sources:
     snippet: A server MUST NOT generate a multipart response to a request for a single range, since a client that does not request multiple parts might not support multipart responses.
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 151
+      line: 161
   - label: status (2)
     section: § 15.5.17
     snippet: The 416 (Range Not Satisfiable) status code indicates that the set of ranges in the request's Range header field (Section 14.2) has been rejected either because none of the requested ranges are satisfiable or because the client has requested an excessive number of small or overlapping ranges (a potential denial of service attack).
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 124
+      line: 134
   - label: status (3)
+    section: § 7.8
+    snippet: A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field.
+    cited_by:
+    - file: lint-http-rules/src/violations/status.rs
+      line: 238
+  - label: status (4)
     section: § 7.8
     snippet: A server that receives an Upgrade header field in an HTTP/1.0 request MUST ignore that Upgrade field.
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 191
+      line: 201
   - label: status_101_switching_protocols
     section: § 15.2.2
     snippet: The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field (Section 7.8), for a change in the application protocol being used on this connection.
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 121
+      line: 128
   - label: status_101_switching_protocols (2)
-    section: § 7.8
-    snippet: A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field.
-    cited_by:
-    - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 193
-    - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 236
-    - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 266
-  - label: status_101_switching_protocols (3)
     section: § 7.8
     snippet: Although protocol names are registered with a preferred case, recipients SHOULD use case-insensitive comparison when matching each protocol-name to supported protocols.
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 225
+      line: 231
   - label: status_103_early_hints_before_final
     section: § 15.2
     snippet: Since HTTP/1.0 did not define any 1xx status codes, a server MUST NOT send a 1xx response to an HTTP/1.0 client.
@@ -10580,7 +10576,7 @@ sources:
     snippet: HTTP/2 does not support the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 192
+      line: 202
   - label: the TE exception
     section: § 8.2.2
     snippet: The only exception to this is the TE header field, which MAY be present in an HTTP/2 request; when it is, it MUST NOT contain any value other than "trailers".
@@ -10771,7 +10767,7 @@ sources:
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
       line: 169
     - file: lint-http-rules/src/violations/status.rs
-      line: 193
+      line: 203
   - label: lint-http-core/src/http_version.rs
     section: § 4.3.1
     snippet: HTTP/3 does not define a way to carry the version identifier that is included in the HTTP/1.1 request line.


### PR DESCRIPTION
`status_101_protocol_forbidden` joins the `status` subject and takes the three sites that report a 101 switching to a protocol the client did not name: the request carried no `Upgrade` at all, or carried one with no protocol on it, or named protocols and the response chose another. The rule's own comment already called them the three faces of §7.8's MUST NOT, so they are one entry and the sentence is quoted once.

`_forbidden` where the version entry beside it is `_unsolicited`: this sentence prohibits the message in so many words, and that is the only thing separating the two words.

`error`, one level above the rule that reports it, and the argument is not the strength of the sentence. A 101 hands the connection over — everything after the empty line is spoken in the new protocol — so a client that never named it has nothing to say and nothing to wait for, which is the reason `upgrade_missing` ranks where it does. The four entries beside this one stay `warn` because their exchanges survive the defect, and the subject's module doc now says the level is decided by whether the conversation can continue.

Floors: 184 of 189 entries cite a sentence; citation 121 → 118, three sites for one sentence that has not stopped being read.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
