### PR TITLE
A hand-off that nobody took

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1647,6 +1647,10 @@ severity = "warn"
 # Weight is not a qvalue
 severity = "warn"
 
+[violations.status_101_ignored]
+# HTTP continues on a connection a 101 handed off
+severity = "warn"
+
 [violations.status_101_protocol_forbidden]
 # A 101 switches to a protocol the client did not indicate
 severity = "error"

--- a/docs/rules/status_101_switching_protocols.md
+++ b/docs/rules/status_101_switching_protocols.md
@@ -17,7 +17,7 @@ Validates that `101 Switching Protocols` responses follow correct HTTP upgrade s
 
 ## Specifications
 
-- [RFC 9110 §15.2.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.2.2): 101 Switching Protocols — the response MUST generate an `Upgrade` field naming the protocol(s) in effect after it
+- [RFC 9110 §15.2.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.2.2): 101 Switching Protocols — the status code is a change in the application protocol being used on this connection, and the response MUST generate an `Upgrade` field naming the protocol(s) in effect after it
 - [RFC 9110 §7.8](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8): Upgrade — the mechanism a 101 answers, the MUST NOT on switching to a protocol the client did not indicate, and the MUST that a server ignore an `Upgrade` received in an HTTP/1.0 request
 - [RFC 9113 §8.6](https://www.rfc-editor.org/rfc/rfc9113.html#section-8.6): The Upgrade Header Field — HTTP/2 does not support the 101 status code, and says why: its semantics are not applicable to a multiplexed protocol
 - [RFC 9114 §4.5](https://www.rfc-editor.org/rfc/rfc9114.html#section-4.5): HTTP Upgrade — the only place RFC 9114 mentions 101, withholding the upgrade mechanism and the status code together

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1331,8 +1331,11 @@ severity = "warn"
         /// the count of *sentences read* is unchanged and the count of sites
         /// naming one fell by three. **Three more of that rule's went the
         /// ordinary way** — the faces of § 7.8's MUST NOT, which had quoted one
-        /// sentence at three sites and now report one entry.
-        const FLOOR: usize = 118;
+        /// sentence at three sites and now report one entry — and the seventh
+        /// took the rule's last site with it: § 15.2.2's definition, read for
+        /// the connection it says changed protocol, now sits on
+        /// `status_101_ignored`.
+        const FLOOR: usize = 117;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/rules/status_101_switching_protocols.rs
+++ b/lint-http-rules/src/rules/status_101_switching_protocols.rs
@@ -5,7 +5,8 @@
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
 use crate::violations::status::{
-    RFC_9110_7_8, RFC_9113_8_6, RFC_9114_4_5, STATUS_101_PROTOCOL_FORBIDDEN, STATUS_101_UNSOLICITED,
+    RFC_9110_7_8, RFC_9113_8_6, RFC_9114_4_5, STATUS_101_IGNORED, STATUS_101_PROTOCOL_FORBIDDEN,
+    STATUS_101_UNSOLICITED,
 };
 use crate::violations::upgrade::{RFC_9110_15_2_2, UPGRADE_EMPTY, UPGRADE_MISSING};
 use crate::violations::ViolationDef;
@@ -25,21 +26,22 @@ use crate::violations::ViolationDef;
 ///   should appear (the connection has been handed off to the upgraded protocol).
 pub struct Status101SwitchingProtocols;
 
-/// The `Upgrade` field a 101 owes, the two ways it is not there, and the status
-/// code sent on a version that has no upgrade mechanism to answer.
+/// Everything this rule says, in five entries over two subjects: the `Upgrade`
+/// field a 101 owes and the two ways it is not there; the status code sent on a
+/// version that has no upgrade mechanism to answer; the protocol nobody offered;
+/// and the connection that kept speaking HTTP after being handed off.
 ///
-/// **This rule declares no `SpecRef` of its own any more.** Every sentence it
-/// names is on one of the entries above, in `violations/upgrade.rs` and
-/// `violations/status.rs`, and `specifications()` is assembled from those — the
-/// three sections the version entry holds among them, since one entry naming
-/// three documents is what a per-version const would otherwise have split.
-/// What is left unconverted is a protocol nobody offered and traffic after the
-/// switch, each a reading of its own.
+/// **This rule declares no `SpecRef` of its own.** Every sentence it names is on
+/// one of these entries, in `violations/upgrade.rs` and `violations/status.rs`,
+/// and `specifications()` is assembled from those — the three sections the
+/// version entry holds among them, since one entry naming three documents is
+/// what a per-version const would otherwise have split.
 static DECLARED: &[&ViolationDef] = &[
     &UPGRADE_MISSING,
     &UPGRADE_EMPTY,
     &STATUS_101_UNSOLICITED,
     &STATUS_101_PROTOCOL_FORBIDDEN,
+    &STATUS_101_IGNORED,
 ];
 
 impl RuleMeta for Status101SwitchingProtocols {
@@ -122,17 +124,18 @@ impl Rule for Status101SwitchingProtocols {
             // The operative clause is "for a change in the application protocol being
             // used on this connection": a 101 switches the connection's protocol, so a
             // later HTTP transaction on it means the hand-off did not take. There is no
-            // hard "MUST NOT send HTTP after 101"; this is derived from that switch, and
-            // it is why the earlier cite quoted the wrong (introductory) half of the
-            // sentence — the connection-change clause is what governs here.
-            // cite(RFC 9110 § 15.2.2): "The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field (Section 7.8), for a change in the application protocol being used on this connection."
+            // hard "MUST NOT send HTTP after 101"; the defect is derived from what the
+            // code indicates, which is the sentence quoted on the entry — and the reason
+            // an earlier cite here quoted the wrong (introductory) half of it.
+            //
+            // The connection id is what makes the reading possible and it is optional:
+            // a capture written without one produces no finding, which is a limit of the
+            // capture rather than a verdict about the traffic.
             if tx.connection_id.is_some() {
                 for prev in history.iter() {
                     if let Some(prev_resp) = &prev.response {
                         if prev_resp.status == 101 {
-                            return Some(self.cited(&RFC_9110_15_2_2, ctx.severity, "HTTP traffic after 101 Switching Protocols on the same connection; \
-                                     the connection should have been handed off to the upgraded protocol"
-                                        .into()));
+                            return Some(ctx.report(&STATUS_101_IGNORED));
                         }
                     }
                 }

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -416,7 +416,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 184;
+        const FLOOR: usize = 185;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/status.rs
+++ b/lint-http-rules/src/violations/status.rs
@@ -41,18 +41,26 @@
 //! speak. There is no later message to repair it in, which is the argument
 //! `upgrade_missing` and `upgrade_empty` already make for `error`.
 //!
-//! So four of the five default to `warn`, which is the severity the rules
+//! **The sixth is read out of a third message**, and it is the widest this
+//! subject goes: a `101` announces that the connection has stopped speaking
+//! HTTP, so HTTP in a *later transaction on the same connection* is evidence the
+//! hand-off never took. The other five compare a response with the request it
+//! answers; this one compares a connection with a response earlier on it, which
+//! is why it needs the history and a connection id to be reported at all.
+//!
+//! So five of the six default to `warn`, which is the severity the rules
 //! reporting them had already chosen for themselves: a client handed a response
 //! it did not ask for, or cannot parse, has to notice that on its own, and the
 //! exchange carries on around it. **The question that separates the levels is
 //! not how strong the sentence is but whether the exchange can continue** — two
-//! of the five quote a prohibition, and only one of those two ends the
+//! of the six quote a prohibition, and only one of those two ends the
 //! conversation.
 
 use crate::lint::Severity;
 use crate::rules::SpecRef;
 use crate::violations::content_range::RFC_9110_15_3_7_2;
 use crate::violations::defects;
+use crate::violations::upgrade::RFC_9110_15_2_2;
 
 /// What a 206 says it is doing, and the field a single-part one has to carry
 /// while it does.
@@ -243,6 +251,42 @@ defects! {
         default_severity: Severity::Error,
         spec: &[RFC_9110_7_8],
     }
+
+    /// HTTP spoken on a connection a `101` already handed over. The status code
+    /// is defined as a change in the application protocol *being used on this
+    /// connection*, so a later HTTP transaction on the same connection is
+    /// evidence the change never happened — the response announced a hand-off
+    /// and both endpoints carried on as before.
+    ///
+    /// **`_ignored`, and it is the first entry in this catalogue to use the
+    /// word.** No sentence says "MUST NOT send HTTP after a 101": the defect is
+    /// derived from what the code indicates, which is why it is neither
+    /// `_forbidden` nor a value being measured. And it is not `_conflicting`
+    /// either — that word is for two claims about one thing, and here there is
+    /// one claim that nothing acted on.
+    ///
+    /// **The evidence is a third message, which is new for this subject.** Every
+    /// other entry here is read out of a response and the request it answers;
+    /// this one is read out of a response in *an earlier transaction on the same
+    /// connection*, which is why the rule reporting it needs the history and the
+    /// connection id. A capture with no connection id cannot produce it, and
+    /// that is a limit of the capture rather than a verdict.
+    ///
+    /// **Which endpoint is at fault is not decidable from here**, and the
+    /// message says so by describing the connection rather than a sender: a
+    /// client that kept speaking HTTP and a server that answered it are both
+    /// consistent with what was recorded. `warn`, because everything on the wire
+    /// is legible and the exchange works — what is wrong is that a hand-off was
+    /// announced and did not take.
+    ///
+    // cite(RFC 9110 § 15.2.2): "The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field (Section 7.8), for a change in the application protocol being used on this connection."
+    STATUS_101_IGNORED = {
+        id: "status_101_ignored",
+        title: "HTTP continues on a connection a 101 handed off",
+        message: "HTTP traffic after 101 Switching Protocols on the same connection; the connection should have been handed off to the upgraded protocol",
+        default_severity: Severity::Warn,
+        spec: &[RFC_9110_15_2_2],
+    }
 }
 
 #[cfg(test)]
@@ -261,6 +305,7 @@ mod tests {
             &STATUS_206_MULTIPART_FORBIDDEN,
             &STATUS_101_UNSOLICITED,
             &STATUS_101_PROTOCOL_FORBIDDEN,
+            &STATUS_101_IGNORED,
         ] {
             assert!(def.id.starts_with("status_"), "{} is not a status", def.id);
             assert!(!def.id.contains("range"), "{} names a field", def.id);
@@ -319,6 +364,7 @@ mod tests {
             &STATUS_206_UNSOLICITED,
             &STATUS_416_UNSOLICITED,
             &STATUS_206_MULTIPART_FORBIDDEN,
+            &STATUS_101_IGNORED,
         ] {
             assert_eq!(def.spec.len(), 1, "{}", def.id);
             assert!(!def.message.is_empty(), "{} holds no message", def.id);
@@ -342,6 +388,7 @@ mod tests {
             &STATUS_416_UNSOLICITED,
             &STATUS_206_MULTIPART_FORBIDDEN,
             &STATUS_101_UNSOLICITED,
+            &STATUS_101_IGNORED,
         ] {
             assert_eq!(def.default_severity, Severity::Warn, "{}", def.id);
         }

--- a/lint-http-rules/src/violations/upgrade.rs
+++ b/lint-http-rules/src/violations/upgrade.rs
@@ -27,12 +27,16 @@ use crate::lint::Severity;
 use crate::rules::SpecRef;
 use crate::violations::defects;
 
-/// The status code's section, where the requirement on the field is written.
+/// The status code's section: what the code indicates, and the requirement on
+/// the field written into the same paragraph. Shared with
+/// [`status`](crate::violations::status), whose entry reads the first half of it
+/// — a connection that changed protocol — where the two entries here read the
+/// second.
 pub const RFC_9110_15_2_2: SpecRef = SpecRef {
     spec: "RFC 9110",
     section: Some("15.2.2"),
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.2.2",
-    note: "101 Switching Protocols — the response MUST generate an `Upgrade` field naming the protocol(s) in effect after it",
+    note: "101 Switching Protocols — the status code is a change in the application protocol being used on this connection, and the response MUST generate an `Upgrade` field naming the protocol(s) in effect after it",
 };
 
 defects! {

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -5147,7 +5147,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
       line: 118
     - file: lint-http-rules/src/violations/status.rs
-      line: 114
+      line: 122
   - label: accept_ranges_on_partial_content
     section: § 14.2
     snippet: A server MUST ignore a Range header field received with a request method that is unrecognized or for which range handling is not defined.
@@ -8733,41 +8733,41 @@ sources:
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 43
   - label: status
+    section: § 15.2.2
+    snippet: The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field (Section 7.8), for a change in the application protocol being used on this connection.
+    cited_by:
+    - file: lint-http-rules/src/violations/status.rs
+      line: 282
+  - label: status (2)
     section: § 15.3.7.2
     snippet: A server MUST NOT generate a multipart response to a request for a single range, since a client that does not request multiple parts might not support multipart responses.
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 161
-  - label: status (2)
+      line: 169
+  - label: status (3)
     section: § 15.5.17
     snippet: The 416 (Range Not Satisfiable) status code indicates that the set of ranges in the request's Range header field (Section 14.2) has been rejected either because none of the requested ranges are satisfiable or because the client has requested an excessive number of small or overlapping ranges (a potential denial of service attack).
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 134
-  - label: status (3)
+      line: 142
+  - label: status (4)
     section: § 7.8
     snippet: A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field.
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 238
-  - label: status (4)
+      line: 246
+  - label: status (5)
     section: § 7.8
     snippet: A server that receives an Upgrade header field in an HTTP/1.0 request MUST ignore that Upgrade field.
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 201
+      line: 209
   - label: status_101_switching_protocols
-    section: § 15.2.2
-    snippet: The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field (Section 7.8), for a change in the application protocol being used on this connection.
-    cited_by:
-    - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 128
-  - label: status_101_switching_protocols (2)
     section: § 7.8
     snippet: Although protocol names are registered with a preferred case, recipients SHOULD use case-insensitive comparison when matching each protocol-name to supported protocols.
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 231
+      line: 234
   - label: status_103_early_hints_before_final
     section: § 15.2
     snippet: Since HTTP/1.0 did not define any 1xx status codes, a server MUST NOT send a 1xx response to an HTTP/1.0 client.
@@ -9153,9 +9153,9 @@ sources:
     snippet: The server MUST generate an Upgrade header field in the response that indicates which protocol(s) will be in effect after this response.
     cited_by:
     - file: lint-http-rules/src/violations/upgrade.rs
-      line: 43
+      line: 47
     - file: lint-http-rules/src/violations/upgrade.rs
-      line: 62
+      line: 66
   - label: upgrade_and_connection_consistent
     section: § 7.6.1
     snippet: In contrast, a connection-specific field received without a corresponding connection option usually indicates that the field has been improperly forwarded by an intermediary and ought to be ignored by the recipient.
@@ -10576,7 +10576,7 @@ sources:
     snippet: HTTP/2 does not support the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 202
+      line: 210
   - label: the TE exception
     section: § 8.2.2
     snippet: The only exception to this is the TE header field, which MAY be present in an HTTP/2 request; when it is, it MUST NOT contain any value other than "trailers".
@@ -10767,7 +10767,7 @@ sources:
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
       line: 169
     - file: lint-http-rules/src/violations/status.rs
-      line: 203
+      line: 211
   - label: lint-http-core/src/http_version.rs
     section: § 4.3.1
     snippet: HTTP/3 does not define a way to carry the version identifier that is included in the HTTP/1.1 request line.


### PR DESCRIPTION
`status_101_ignored` joins the `status` subject and takes the rule's last site: HTTP spoken in a later transaction on a connection an earlier 101 handed off. `status_101_switching_protocols` converts whole and declares no `SpecRef` of its own — every sentence it names now lives on an entry.

`_ignored` is the catalogue's first use of the word, and the alternatives are why. No sentence says "MUST NOT send HTTP after a 101", so it is not `_forbidden`; nothing is being measured, so it is not a value defect; and it is not `_conflicting` either, since that word is for two claims about one thing and here there is one claim nothing acted on.

The evidence is a third message, which is new for this subject: the other five entries compare a response with the request it answers, and this one compares a connection with a response earlier on it. Which endpoint kept speaking HTTP is not decidable from a capture, so the message describes the connection rather than a sender, and a capture with no connection id produces no finding at all — a limit of the capture rather than a verdict.

§15.2.2's note widens to hold both halves of the paragraph: what the status code indicates, which this entry reads, and the field the response must generate, which the two `upgrade_*` entries read.

Floors: 185 of 190 entries cite a sentence; citation 118 → 117.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
