### PR TITLE
A host field written and left blank

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1071,6 +1071,10 @@ severity = "warn"
 # Authentication scheme is not one the deployment recognises
 severity = "warn"
 
+[violations.authority_empty]
+# A request's authority field is present and empty
+severity = "error"
+
 [violations.authority_missing]
 # A request that owes an authority names none
 severity = "error"

--- a/lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
+++ b/lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
@@ -5,9 +5,9 @@
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
 use crate::violations::authority::{
-    AUTHORITY_MISSING, AUTHORITY_TUNNEL_MISSING, AUTHORITY_TUNNEL_USERINFO_FORBIDDEN,
-    AUTHORITY_USERINFO_FORBIDDEN, RFC_9110_9_3_6, RFC_9113_8_3_1, RFC_9113_8_5, RFC_9114_4_3_1,
-    RFC_9114_4_4,
+    AUTHORITY_EMPTY, AUTHORITY_MISSING, AUTHORITY_TUNNEL_MISSING,
+    AUTHORITY_TUNNEL_USERINFO_FORBIDDEN, AUTHORITY_USERINFO_FORBIDDEN, RFC_9110_9_3_6,
+    RFC_9113_8_3_1, RFC_9113_8_5, RFC_9114_4_3_1, RFC_9114_4_4,
 };
 use crate::violations::request_target::{
     REQUEST_TARGET_ASTERISK_FORBIDDEN, REQUEST_TARGET_PATH_MISSING, RFC_9110_7_1,
@@ -70,6 +70,7 @@ static DECLARED: &[&ViolationDef] = &[
     &REQUEST_TARGET_PATH_MISSING,
     &AUTHORITY_TUNNEL_MISSING,
     &AUTHORITY_MISSING,
+    &AUTHORITY_EMPTY,
 ];
 
 /// The specification references this rule declares, each named so a finding
@@ -408,17 +409,53 @@ impl Rule for Http3PseudoHeadersValid {
                 // authority to convey, which is the opposite requirement.
                 let authority =
                     crate::helpers::uri::extract_authority_from_request_target(&tx.request.uri);
-                let has_host = tx.request.headers.contains_key("host");
-                if authority.is_none() && !has_host {
-                    return Some(ctx.report_with(
-                        &AUTHORITY_MISSING,
-                        format!(
-                            "Request target '{}' names no authority, and no 'Host' field names one \
-                             either: an 'http' or 'https' request carries the host in ':authority' \
-                             or in a 'Host' field",
-                            crate::helpers::shown::shown_in_finding(uri_trimmed)
-                        ),
-                    ));
+                if authority.is_none() {
+                    // The same clause asks two things of a request whose target
+                    // names no authority: that one of the two fields be there,
+                    // and that a field which is there not be empty. A sender who
+                    // wrote `Host:` and stopped answered the first and broke the
+                    // second, which is a different mistake from writing no field
+                    // at all and a different one to fix — and both are in the
+                    // capture, so both are said.
+                    //
+                    // Read as written, and trimmed of `OWS` alone: on a value
+                    // read one `char` per octet, `str::trim` would take a %xA0
+                    // the sender put inside the field and call the result empty.
+                    // cite(RFC 9114 § 4.3.1): "If these fields are present, they MUST NOT be empty."
+                    // cite(RFC 9110 § 5.5): "A field value does not include leading or trailing whitespace."
+                    // Line by line, because `Host` is not a list field and two
+                    // lines of it are not one value — that count is
+                    // `host_header`'s finding, and what matters here is whether
+                    // any line of it names an authority.
+                    let host_lines = crate::helpers::headers::field_lines_as_written(
+                        &tx.request.headers,
+                        "host",
+                    );
+                    if host_lines.is_empty() {
+                        return Some(ctx.report_with(
+                            &AUTHORITY_MISSING,
+                            format!(
+                                "Request target '{}' names no authority, and the request carries \
+                                 no 'Host' field either: an 'http' or 'https' request carries the \
+                                 host in ':authority' or in a 'Host' field",
+                                crate::helpers::shown::shown_in_finding(uri_trimmed)
+                            ),
+                        ));
+                    }
+                    if host_lines
+                        .iter()
+                        .all(|line| crate::helpers::headers::trim_ows(line).is_empty())
+                    {
+                        return Some(ctx.report_with(
+                            &AUTHORITY_EMPTY,
+                            format!(
+                                "Request target '{}' names no authority and the 'Host' field \
+                                 beside it is empty: whichever of the two an 'http' or 'https' \
+                                 request carries the host in, that field is not empty",
+                                crate::helpers::shown::shown_in_finding(uri_trimmed)
+                            ),
+                        ));
+                    }
                 }
 
                 // § 4.3.1's userinfo MUST NOT, readable exactly where the
@@ -1245,15 +1282,44 @@ mod tests {
         assert!(v.is_none());
     }
 
-    #[test]
-    fn host_present_but_empty_counts_as_present() {
-        // An empty Host header still counts as "present" for the authority
-        // presence check. Value validation is handled by other rules.
+    /// A `Host` written and left blank answers the either-or's first half and
+    /// breaks its second, and it had been silent here: this test asserted that
+    /// an empty value "counts as present" and left the value to other rules,
+    /// which over this version read none of it — `host_header` declines an empty
+    /// `Host` on RFC 9112 § 3.2's reading, where an empty value is what a
+    /// missing authority *requires*.
+    #[rstest]
+    #[case("")]
+    #[case(" ")]
+    #[case("\t")]
+    fn a_host_written_and_left_blank_names_no_authority(#[case] value: &str) {
         let rule = Http3PseudoHeadersValid;
         let mut tx = make_h3_transaction();
         tx.request.method = "GET".into();
         tx.request.uri = "/resource".into();
-        tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("host", "")]);
+        tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("host", value)]);
+
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .expect("a finding");
+        assert_eq!(v.violation, "authority_empty", "{:?}: {}", value, v.message);
+        assert!(v.cite.is_some(), "{}", v.message);
+    }
+
+    /// The same field with an authority on it is not this defect, and neither
+    /// rule says anything.
+    #[test]
+    fn a_host_that_names_an_authority_is_accepted() {
+        let rule = Http3PseudoHeadersValid;
+        let mut tx = make_h3_transaction();
+        tx.request.method = "GET".into();
+        tx.request.uri = "/resource".into();
+        tx.request.headers =
+            crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
         let v = crate::test_helpers::run_rule(
             &rule,

--- a/lint-http-rules/src/violations/authority.rs
+++ b/lint-http-rules/src/violations/authority.rs
@@ -271,6 +271,44 @@ defects! {
         default_severity: Severity::Error,
         spec: &[RFC_9114_4_3_1],
     }
+
+    /// A request that answered the requirement above with a field written and
+    /// left blank. The same clause states both: the request carries one of the
+    /// two fields, and if it carries either, it is not empty — so a `Host:` with
+    /// nothing on it satisfies the letter of the first half and is named by the
+    /// second.
+    ///
+    /// **Separate from [`AUTHORITY_MISSING`] because the senders differ and so
+    /// do their fixes.** One never wrote the field; this one wrote it and put no
+    /// authority in it, which is a different mistake to make and a different one
+    /// to correct. The closed vocabulary already separates the two, and here the
+    /// evidence supports the separation: an absent field line and a blank one
+    /// are both in the capture, unlike the pseudo-headers whose absence and
+    /// blankness reassemble into one target.
+    ///
+    /// **What it is not is an HTTP/1.1 empty `Host`.** RFC 9112 § 3.2 *requires*
+    /// an empty field value where the target URI's authority is missing or
+    /// undefined, which is why `host_header` reports nothing for one and says so
+    /// in its description. This entry is the other version's sentence, and it is
+    /// read only on a request that version governs.
+    ///
+    /// **Nor is it a `Host` that disagrees with an `:authority`.** The clause's
+    /// third half — both fields present, both naming the same authority — is
+    /// `host_and_authority_consistent`'s, and an empty `Host` beside a target
+    /// that does name an authority is that rule's finding rather than this one.
+    /// This entry is for the request that names an authority *nowhere*.
+    ///
+    /// `error`, with its sibling: the consequence is the recipient's either way,
+    /// and it is that the request names no origin.
+    ///
+    // cite(RFC 9114 § 4.3.1): "If these fields are present, they MUST NOT be empty."
+    AUTHORITY_EMPTY = {
+        id: "authority_empty",
+        title: "A request's authority field is present and empty",
+        message: "",
+        default_severity: Severity::Error,
+        spec: &[RFC_9114_4_3_1],
+    }
 }
 
 #[cfg(test)]

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -418,7 +418,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 191;
+        const FLOOR: usize = 192;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -5039,9 +5039,9 @@ sources:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 424
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 258
+      line: 259
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 365
+      line: 366
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 192
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
@@ -5305,7 +5305,7 @@ sources:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 401
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 244
+      line: 245
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
       line: 319
   - label: alt_svc_header_syntax
@@ -6946,6 +6946,8 @@ sources:
       line: 158
     - file: lint-http-rules/src/rules/host_header.rs
       line: 229
+    - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
+      line: 425
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
       line: 538
     - file: lint-http-rules/src/rules/link_header_valid.rs
@@ -10650,6 +10652,10 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 416
+    - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
+      line: 424
+    - file: lint-http-rules/src/violations/authority.rs
+      line: 304
   - label: http3_goaway_semantics
     section: § 5.2
     snippet: Endpoints MUST NOT initiate new requests or promise new pushes on the connection after receipt of a GOAWAY frame from the peer.
@@ -10693,47 +10699,47 @@ sources:
     snippet: All HTTP/3 requests MUST include exactly one value for the :method, :scheme, and :path pseudo-header fields, unless the request is a CONNECT request; see Section 4.4.
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 236
+      line: 237
   - label: http3_pseudo_headers_valid (2)
     section: § 4.3.1
     snippet: Contains the authority portion of the target URI (Section 3.2 of [URI]).
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 472
+      line: 509
   - label: http3_pseudo_headers_valid (3)
     section: § 4.3.1
     snippet: Contains the scheme portion of the target URI (Section 3.1 of [URI]).
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 441
+      line: 478
   - label: http3_pseudo_headers_valid (4)
     section: § 4.3.2
     snippet: For responses, a single ":status" pseudo-header field is defined that carries the HTTP status code; see Section 15 of [HTTP].
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 505
+      line: 542
   - label: http3_pseudo_headers_valid (5)
     section: § 4.3.2
     snippet: This pseudo-header field MUST be included in all responses; otherwise, the response is malformed (see Section 4.1.2).
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 506
+      line: 543
   - label: http3_pseudo_headers_valid (6)
     section: § 4.4
     snippet: The :authority pseudo-header field contains the host and port to connect to
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 278
+      line: 279
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 311
+      line: 312
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 332
+      line: 333
   - label: http3_pseudo_headers_valid (7)
     section: § 4.4
     snippet: The :method pseudo-header field is set to "CONNECT"
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 259
+      line: 260
   - label: http3_settings_frame
     section: § 11.2.2
     snippet: The entries in Table 3 are registered by this document


### PR DESCRIPTION
`authority_empty` joins the authority subject and takes a request that answered RFC 9114 §4.3.1's either-or with a `Host` field carrying nothing. The same clause states both halves — one of the two fields is there, and a field that is there is not empty — so the entry cites the second sentence where its sibling cites the first, and the HTTP/3 rule reports whichever of the two the request earned.

Two entries because the senders differ and so do their fixes: one never wrote the field, the other wrote it and put no authority in it. Here the evidence supports the split, which is what makes it worth making — a field line that is absent and one that is blank are both in the capture, unlike the pseudo-headers whose absence and blankness reassemble into the same target.

Nobody was reporting it. `host_header` declines an empty `Host` deliberately, because RFC 9112 §3.2 *requires* one where the target URI's authority is missing, and `host_and_authority_consistent` reads the same clause but only for a request carrying both fields. The test that stood here asserted an empty value "counts as present" and left the value to other rules, which over this version read none of it.

The lines are read one by one and trimmed of `OWS` alone: `Host` is not a list field, so two lines of it are not one value — that count is `host_header`'s finding — and on a value read one `char` per octet a `str::trim` would take a %xA0 the sender wrote inside the field and call the result empty.

Floor: 192 of 197 entries cite a sentence.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
