### PR TITLE
Metadata on a response with no content

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1695,9 +1695,17 @@ severity = "warn"
 # 206 Partial Content answers a request that asked for no range
 severity = "warn"
 
+[violations.status_304_metadata_forbidden]
+# A 304 sends representation metadata beyond the fields it owes
+severity = "warn"
+
 [violations.status_416_unsolicited]
 # 416 Range Not Satisfiable answers a request that named no range
 severity = "warn"
+
+[violations.status_metadata_redundant]
+# A response that cannot carry content sends representation metadata
+severity = "info"
 
 [violations.strict_transport_security_directive_duplicated]
 # A directive is written more than once in one policy

--- a/docs/rules/content_encoding_and_type_consistent.md
+++ b/docs/rules/content_encoding_and_type_consistent.md
@@ -10,7 +10,7 @@ SPDX-License-Identifier: ISC
 
 Validate `Content-Encoding` header members for common correctness issues: members must be valid `token`s, a wildcard `*` is rejected (it belongs to `Accept-Encoding`), and a coding repeated within the field is flagged.
 
-Responses that carry no content (1xx, 204, 304) are flagged for sending `Content-Encoding` at all. For 304 this follows RFC 9110 §15.4.5, which tells a sender not to include representation metadata beyond a listed set; for 1xx and 204 it is this rule's inference that a coding describing absent content is a misconfiguration.
+Responses that carry no content (1xx, 204, 304) are flagged for sending `Content-Encoding` at all, and **the two cases are reported separately** because their evidence differs in kind. A 304 answers to RFC 9110 §15.4.5, which tells a sender not to generate representation metadata beyond a listed set. A 1xx or 204 answers to nothing: no sentence says it, and §15.3.5 leans the other way — a 204's metadata "refer to the target resource and its selected representation after the requested action was applied", which makes describing a representation the client is not receiving a defensible thing to do. The inference is kept because in traffic it is far more often a proxy adding a coding header to a response it never encoded, and it is a separate violation id so that an operator who disagrees can silence it without losing the finding the document does state.
 
 Repeating a coding is likewise a judgement call rather than a conformance failure — `gzip, gzip` legitimately expresses gzip applied twice — but in practice it usually means two layers each added the header.
 
@@ -22,7 +22,8 @@ Repeating a coding is likewise a judgement call rather than a conformance failur
 
 - [RFC 9110 §8.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4): `Content-Encoding = #content-coding`, and the reservation of `identity` for Accept-Encoding — the reason it is flagged here
 - [RFC 9110 §12.5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.3): The wider Accept-Encoding grammar (`codings = content-coding / "identity" / "*"`), which is why the two headers are checked against different vocabularies
-- [RFC 9110 §15.4.5](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.5): Why a 304 should not carry Content-Encoding: a sender SHOULD NOT include representation metadata beyond the listed fields. (This reference previously pointed at §8.3, which is Content-Type, not message-body rules.) The 1xx and 204 cases have no such sentence and are inferred
+- [RFC 9110 §15.4.5](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.5): 304 Not Modified — the fields a 304 MUST send, the SHOULD NOT against any other representation metadata unless it guides cache updates, and the response being terminated by the end of the header section
+- [RFC 9110 §15.3.5](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.5): 204 No Content — the response is terminated by the end of its header section and cannot contain content, and its metadata refers to the target resource and its selected representation after the action was applied
 - [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 
 ## Configuration

--- a/lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
+++ b/lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
@@ -7,6 +7,9 @@ use crate::rules::{Rule, RuleMeta};
 use crate::violations::content_coding::{
     CONTENT_CODING_REDUNDANT, CONTENT_CODING_WILDCARD_FORBIDDEN, RFC_9110_12_5_3, RFC_9110_8_4,
 };
+use crate::violations::status::{
+    RFC_9110_15_4_5, STATUS_304_METADATA_FORBIDDEN, STATUS_METADATA_REDUNDANT,
+};
 use crate::violations::token::{
     token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN, TOKEN_EMPTY,
     TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
@@ -26,26 +29,36 @@ pub struct ContentEncodingAndTypeConsistent;
 /// code — so here the id retires a duplication the prose still carries.
 ///
 /// **Nothing this rule is named for changed.** A coding repeated, a `*` where
-/// none is defined, a member whose coding half is missing, and the field on a
-/// response with no content are all statements about what a *well-formed* list
-/// means, and they keep the rule's severity because no production is broken by
-/// any of them.
+/// none is defined and a member whose coding half is missing are all statements
+/// about what a *well-formed* list means, and they keep the rule's severity
+/// because no production is broken by any of them.
+///
+/// **The field on a response with no content is not this field's defect at
+/// all**, and it is two entries rather than one. The claim is about the status
+/// code — a coding header is unremarkable under any other one — so both live in
+/// [`status`](crate::violations::status): a 304 carrying representation metadata
+/// beyond the fields it owes, which § 15.4.5 states, and the same header on a
+/// `1xx` or `204`, which nothing states and this crate reports anyway. Splitting
+/// them is what keeps the stated finding out of the inference's reach.
 static DECLARED: &[&ViolationDef] = &[
     &TOKEN_CHARACTER_FORBIDDEN,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
     &TOKEN_EMPTY,
     &CONTENT_CODING_WILDCARD_FORBIDDEN,
     &CONTENT_CODING_REDUNDANT,
+    &STATUS_304_METADATA_FORBIDDEN,
+    &STATUS_METADATA_REDUNDANT,
 ];
 
-/// The specification references this rule declares, each named so a finding
-/// site can cite the one it enforces. `specifications()` below is built from
-/// exactly these, so the docs and the citations cannot name different text.
-const RFC_9110_15_4_5: crate::rules::SpecRef = crate::rules::SpecRef {
+/// The one sentence this rule reads that no entry of its own carries: what a
+/// `204` says its header fields are about. It is the argument *against* the
+/// inference the rule makes for a bodyless response, and it is declared so a
+/// reader of the docs can weigh the finding the way the rule's author had to.
+const RFC_9110_15_3_5: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
-    section: Some("15.4.5"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.5",
-    note: "Why a 304 should not carry Content-Encoding: a sender SHOULD NOT include representation metadata beyond the listed fields. (This reference previously pointed at §8.3, which is Content-Type, not message-body rules.) The 1xx and 204 cases have no such sentence and are inferred",
+    section: Some("15.3.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.5",
+    note: "204 No Content — the response is terminated by the end of its header section and cannot contain content, and its metadata refers to the target resource and its selected representation after the action was applied",
 };
 
 impl RuleMeta for ContentEncodingAndTypeConsistent {
@@ -60,7 +73,7 @@ severity = "warn"
     }
 
     fn description(&self) -> &'static str {
-        "Validate `Content-Encoding` header members for common correctness issues: members must be valid `token`s, a wildcard `*` is rejected (it belongs to `Accept-Encoding`), and a coding repeated within the field is flagged.\n\nResponses that carry no content (1xx, 204, 304) are flagged for sending `Content-Encoding` at all. For 304 this follows RFC 9110 §15.4.5, which tells a sender not to include representation metadata beyond a listed set; for 1xx and 204 it is this rule's inference that a coding describing absent content is a misconfiguration.\n\nRepeating a coding is likewise a judgement call rather than a conformance failure — `gzip, gzip` legitimately expresses gzip applied twice — but in practice it usually means two layers each added the header.\n\n**Note:** despite the rule's name, no `Content-Type` consistency check is performed; the rule inspects `Content-Encoding` only.\n\n**The value is read as octets and over the whole field section.** Every character of a `token` is visible US-ASCII, so an `obs-text` octet in a coding name is reported for what it is — a character the production does not admit, named as the byte it is — rather than as a verdict about the field's encoding. It used to be the second: a value the string reader refused was reported as *not valid UTF-8*, which is a claim about the whole value where the defect is one character of one member. The lines of a section are joined first, because `#content-coding` makes them one list."
+        "Validate `Content-Encoding` header members for common correctness issues: members must be valid `token`s, a wildcard `*` is rejected (it belongs to `Accept-Encoding`), and a coding repeated within the field is flagged.\n\nResponses that carry no content (1xx, 204, 304) are flagged for sending `Content-Encoding` at all, and **the two cases are reported separately** because their evidence differs in kind. A 304 answers to RFC 9110 §15.4.5, which tells a sender not to generate representation metadata beyond a listed set. A 1xx or 204 answers to nothing: no sentence says it, and §15.3.5 leans the other way — a 204's metadata \"refer to the target resource and its selected representation after the requested action was applied\", which makes describing a representation the client is not receiving a defensible thing to do. The inference is kept because in traffic it is far more often a proxy adding a coding header to a response it never encoded, and it is a separate violation id so that an operator who disagrees can silence it without losing the finding the document does state.\n\nRepeating a coding is likewise a judgement call rather than a conformance failure — `gzip, gzip` legitimately expresses gzip applied twice — but in practice it usually means two layers each added the header.\n\n**Note:** despite the rule's name, no `Content-Type` consistency check is performed; the rule inspects `Content-Encoding` only.\n\n**The value is read as octets and over the whole field section.** Every character of a `token` is visible US-ASCII, so an `obs-text` octet in a coding name is reported for what it is — a character the production does not admit, named as the byte it is — rather than as a verdict about the field's encoding. It used to be the second: a value the string reader refused was reported as *not valid UTF-8*, which is a claim about the whole value where the defect is one character of one member. The lines of a section are joined first, because `#content-coding` makes them one list."
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
@@ -68,6 +81,7 @@ severity = "warn"
             RFC_9110_8_4,
             RFC_9110_12_5_3,
             RFC_9110_15_4_5,
+            RFC_9110_15_3_5,
             RFC_9110_5_6_2,
         ]
     }
@@ -210,19 +224,38 @@ impl Rule for ContentEncodingAndTypeConsistent {
                 // 1xx and 204 are the linter's inference: those responses carry no content,
                 // so a coding describing how the content was encoded has nothing to
                 // describe. No sentence says this, and for 204 the spec arguably leans the
-                // other way — §15.3.5 has metadata "refer to the target resource and its
-                // selected representation", which would make representation metadata
-                // meaningful even with no content to send. Kept because a Content-Encoding
-                // on a bodyless response is far more often a misconfiguration than a
-                // deliberate description of a representation the client is not receiving;
-                // recorded as the possible false positive it is.
+                // other way — metadata on such a response is *meaningful*, which would make
+                // a coding header describing a representation the client is not receiving a
+                // conforming thing to send. Kept because in traffic it is far more often a
+                // misconfiguration; recorded as the possible false positive it is.
+                // cite(RFC 9110 § 15.3.5): "Metadata in the response header fields refer to the target resource and its selected representation after the requested action was applied."
+                //
+                // **The two verdicts are two entries**, because their evidence differs in
+                // kind: one quotes a SHOULD NOT and the other quotes nothing, and one id
+                // over both would put § 15.4.5 behind the inference. It also gives an
+                // operator who disagrees with the inference something to silence that does
+                // not take the stated finding with it.
                 let is_no_body_status =
                     (100..200).contains(&status) || status == 204 || status == 304;
                 if is_no_body_status && resp.headers.contains_key("content-encoding") {
-                    return Some(self.cited(&RFC_9110_15_4_5, ctx.severity, format!(
-                            "Response {} carries no content, so it should not send Content-Encoding",
-                            status
-                        )));
+                    return Some(if status == 304 {
+                        ctx.report_with(
+                            &STATUS_304_METADATA_FORBIDDEN,
+                            "304 Not Modified sends Content-Encoding, which is representation \
+                             metadata and not one of the fields the status code is required to \
+                             carry: the response exists to transfer as little as possible"
+                                .into(),
+                        )
+                    } else {
+                        ctx.report_with(
+                            &STATUS_METADATA_REDUNDANT,
+                            format!(
+                                "Response {status} is terminated by the end of its header section \
+                                 and carries no content, so the Content-Encoding beside it names a \
+                                 coding applied to nothing the client will receive"
+                            ),
+                        )
+                    });
                 }
 
                 let mut seen = std::collections::HashSet::new();
@@ -569,10 +602,21 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn response_no_body_status_with_encoding_reports_violation() -> anyhow::Result<()> {
+    /// The status code is the subject and the two verdicts are two entries: the
+    /// 304 quotes a SHOULD NOT and the other two quote nothing, so an operator
+    /// who reads the inference as a false positive can silence it and keep the
+    /// finding the document states. They rank differently for the same reason.
+    #[rstest]
+    #[case(100, "status_metadata_redundant", crate::lint::Severity::Info)]
+    #[case(204, "status_metadata_redundant", crate::lint::Severity::Info)]
+    #[case(304, "status_304_metadata_forbidden", crate::lint::Severity::Warn)]
+    fn a_bodyless_response_carrying_a_coding_answers_to_its_status(
+        #[case] status: u16,
+        #[case] violation: &str,
+        #[case] severity: crate::lint::Severity,
+    ) -> anyhow::Result<()> {
         let rule = ContentEncodingAndTypeConsistent;
-        let mut tx = crate::test_helpers::make_test_transaction_with_response(100, &[]);
+        let mut tx = crate::test_helpers::make_test_transaction_with_response(status, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-encoding", "gzip")]);
 
@@ -581,10 +625,13 @@ mod tests {
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-        );
-        assert!(v.is_some());
-        let v = v.unwrap();
-        assert!(v.message.contains("should not send Content-Encoding"));
+        )
+        .expect("a finding");
+        assert_eq!(v.violation, violation, "{status}");
+        assert_eq!(v.severity, severity, "{status}");
+        // Only the 304 names a sentence; the inference names none, which is the
+        // whole difference between the two entries.
+        assert_eq!(v.cite.is_some(), status == 304, "{status}: {}", v.message);
         Ok(())
     }
 }

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1362,7 +1362,11 @@ severity = "warn"
         /// **`authority_missing` took the last of that rule's**, and this one is
         /// the ordinary shape rather than a loss: the entry names § 4.3.1 alone,
         /// so the finding is still cited — by the def instead of by the site.
-        const FLOOR: usize = 108;
+        /// **`status_304_metadata_forbidden` took one more of the same shape**,
+        /// and the site it left held two verdicts under one citation: the 304
+        /// half still carries § 15.4.5 from its entry, and the 1xx/204 half now
+        /// carries nothing, which is what it always was.
+        const FLOOR: usize = 107;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -418,7 +418,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 193;
+        const FLOOR: usize = 194;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/status.rs
+++ b/lint-http-rules/src/violations/status.rs
@@ -98,6 +98,16 @@ pub const RFC_9113_8_6: SpecRef = SpecRef {
     note: "The Upgrade Header Field — HTTP/2 does not support the 101 status code, and says why: its semantics are not applicable to a multiplexed protocol",
 };
 
+/// What a 304 is for, the fields it owes, and the SHOULD NOT that keeps
+/// everything else off it. The goal stated in the same sentence is the reason:
+/// a response whose whole point is to transfer as little as possible.
+pub const RFC_9110_15_4_5: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.4.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.5",
+    note: "304 Not Modified — the fields a 304 MUST send, the SHOULD NOT against any other representation metadata unless it guides cache updates, and the response being terminated by the end of the header section",
+};
+
 /// HTTP/3's, which withholds the mechanism and the code in one sentence.
 pub const RFC_9114_4_5: SpecRef = SpecRef {
     spec: "RFC 9114",
@@ -286,6 +296,66 @@ defects! {
         message: "HTTP traffic after 101 Switching Protocols on the same connection; the connection should have been handed off to the upgraded protocol",
         default_severity: Severity::Warn,
         spec: &[RFC_9110_15_2_2],
+    }
+
+    /// A 304 carrying representation metadata beyond the fields it is required
+    /// to send. The status code exists to move as little as possible — the
+    /// client already holds the representation — so § 15.4.5 lists what a 304
+    /// MUST carry and asks a sender for nothing else, unless what it adds is
+    /// there to guide a cache update.
+    ///
+    /// **Read against the response alone**, which makes it the odd one in this
+    /// subject: every other entry here compares a response with the request it
+    /// answers or with an earlier message on the connection, and this one is
+    /// decided by the status code and a field beside it. The subject is still
+    /// the status — the field would be unremarkable under any other code — but
+    /// the evidence is in one message.
+    ///
+    /// `warn`, and the sentence is a SHOULD NOT: the response is readable, the
+    /// cache validation it exists for still works, and what is lost is the
+    /// economy the code was chosen for.
+    ///
+    // cite(RFC 9110 § 15.4.5): "Since the goal of a 304 response is to minimize information transfer when the recipient already has one or more cached representations, a sender SHOULD NOT generate representation metadata other than the above listed fields unless said metadata exists for the purpose of guiding cache updates (e.g., Last-Modified might be useful if the response does not have an ETag field)."
+    STATUS_304_METADATA_FORBIDDEN = {
+        id: "status_304_metadata_forbidden",
+        title: "A 304 sends representation metadata beyond the fields it owes",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_9110_15_4_5],
+    }
+
+    /// Representation metadata on a response that cannot carry content at all —
+    /// a `1xx` or a `204`, each terminated by the end of its header section.
+    /// The field describes how content was encoded, and there is no content for
+    /// it to have been applied to.
+    ///
+    /// **Uncited because no sentence asks for this, and one leans the other
+    /// way.** § 15.3.5 says of a 204 that "Metadata in the response header
+    /// fields refer to the target resource and its selected representation
+    /// after the requested action was applied" — so metadata on a bodyless
+    /// response is *meaningful*, and a server describing a representation the
+    /// client is not being sent has a reading to stand on. What keeps the entry
+    /// is frequency rather than conformance: in traffic this is a proxy or a
+    /// framework adding a coding header to a response it never encoded.
+    ///
+    /// **Which is exactly why it is not folded into
+    /// [`STATUS_304_METADATA_FORBIDDEN`].** That one quotes a SHOULD NOT and
+    /// this one quotes nothing; one id over both would put § 15.4.5 behind an
+    /// inference, and an operator who reads this entry as a false positive
+    /// could not silence it without losing the finding the document does state.
+    /// **Where the evidence differs in kind, the entry differs too, even when
+    /// the fix is the same.**
+    ///
+    /// `info`, which is what `_redundant` means: nothing here is unreadable,
+    /// nothing is prohibited, and what the finding says is that the field was
+    /// avoidable.
+    ///
+    STATUS_METADATA_REDUNDANT = {
+        id: "status_metadata_redundant",
+        title: "A response that cannot carry content sends representation metadata",
+        message: "",
+        default_severity: Severity::Info,
+        spec: &[],
     }
 }
 

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -5151,7 +5151,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
       line: 118
     - file: lint-http-rules/src/violations/status.rs
-      line: 122
+      line: 132
   - label: accept_ranges_on_partial_content
     section: § 14.2
     snippet: A server MUST ignore a Range header field received with a request method that is unrecognized or for which range handling is not defined.
@@ -5493,7 +5493,7 @@ sources:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 146
     - file: lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
-      line: 122
+      line: 136
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
       line: 135
   - label: compression_and_transfer_encoding_consistent (5)
@@ -5649,11 +5649,17 @@ sources:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
       line: 251
   - label: content_encoding_and_type_consistent
+    section: § 15.3.5
+    snippet: Metadata in the response header fields refer to the target resource and its selected representation after the requested action was applied.
+    cited_by:
+    - file: lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
+      line: 231
+  - label: content_encoding_and_type_consistent (2)
     section: § 15.4.5
     snippet: a sender SHOULD NOT generate representation metadata other than the above listed fields unless said metadata exists for the purpose of guiding cache updates
     cited_by:
     - file: lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
-      line: 208
+      line: 222
   - label: content_encoding_registered
     section: § 12.5.3
     snippet: codings = content-coding / "identity" / "*"
@@ -8733,31 +8739,37 @@ sources:
     snippet: The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field (Section 7.8), for a change in the application protocol being used on this connection.
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 282
+      line: 292
   - label: status (2)
     section: § 15.3.7.2
     snippet: A server MUST NOT generate a multipart response to a request for a single range, since a client that does not request multiple parts might not support multipart responses.
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 169
+      line: 179
   - label: status (3)
+    section: § 15.4.5
+    snippet: Since the goal of a 304 response is to minimize information transfer when the recipient already has one or more cached representations, a sender SHOULD NOT generate representation metadata other than the above listed fields unless said metadata exists for the purpose of guiding cache updates (e.g., Last-Modified might be useful if the response does not have an ETag field).
+    cited_by:
+    - file: lint-http-rules/src/violations/status.rs
+      line: 318
+  - label: status (4)
     section: § 15.5.17
     snippet: The 416 (Range Not Satisfiable) status code indicates that the set of ranges in the request's Range header field (Section 14.2) has been rejected either because none of the requested ranges are satisfiable or because the client has requested an excessive number of small or overlapping ranges (a potential denial of service attack).
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 142
-  - label: status (4)
+      line: 152
+  - label: status (5)
     section: § 7.8
     snippet: A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field.
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 246
-  - label: status (5)
+      line: 256
+  - label: status (6)
     section: § 7.8
     snippet: A server that receives an Upgrade header field in an HTTP/1.0 request MUST ignore that Upgrade field.
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 209
+      line: 219
   - label: status_101_switching_protocols
     section: § 7.8
     snippet: Although protocol names are registered with a preferred case, recipients SHOULD use case-insensitive comparison when matching each protocol-name to supported protocols.
@@ -10582,7 +10594,7 @@ sources:
     snippet: HTTP/2 does not support the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 210
+      line: 220
   - label: the TE exception
     section: § 8.2.2
     snippet: The only exception to this is the TE header field, which MAY be present in an HTTP/2 request; when it is, it MUST NOT contain any value other than "trailers".
@@ -10789,7 +10801,7 @@ sources:
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
       line: 169
     - file: lint-http-rules/src/violations/status.rs
-      line: 211
+      line: 221
   - label: lint-http-core/src/http_version.rs
     section: § 4.3.1
     snippet: HTTP/3 does not define a way to carry the version identifier that is included in the HTTP/1.1 request line.


### PR DESCRIPTION
`status_304_metadata_forbidden` and `status_metadata_redundant` join the status subject and take the one site `content_encoding_and_type_consistent` had for a coding header on a bodyless response. The claim was never the coding's — a `Content-Encoding` is unremarkable under any other status code — so both entries are the status's, which is where that family has lived since the subject existed.

Two entries for one site, because the evidence differs in kind. A 304 answers to RFC 9110 §15.4.5's SHOULD NOT against representation metadata beyond the fields it owes, and its findings cite it. A 1xx or 204 answers to nothing: no sentence says it, and §15.3.5 leans the other way, since a 204's metadata refers to the target resource and its selected representation after the action was applied. One id over both would have put §15.4.5 behind the inference.

It also gives the doubt somewhere to go. The inference is kept — in traffic this is a proxy adding a coding header to a response it never encoded — and an operator who reads it as a false positive can now silence that id without losing the finding the document states. The two rank apart for the same reason: `warn` for the sentence, `info` for the advice.

§15.3.5 joins the rule's specifications, because the argument against its own inference is a sentence the rule reads.

Floors: 194 of 200 entries cite a sentence; citation 108 → 107, the site's one citation now riding on the half of it that earned one.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
