### PR TITLE
The field a second status code owes

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1803,13 +1803,21 @@ severity = "warn"
 # A coding is applied in transit that the representation already carries
 severity = "info"
 
-[violations.upgrade_empty]
+[violations.upgrade_101_empty]
 # A 101 response names no protocol on its Upgrade field
 severity = "error"
 
-[violations.upgrade_missing]
+[violations.upgrade_101_missing]
 # A 101 response carries no Upgrade field
 severity = "error"
+
+[violations.upgrade_426_empty]
+# A 426 response names no protocol on its Upgrade field
+severity = "warn"
+
+[violations.upgrade_426_missing]
+# A 426 response carries no Upgrade field
+severity = "warn"
 
 [violations.uri_character_forbidden]
 # Value holds a character no URI is written with

--- a/docs/rules/status_426_upgrade_valid.md
+++ b/docs/rules/status_426_upgrade_valid.md
@@ -26,7 +26,7 @@ Scope: this rule reads a response's header section, and its subject is *the serv
 
 ## Specifications
 
-- [RFC 9110 §15.5.22](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.22): 426 Upgrade Required — the MUST, its object clause (to indicate the required protocol(s)), and what the status itself says the server is asking the client to do
+- [RFC 9110 §15.5.22](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.22): 426 Upgrade Required — the server refuses the request under the current protocol, and MUST send an `Upgrade` field to indicate the required protocol(s). RFC 9110 §7.8 states the same MUST from the field's side.
 - [RFC 9110 §7.8](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8): Upgrade — the same MUST from the field's side, worded with the ordering clause; also the MAY that licenses the field's absence on every other response
 - [RFC 9113 §8.2.2](https://www.rfc-editor.org/rfc/rfc9113.html#section-8.2.2): Connection-Specific Header Fields — why an HTTP/2 response is not asked for a field it must not generate
 - [RFC 9114 §4.5](https://www.rfc-editor.org/rfc/rfc9114.html#section-4.5): HTTP Upgrade — HTTP/3 does not have the mechanism this field belongs to, which is a stronger reason than the field being forbidden

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1365,8 +1365,12 @@ severity = "warn"
         /// **`status_304_metadata_forbidden` took one more of the same shape**,
         /// and the site it left held two verdicts under one citation: the 304
         /// half still carries § 15.4.5 from its entry, and the 1xx/204 half now
-        /// carries nothing, which is what it always was.
-        const FLOOR: usize = 107;
+        /// carries nothing, which is what it always was. **`upgrade_426_missing`
+        /// took the last one of this session**, and its site had cited the
+        /// *trailer* sentence rather than the requirement it reports — the entry
+        /// names § 15.5.22 and the trailer nuance stays in the message, where it
+        /// was always the aside.
+        const FLOOR: usize = 106;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/rules/status_101_switching_protocols.rs
+++ b/lint-http-rules/src/rules/status_101_switching_protocols.rs
@@ -8,7 +8,7 @@ use crate::violations::status::{
     RFC_9110_7_8, RFC_9113_8_6, RFC_9114_4_5, STATUS_101_IGNORED, STATUS_101_PROTOCOL_FORBIDDEN,
     STATUS_101_UNSOLICITED,
 };
-use crate::violations::upgrade::{RFC_9110_15_2_2, UPGRADE_EMPTY, UPGRADE_MISSING};
+use crate::violations::upgrade::{RFC_9110_15_2_2, UPGRADE_101_EMPTY, UPGRADE_101_MISSING};
 use crate::violations::ViolationDef;
 
 /// Validate 101 Switching Protocols responses follow correct upgrade semantics.
@@ -37,8 +37,8 @@ pub struct Status101SwitchingProtocols;
 /// version entry holds among them, since one entry naming three documents is
 /// what a per-version const would otherwise have split.
 static DECLARED: &[&ViolationDef] = &[
-    &UPGRADE_MISSING,
-    &UPGRADE_EMPTY,
+    &UPGRADE_101_MISSING,
+    &UPGRADE_101_EMPTY,
     &STATUS_101_UNSOLICITED,
     &STATUS_101_PROTOCOL_FORBIDDEN,
     &STATUS_101_IGNORED,
@@ -219,7 +219,7 @@ impl Rule for Status101SwitchingProtocols {
             if resp_upgrade_combined.is_none() {
                 return Some(
                     ctx.report_with(
-                        &UPGRADE_MISSING,
+                        &UPGRADE_101_MISSING,
                         "101 Switching Protocols response missing required Upgrade header \
                      (RFC 9110 §15.2.2)"
                             .into(),
@@ -259,7 +259,7 @@ impl Rule for Status101SwitchingProtocols {
             if chosen_list.is_empty() {
                 return Some(
                     ctx.report_with(
-                        &UPGRADE_EMPTY,
+                        &UPGRADE_101_EMPTY,
                         "101 Switching Protocols response Upgrade header contains no protocol \
                      tokens (RFC 9110 §15.2.2)"
                             .into(),

--- a/lint-http-rules/src/rules/status_426_upgrade_valid.rs
+++ b/lint-http-rules/src/rules/status_426_upgrade_valid.rs
@@ -5,20 +5,28 @@
 use crate::helpers::headers::{combined_field_value_as_written, trim_ows};
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::upgrade::{RFC_9110_15_5_22, UPGRADE_426_EMPTY, UPGRADE_426_MISSING};
+use crate::violations::ViolationDef;
 
 pub struct Status426UpgradeValid;
+
+/// The two halves of one MUST, and both are the *field's* defects rather than
+/// this status code's — the line [`upgrade`](crate::violations::upgrade) draws
+/// for the `101` pair beside them, on the same reasoning: the sentence is
+/// addressed to the field's presence, and the field is what an operator would
+/// look for in the message.
+///
+/// **The ids name the status code because the sentences do.** § 15.2.2 requires
+/// the field of a `101` and § 15.5.22 of a `426`, and a rule reporting either
+/// knows which it read — so each status code has its own pair, its own citation
+/// and its own rank. A `101` that omits the field has ended the conversation;
+/// this one has not, which is why these two are `warn` where those two are
+/// `error`.
+static DECLARED: &[&ViolationDef] = &[&UPGRADE_426_MISSING, &UPGRADE_426_EMPTY];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_9110_15_5_22: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("15.5.22"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.22",
-    note: "426 Upgrade Required — the MUST, its object clause (to indicate the \
-           required protocol(s)), and what the status itself says the server is \
-           asking the client to do",
-};
 const RFC_9110_7_8: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
     section: Some("7.8"),
@@ -76,6 +84,10 @@ severity = "warn"
 
     fn description(&self) -> &'static str {
         "Reports a `426 (Upgrade Required)` response that carries no `Upgrade` header field, and one whose `Upgrade` names no protocol.\n\n**The requirement is stated twice, in the two sections that own the halves of it.** RFC 9110 §15.5.22: *The server MUST send an Upgrade header field in a 426 response to indicate the required protocol(s) (Section 7.8).* And §7.8, from the field's side: *A server that sends a 426 (Upgrade Required) response MUST send an Upgrade header field to indicate the acceptable protocols, in order of descending preference.* The status itself is what makes the field load-bearing — it says the server *refuses to perform the request using the current protocol but might be willing to do so after the client upgrades to a different protocol*, so a 426 with no `Upgrade` asks for a change it does not describe.\n\n**The second finding is the clause after \"to indicate\".** `Upgrade` is `#protocol`, so `Upgrade:` is a well-formed list of no protocols and no grammar rule reports it — `upgrade_header_syntax` says so explicitly. What this rule reports is not the grammar but the purpose: on a 426 the field is sent to name what to upgrade to, and a list of none names nothing. On every other response that same value draws nothing from anybody, which is what makes this the *status's* requirement rather than the field's. (Contrast `Allow` on a 405, where §10.2.1 gives the empty value a documented meaning — *the resource allows no methods* — and `status_405_allow_valid` therefore accepts it.)\n\n**Two versions are declined, and each has its own sentence.** Over HTTP/2 an endpoint MUST NOT generate a message containing connection-specific header fields (RFC 9113 §8.2.2), and over HTTP/3 the Upgrade mechanism does not exist at all (RFC 9114 §4.5) — so on those versions this MUST cannot be obeyed, and asking for the field would be advice a server must not follow. That is the defect `sec_websocket_headers_consistent` was once reported for: a rule demanding a field on versions that forbid it. A 426 that *does* carry `Upgrade` there is reported by `no_connection_specific_fields`, with the version's own sentence, so nothing is unreported by this decline. The **response's** version decides it, not the request's: a reverse proxy may have taken the request over one version and answered from an origin speaking another, and the field would have been written in the section this response carries. The test is *not one of the two that forbid it* rather than *is this HTTP/1.x*, so a version deriving from no `HTTP-version` production is still measured.\n\n**A trailer does not answer it.** The requirement names a header field, and §6.5.1 forbids a trailer field unless the field's own definition permits one, which §7.8 does not. A 426 carrying `Upgrade` only in its trailer section is reported here as carrying none, and the finding says the trailer was seen; that the placement is itself a defect is `trailer_fields_valid`'s finding, whose §6.5.1 table names this field.\n\n**Not reported: the order.** §7.8 asks for the protocols *in order of descending preference*, which is what a sender meant by the order it wrote — no field records a preference for the order to disagree with. Nor is any name checked against the Upgrade Token Registry: §16.7's policy is First Come First Served and §7.8's *ought to be registered* is not a requirement.\n\n**What the neighbours own.** Whether the value derives from `protocol = protocol-name [\"/\" protocol-version]` is `upgrade_header_syntax`'s. Whether the field is named by an `upgrade` connection option — which §7.8 asks of every sender of `Upgrade`, including this one — is `upgrade_and_connection_consistent`'s. The mirror requirement on a `101` response, and the rule that the chosen protocol was one the client offered, is `status_101_switching_protocols`'s.\n\nScope: this rule reads a response's header section, and its subject is *the server* — whatever answered, which for a capture taken at a proxy is the party that wrote this response. Where the field appears on several lines they are one value (§5.2), and the value is read as written rather than through a UTF-8 decode, so a field carrying `obs-text` counts as a field that is there."
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
@@ -199,17 +211,16 @@ impl Rule for Status426UpgradeValid {
                     .as_ref()
                     .is_some_and(|trailers| trailers.contains_key("upgrade"));
 
-                return Some(self.cited(&RFC_9110_6_5_1,
-                    ctx.severity,
+                return Some(ctx.report_with(
+                    &UPGRADE_426_MISSING,
                     format!(
                         "426 Upgrade Required with no Upgrade header field. The status says the server \
                          refuses the request under the current protocol but might comply after the \
                          client upgrades, and the field is what names the protocol to upgrade *to*; \
-                         without it the response asks for a change it does not describe (RFC 9110 \
-                         §15.5.22){}",
+                         without it the response asks for a change it does not describe{}",
                         if in_trailer_section {
                             ". This response's trailer section carries an Upgrade, and a trailer field \
-                             does not answer a requirement on the header section"
+                             does not answer a requirement on the header section (RFC 9110 §6.5.1)"
                         } else {
                             ""
                         }
@@ -232,12 +243,13 @@ impl Rule for Status426UpgradeValid {
             // cite(RFC 9110 § 15.5.22): "The 426 (Upgrade Required) status code indicates that the server refuses to perform the request using the current protocol but might be willing to do so after the client upgrades to a different protocol."
             // cite(RFC 9110 § 5.5): "A field value does not include leading or trailing whitespace.  When a specific version of HTTP allows such whitespace to appear in a message, a field parsing implementation MUST exclude such whitespace prior to evaluating the field value."
             if trim_ows(&value).is_empty() {
-                return Some(self.violation(
-                    ctx.severity,
+                return Some(ctx.report_with(
+                    &UPGRADE_426_EMPTY,
                     "426 Upgrade Required whose Upgrade header field names no protocol. The field is \
                      `#protocol`, so an empty value is a well-formed list of none — but the requirement \
                      is to send the field *to indicate the required protocol(s)*, and a client reading \
-                     this response has nothing to upgrade to (RFC 9110 §15.5.22, §7.8)"
+                     this response has nothing to upgrade to (RFC 9110 §7.8 states the same MUST from \
+                     the field's side)"
                         .to_string(),
                 ));
             }

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -418,7 +418,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 194;
+        const FLOOR: usize = 196;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/status.rs
+++ b/lint-http-rules/src/violations/status.rs
@@ -39,7 +39,7 @@
 //! the client never named is not a status code describing an exchange wrongly —
 //! it is a connection that has *left HTTP* for something the client cannot
 //! speak. There is no later message to repair it in, which is the argument
-//! `upgrade_missing` and `upgrade_empty` already make for `error`.
+//! `upgrade_101_missing` and `upgrade_101_empty` already make for `error`.
 //!
 //! **The sixth is read out of a third message**, and it is the widest this
 //! subject goes: a `101` announces that the connection has stopped speaking
@@ -249,7 +249,7 @@ defects! {
     /// everything after the response's empty line is spoken in the new protocol,
     /// so a client that never named it has nothing to say and nothing to wait
     /// for. That is the same argument
-    /// [`upgrade_missing`](crate::violations::upgrade::UPGRADE_MISSING) makes,
+    /// [`upgrade_101_missing`](crate::violations::upgrade::UPGRADE_101_MISSING) makes,
     /// and it is what separates this entry from the four `warn`s beside it,
     /// where the exchange survives the defect.
     ///

--- a/lint-http-rules/src/violations/upgrade.rs
+++ b/lint-http-rules/src/violations/upgrade.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: ISC
 
-//! `Upgrade` defects — the field a `101` owes, and what is on it.
+//! `Upgrade` defects — the field two status codes owe, and what is on it.
 //!
 //! A `101 (Switching Protocols)` is a connection changing hands: everything
 //! after the response's empty line is spoken in another protocol. The status
@@ -10,6 +10,13 @@
 //! is why RFC 9110 § 15.2.2 requires the field of the response rather than
 //! merely recommending it — a client that has stopped speaking HTTP and does
 //! not know what it is now speaking has no way to continue and no way to ask.
+//!
+//! A `426 (Upgrade Required)` is the same field asked for by the opposite
+//! event: the server refuses the request *under the current protocol* and the
+//! field names what it would accept instead. § 15.5.22 states that MUST from
+//! the status's side and § 7.8 from the field's, in the same words either way —
+//! sent *to indicate* the protocols — so a 426 with no field, or with a field
+//! naming nothing, asks for a change it does not describe.
 //!
 //! **The subject is the field even though the requirement is written into a
 //! status code's section**, which is the line `content_range` draws for the
@@ -19,9 +26,18 @@
 //! upgrade mechanism, that it may not switch to something nobody offered —
 //! belongs to [`status`](crate::violations::status).
 //!
-//! Both entries are `error`, and it is the same argument in two halves: the
-//! response has already ended the HTTP conversation, so there is no later
-//! message in which the omission can be repaired.
+//! **Four entries: the same two defects under each of the two status codes**,
+//! and the ids say which because the conditions and the sentences both differ.
+//! An entry naming § 15.2.2 and § 15.5.22 together would give up the citation
+//! its findings can carry — 2 sites out of 2 know which status they read — and
+//! it would flatten a difference in rank that is real.
+//!
+//! **The rank is where the two codes part.** A `101` has already ended the HTTP
+//! conversation, so there is no later message in which the omission can be
+//! repaired: both of its entries are `error`. A `426` is an ordinary response a
+//! client can read; what it loses is the advice, and the request can be made
+//! again. Both of those are `warn`. **Ask whether the exchange can continue**,
+//! which is the same question `status`'s entries are ranked by.
 
 use crate::lint::Severity;
 use crate::rules::SpecRef;
@@ -39,14 +55,26 @@ pub const RFC_9110_15_2_2: SpecRef = SpecRef {
     note: "101 Switching Protocols — the status code is a change in the application protocol being used on this connection, and the response MUST generate an `Upgrade` field naming the protocol(s) in effect after it",
 };
 
+/// The 426's section: what the status code refuses, and the MUST that the
+/// response name what it would accept. The field's own section states the same
+/// requirement — § 7.8, worded with the ordering clause — and a requirement
+/// written twice in one document is quoted once, at the sentence that also
+/// carries the condition.
+pub const RFC_9110_15_5_22: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.5.22"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.22",
+    note: "426 Upgrade Required — the server refuses the request under the current protocol, and MUST send an `Upgrade` field to indicate the required protocol(s). RFC 9110 §7.8 states the same MUST from the field's side.",
+};
+
 defects! {
     /// A `101` response with no `Upgrade` field on it at all. The connection
     /// has changed protocol and the message that changed it does not say to
     /// what.
     ///
     // cite(RFC 9110 § 15.2.2): "The server MUST generate an Upgrade header field in the response that indicates which protocol(s) will be in effect after this response."
-    UPGRADE_MISSING = {
-        id: "upgrade_missing",
+    UPGRADE_101_MISSING = {
+        id: "upgrade_101_missing",
         title: "A 101 response carries no Upgrade field",
         message: "",
         default_severity: Severity::Error,
@@ -64,12 +92,58 @@ defects! {
     /// the two rank the same.
     ///
     // cite(RFC 9110 § 15.2.2): "The server MUST generate an Upgrade header field in the response that indicates which protocol(s) will be in effect after this response."
-    UPGRADE_EMPTY = {
-        id: "upgrade_empty",
+    UPGRADE_101_EMPTY = {
+        id: "upgrade_101_empty",
         title: "A 101 response names no protocol on its Upgrade field",
         message: "",
         default_severity: Severity::Error,
         spec: &[RFC_9110_15_2_2],
+    }
+
+    /// A `426` response with no `Upgrade` field on it at all. The status code
+    /// says the server refuses the request under the current protocol but might
+    /// comply after the client upgrades, and the field is what names the
+    /// protocol to upgrade *to* — so without it the response asks for a change
+    /// it does not describe.
+    ///
+    /// **A trailer does not answer it**, and the site that reports this says so
+    /// when it finds one: the requirement names a header field, and § 6.5.1
+    /// forbids a trailer field unless the field's own definition permits it,
+    /// which § 7.8 does not. That the placement is itself a defect is
+    /// `trailer_fields_valid`'s finding rather than this entry's.
+    ///
+    /// `warn`, where the `101` pair is `error`: this response is ordinary HTTP a
+    /// client can read to the end, and what it loses is the advice — the request
+    /// can be made again over a protocol the client guesses at or gives up on.
+    /// The conversation continues, badly.
+    ///
+    // cite(RFC 9110 § 15.5.22): "The server MUST send an Upgrade header field in a 426 response to indicate the required protocol(s) (Section 7.8)."
+    UPGRADE_426_MISSING = {
+        id: "upgrade_426_missing",
+        title: "A 426 response carries no Upgrade field",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_9110_15_5_22],
+    }
+
+    /// The field written on a `426`, and no protocol name on it. `Upgrade` is
+    /// `#protocol`, so a value of none is a well-formed list and no grammar rule
+    /// has anything to say — what is broken is the clause after *to indicate*,
+    /// which is why this is the status's requirement and not the field's
+    /// syntax. On any other response the same value is nobody's finding.
+    ///
+    /// Separated from the absent field for the reason the `101` pair is: a field
+    /// that is not there is a server that never learned the requirement, and
+    /// `Upgrade:` with nothing after it is a server that built the value from a
+    /// list and found the list empty.
+    ///
+    // cite(RFC 9110 § 15.5.22): "The server MUST send an Upgrade header field in a 426 response to indicate the required protocol(s) (Section 7.8)."
+    UPGRADE_426_EMPTY = {
+        id: "upgrade_426_empty",
+        title: "A 426 response names no protocol on its Upgrade field",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_9110_15_5_22],
     }
 }
 
@@ -78,13 +152,32 @@ mod tests {
     use super::*;
 
     /// The pair `docs/development.md` keeps apart everywhere: never written
-    /// against written blank. They rank together because the *recipient* is in
-    /// the same position for both — the conversation has already left HTTP.
+    /// against written blank. Each status code's two rank together, because the
+    /// *recipient* is in the same position for both halves of either pair.
     #[test]
     fn the_absent_field_and_the_blank_one_are_two_ids_of_one_rank() {
-        assert_eq!(UPGRADE_MISSING.id, "upgrade_missing");
-        assert_eq!(UPGRADE_EMPTY.id, "upgrade_empty");
-        assert_eq!(UPGRADE_MISSING.default_severity, Severity::Error);
-        assert_eq!(UPGRADE_EMPTY.default_severity, Severity::Error);
+        assert_eq!(UPGRADE_101_MISSING.id, "upgrade_101_missing");
+        assert_eq!(UPGRADE_101_EMPTY.id, "upgrade_101_empty");
+        assert_eq!(UPGRADE_101_MISSING.default_severity, Severity::Error);
+        assert_eq!(UPGRADE_101_EMPTY.default_severity, Severity::Error);
+        assert_eq!(UPGRADE_426_MISSING.id, "upgrade_426_missing");
+        assert_eq!(UPGRADE_426_EMPTY.id, "upgrade_426_empty");
+        assert_eq!(UPGRADE_426_MISSING.default_severity, Severity::Warn);
+        assert_eq!(UPGRADE_426_EMPTY.default_severity, Severity::Warn);
+    }
+
+    /// The id names the status code because the sentence requiring the field
+    /// does: one entry over both codes would name two sections and carry
+    /// neither onto a finding, and every site here knows which status it read.
+    /// The ranks differ for a reason no shared entry could hold — a `101` has
+    /// left HTTP and a `426` has not.
+    #[test]
+    fn each_status_codes_pair_names_its_own_sentence() {
+        assert_eq!(UPGRADE_101_MISSING.spec, [RFC_9110_15_2_2]);
+        assert_eq!(UPGRADE_426_MISSING.spec, [RFC_9110_15_5_22]);
+        assert_ne!(
+            UPGRADE_101_MISSING.default_severity,
+            UPGRADE_426_MISSING.default_severity
+        );
     }
 }

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -6775,7 +6775,7 @@ sources:
     - file: lint-http-rules/src/rules/proxy_connection_discouraged.rs
       line: 134
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
-      line: 184
+      line: 196
     - file: lint-http-rules/src/rules/status_code_semantics.rs
       line: 21
     - file: lint-http-rules/src/rules/te_header_valid.rs
@@ -7015,7 +7015,7 @@ sources:
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
       line: 240
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
-      line: 196
+      line: 208
     - file: lint-http-rules/src/rules/trailer_fields_valid.rs
       line: 141
     - file: lint-http-rules/src/rules/trailer_fields_valid.rs
@@ -7341,7 +7341,7 @@ sources:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 289
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
-      line: 233
+      line: 244
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 99
     - file: lint-http-rules/src/rules/upgrade_header_syntax.rs
@@ -8885,19 +8885,23 @@ sources:
     snippet: The 426 (Upgrade Required) status code indicates that the server refuses to perform the request using the current protocol but might be willing to do so after the client upgrades to a different protocol.
     cited_by:
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
-      line: 232
+      line: 243
   - label: status_426_upgrade_valid (2)
     section: § 15.5.22
     snippet: The server MUST send an Upgrade header field in a 426 response to indicate the required protocol(s) (Section 7.8).
     cited_by:
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
-      line: 125
+      line: 137
+    - file: lint-http-rules/src/violations/upgrade.rs
+      line: 120
+    - file: lint-http-rules/src/violations/upgrade.rs
+      line: 140
   - label: status_426_upgrade_valid (3)
     section: § 7.8
     snippet: A server MAY send an Upgrade header field in any other response to advertise that it implements support for upgrading to the listed protocols, in order of descending preference, when appropriate for a future request.
     cited_by:
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
-      line: 145
+      line: 157
     - file: lint-http-rules/src/rules/upgrade_header_syntax.rs
       line: 375
   - label: status_426_upgrade_valid (4)
@@ -8905,7 +8909,7 @@ sources:
     snippet: A server that sends a 426 (Upgrade Required) response MUST send an Upgrade header field to indicate the acceptable protocols, in order of descending preference.
     cited_by:
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
-      line: 231
+      line: 242
   - label: status_and_caching_semantics
     section: § 15.1
     snippet: Responses with status codes that are defined as heuristically cacheable (e.g., 200, 203, 204, 206, 300, 301, 308, 404, 405, 410, 414, and 501 in this specification) can be reused by a cache with heuristic expiration unless otherwise indicated by the method definition or explicit cache controls
@@ -9161,9 +9165,9 @@ sources:
     snippet: The server MUST generate an Upgrade header field in the response that indicates which protocol(s) will be in effect after this response.
     cited_by:
     - file: lint-http-rules/src/violations/upgrade.rs
-      line: 47
+      line: 75
     - file: lint-http-rules/src/violations/upgrade.rs
-      line: 66
+      line: 94
   - label: upgrade_and_connection_consistent
     section: § 7.6.1
     snippet: In contrast, a connection-specific field received without a corresponding connection option usually indicates that the field has been improperly forwarded by an intermediary and ought to be ignored by the recipient.
@@ -10550,7 +10554,7 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 375
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
-      line: 168
+      line: 180
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 215
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
@@ -10799,7 +10803,7 @@ sources:
     - file: lint-http-rules/src/rules/http3_status_code_valid.rs
       line: 125
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
-      line: 169
+      line: 181
     - file: lint-http-rules/src/violations/status.rs
       line: 221
   - label: lint-http-core/src/http_version.rs


### PR DESCRIPTION
`upgrade_426_missing` and `upgrade_426_empty` join the Upgrade subject and take `status_426_upgrade_valid`'s two sites: a 426 carrying no field, and one whose field names no protocol. Both are the field's defects even though the sentence requiring them is written into a status code's section — the reading the 101 pair beside them already made, on the same ground: the sentence is addressed to the field's presence, and the field is what an operator looks for in the message.

Four entries where there were two, and the ids now name their status code. The requirement is written once per code — §15.2.2 for a 101, §15.5.22 for a 426 — and a rule reporting either knows which it read, so folding them would give up a citation both halves can carry. It would also flatten a difference in rank that is real: a 101 with no Upgrade has ended the HTTP conversation and nothing later repairs it, while a 426 is an ordinary response a client reads to the end and is merely left with advice it cannot act on. `error` and `warn` respectively, which is what both rules had already chosen for themselves.

§7.8 states the same MUST from the field's side, in the same document. A requirement written twice in one document is quoted once, at the sentence that also carries the condition, and the sibling is named in the message and in the rule's specifications.

The missing-field site had cited §6.5.1 — the sentence about trailers, which is the aside its message ends with rather than the requirement it reports. The entry names the requirement and the aside stays in the message.

Floors: 196 of 202 entries cite a sentence; citation 107 → 106.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
