### PR TITLE
What is wrong before the method is read

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1671,8 +1671,20 @@ severity = "warn"
 # The asterisk target is sent with a method other than OPTIONS
 severity = "error"
 
+[violations.request_target_empty]
+# A request-line carries no request-target
+severity = "error"
+
+[violations.request_target_malformed]
+# A request-target derives from none of the four forms
+severity = "error"
+
 [violations.request_target_path_missing]
 # A request that owes a path names none
+severity = "error"
+
+[violations.request_target_whitespace_forbidden]
+# A request-target carries whitespace
 severity = "error"
 
 [violations.status_101_ignored]

--- a/docs/rules/request_target_form_valid.md
+++ b/docs/rules/request_target_form_valid.md
@@ -29,11 +29,11 @@ Reads an HTTP/1.x request-line's request-target and asks two things: which of th
 
 ## Specifications
 
-- [RFC 9112 §3.2](https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2): Request Target: the four forms, and the exclusion of whitespace from all of them
+- [RFC 9112 §3.2](https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2): Request Target — `request-target = origin-form / absolute-form / authority-form / asterisk-form`, no whitespace allowed in any of them, the recipient's SHOULD to answer 400 rather than autocorrect, and why: a request-line like that might be crafted to bypass a filter along the chain
 - [RFC 9112 §3.2.3](https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2.3): authority-form: CONNECT's target, and where the port number is asked for in prose rather than in the grammar
 - [RFC 9112 §3.2.4](https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2.4): asterisk-form: the server-wide OPTIONS request's target
 - [RFC 9110 §7.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.1): Determining the Target Resource — the two method-specific forms, the MUST NOT that keeps each to its method, and the reconstruction being specific to each major protocol version
-- [RFC 9110 §2.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2): The sender's MUST NOT against generating protocol elements outside the ABNF, which is what makes a target in none of the four forms a violation
+- [RFC 9110 §2.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2): Conformance — a sender MUST NOT generate protocol elements that do not match the grammar defined by the corresponding ABNF rules
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/request_target_form_valid.rs
+++ b/lint-http-rules/src/rules/request_target_form_valid.rs
@@ -4,7 +4,10 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
-use crate::violations::request_target::{REQUEST_TARGET_ASTERISK_FORBIDDEN, RFC_9110_7_1};
+use crate::violations::request_target::{
+    REQUEST_TARGET_ASTERISK_FORBIDDEN, REQUEST_TARGET_EMPTY, REQUEST_TARGET_MALFORMED,
+    REQUEST_TARGET_WHITESPACE_FORBIDDEN, RFC_9110_2_2, RFC_9110_7_1, RFC_9112_3_2,
+};
 use crate::violations::ViolationDef;
 
 /// The one finding of this rule the catalogue names: the asterisk sent with a
@@ -13,11 +16,22 @@ use crate::violations::ViolationDef;
 /// and HTTP/3 pseudo-header rules declare the same entry for the same defect
 /// spelled as a `:path`.
 ///
+/// **Three more are the target's own**, and all three are an HTTP/1.x
+/// request-line's alone: whitespace where no form admits any, a target of no
+/// characters, and a target deriving from none of the four. Over the multiplexed
+/// versions a capture holds the URI the transport reassembled, so none of them
+/// has evidence to be read from there — which is why these three entries have
+/// one declarer where the asterisk has three.
+///
 /// The rest of what this rule reports is about the request-*line* — a target
-/// deriving from none of the four forms, from two of them at once, a CONNECT
-/// with half an authority, whitespace where the production admits none — and
+/// deriving from two forms at once, a CONNECT with half an authority — and
 /// each of those is a reading of its own.
-static DECLARED: &[&ViolationDef] = &[&REQUEST_TARGET_ASTERISK_FORBIDDEN];
+static DECLARED: &[&ViolationDef] = &[
+    &REQUEST_TARGET_ASTERISK_FORBIDDEN,
+    &REQUEST_TARGET_WHITESPACE_FORBIDDEN,
+    &REQUEST_TARGET_EMPTY,
+    &REQUEST_TARGET_MALFORMED,
+];
 
 /// Which of the four productions a request-target derives from.
 ///
@@ -131,12 +145,6 @@ pub struct RequestTargetFormValid;
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_9112_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9112",
-    section: Some("3.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2",
-    note: "Request Target: the four forms, and the exclusion of whitespace from all of them",
-};
 const RFC_9112_3_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9112",
     section: Some("3.2.3"),
@@ -148,12 +156,6 @@ const RFC_9112_3_2_4: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("3.2.4"),
     url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2.4",
     note: "asterisk-form: the server-wide OPTIONS request's target",
-};
-const RFC_9110_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("2.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
-    note: "The sender's MUST NOT against generating protocol elements outside the ABNF, which is what makes a target in none of the four forms a violation",
 };
 
 impl RuleMeta for RequestTargetFormValid {
@@ -281,9 +283,8 @@ impl Rule for RequestTargetFormValid {
             // cite(RFC 9112 § 3.2): "A recipient SHOULD NOT attempt to autocorrect and then process the request without a redirect, since the invalid request-line might be deliberately crafted to bypass security filters along the request chain."
             // cite(RFC 9110 § 2.2): "A sender MUST NOT generate protocol elements that do not match the grammar defined by the corresponding ABNF rules."
             if let Some(ws) = target.chars().find(|c| c.is_ascii_whitespace()) {
-                let severity = ctx.severity;
-                return Some(self.violation(
-                    severity,
+                return Some(ctx.report_with(
+                    &REQUEST_TARGET_WHITESPACE_FORBIDDEN,
                     format!(
                         "Request-target '{shown}' contains '{}', and no whitespace is allowed in a request-target -- nor a CR, LF or FF, which no component of any of the four forms admits. The request-line carrying it is malformed, and a recipient is asked not to autocorrect it, since a request-line like this one might be deliberately crafted to bypass a security filter along the request chain",
                         crate::helpers::shown::shown_in_finding(&ws.to_string())
@@ -297,9 +298,8 @@ impl Rule for RequestTargetFormValid {
             // cite(RFC 9110 § 2.2): "A sender MUST NOT generate protocol elements that do not match the grammar defined by the corresponding ABNF rules."
             // cite(RFC 9112 § 3.2): "Recipients of an invalid request-line SHOULD respond with either a 400 (Bad Request) error or a 301 (Moved Permanently) redirect with the request-target properly encoded."
             if target.is_empty() {
-                let severity = ctx.severity;
-                return Some(self.violation(
-                    severity,
+                return Some(ctx.report_with(
+                    &REQUEST_TARGET_EMPTY,
                     "Request carries an empty request-target. Every one of the four forms derives at least one character -- an absolute path opens with '/', an absolute-URI has a scheme and its colon, a host and port has the colon between them, and the asterisk is itself -- so the empty string is none of them and the request-line naming it is invalid".into(),
                 ));
             }
@@ -349,7 +349,7 @@ impl Rule for RequestTargetFormValid {
                     ),
                 ),
                 (None, "CONNECT") => (
-                    None,
+                    Some(&REQUEST_TARGET_MALFORMED),
                     format!(
                         "CONNECT request-target '{shown}' derives from none of the four forms, and a CONNECT sends only the host and port of the tunnel destination, separated by a colon. A recipient has nowhere to open the tunnel to"
                     ),
@@ -415,7 +415,7 @@ impl Rule for RequestTargetFormValid {
                 // cite(RFC 9110 § 2.2): "A sender MUST NOT generate protocol elements that do not match the grammar defined by the corresponding ABNF rules."
                 // cite(RFC 9112 § 3.2): "Recipients of an invalid request-line SHOULD respond with either a 400 (Bad Request) error or a 301 (Moved Permanently) redirect with the request-target properly encoded."
                 (None, _) => (
-                    None,
+                    Some(&REQUEST_TARGET_MALFORMED),
                     format!(
                         "Request-target '{shown}' derives from none of the four forms: it is not an absolute path, not a full target URI with a scheme, not a host and port, and not the asterisk. The request-line carrying it is invalid, and a recipient is asked to answer 400 (Bad Request) rather than guess which was meant"
                     ),

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -418,7 +418,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 196;
+        const FLOOR: usize = 199;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/request_target.rs
+++ b/lint-http-rules/src/violations/request_target.rs
@@ -28,6 +28,13 @@
 //! once for every version (§ 7.1) and sometimes once per version, and where it
 //! is the latter the entry names them all and no finding carries one.
 //!
+//! **Three of the entries below are an HTTP/1.x request-line's alone**, and the
+//! reason is the spelling rather than the element: whitespace inside the target,
+//! a target of no characters and a target deriving from none of the four forms
+//! are all visible where the sender wrote the element out between two spaces.
+//! Over the multiplexed versions a capture holds the URI the transport
+//! reassembled, so none of the three has evidence to be read from.
+//!
 //! What the *components* of a target are made of is not here: a scheme that is
 //! not a scheme name, an authority that is not a host and port, a percent
 //! triplet that does not derive are [`uri`](crate::violations::uri)'s, on every
@@ -38,6 +45,29 @@ use crate::lint::Severity;
 use crate::rules::SpecRef;
 use crate::violations::authority::{RFC_9113_8_3_1, RFC_9114_4_3_1};
 use crate::violations::defects;
+
+/// Where HTTP/1.1 writes the element out: the four forms as one production, the
+/// sentence excluding whitespace from all of them, and what a recipient of an
+/// invalid request-line is asked to answer. The three entries below that are
+/// read out of an HTTP/1.x request-line name it; the two above are about the
+/// element whichever way it arrived.
+pub const RFC_9112_3_2: SpecRef = SpecRef {
+    spec: "RFC 9112",
+    section: Some("3.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2",
+    note: "Request Target — `request-target = origin-form / absolute-form / authority-form / asterisk-form`, no whitespace allowed in any of them, the recipient's SHOULD to answer 400 rather than autocorrect, and why: a request-line like that might be crafted to bypass a filter along the chain",
+};
+
+/// The sentence that makes a value outside its ABNF a violation rather than an
+/// observation. Two entries here need it because the request-target's own
+/// production says what the four forms are and says nothing about a value that
+/// is none of them.
+pub const RFC_9110_2_2: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
+    note: "Conformance — a sender MUST NOT generate protocol elements that do not match the grammar defined by the corresponding ABNF rules",
+};
 
 /// Where the four forms are named, what each is for, and the one MUST NOT that
 /// keeps the two method-specific ones to their methods. Shared by the three
@@ -110,6 +140,79 @@ defects! {
         message: "",
         default_severity: Severity::Error,
         spec: &[RFC_9113_8_3_1, RFC_9114_4_3_1],
+    }
+
+    /// Whitespace inside a request-target: a SP or HTAB, or a CR, LF or FF. The
+    /// sentence excluding it is written of the target as a whole rather than of
+    /// any component, and it is written because senders do it — the paragraph
+    /// carrying it says so, and follows with the reason a recipient is asked not
+    /// to tidy it up: a request-line like that one may have been crafted to get
+    /// two recipients on a chain to read two different requests out of it.
+    ///
+    /// **Only an HTTP/1.x request has this defect to have.** The element arrives
+    /// as a request-line there, with SP delimiting the three parts of it, so a
+    /// space inside the target is a boundary in the wrong place; over HTTP/2 and
+    /// HTTP/3 the transport carries the components separately and a capture holds
+    /// what it reassembled. The octet inside a target is a different question
+    /// again, asked on every version by
+    /// `request_uri_percent_encoding_valid` against the alphabet a URI is
+    /// written from.
+    ///
+    /// `error`, which is what the rule reporting it had already chosen: a
+    /// recipient asked not to guess has nothing left to do but refuse the
+    /// request.
+    ///
+    // cite(RFC 9112 § 3.2): "No whitespace is allowed in the request-target."
+    REQUEST_TARGET_WHITESPACE_FORBIDDEN = {
+        id: "request_target_whitespace_forbidden",
+        title: "A request-target carries whitespace",
+        message: "",
+        default_severity: Severity::Error,
+        spec: &[RFC_9112_3_2],
+    }
+
+    /// A request-line whose target is the empty string. Every one of the four
+    /// forms derives at least one character — an absolute path opens with `/`, an
+    /// absolute-URI has a scheme and its colon, a host and port has the colon
+    /// between them, and the asterisk is itself — so nothing was written where
+    /// the element goes.
+    ///
+    /// Separate from [`REQUEST_TARGET_MALFORMED`] the way the vocabulary
+    /// separates them everywhere: this sender wrote nothing and that one wrote
+    /// something no form generates, and the two are different mistakes to make
+    /// even though a recipient refuses both. **The pseudo-header versions have no
+    /// such split** — there an absent `:path` and a blank one reassemble into one
+    /// target, which is why [`REQUEST_TARGET_PATH_MISSING`] is one entry — and
+    /// the difference is the request-line, where what the sender wrote is on the
+    /// wire.
+    ///
+    // cite(RFC 9110 § 2.2): "A sender MUST NOT generate protocol elements that do not match the grammar defined by the corresponding ABNF rules."
+    REQUEST_TARGET_EMPTY = {
+        id: "request_target_empty",
+        title: "A request-line carries no request-target",
+        message: "",
+        default_severity: Severity::Error,
+        spec: &[RFC_9110_2_2],
+    }
+
+    /// A request-target that derives from none of the four forms. The four are
+    /// alternatives of one production and alternation is not exclusive, so a
+    /// value derives from at least one of them or from none — and "none" is not
+    /// an odd target to be lenient about, it is a request-line whose recipient is
+    /// asked to answer 400 rather than guess which form was meant.
+    ///
+    /// **The entry is the target's and not the method's**, though the rule
+    /// reporting it words the finding differently for a CONNECT: a method that
+    /// requires one particular form has more to say about a value in none of
+    /// them, and none of that changes what is wrong with the value.
+    ///
+    // cite(RFC 9110 § 2.2): "A sender MUST NOT generate protocol elements that do not match the grammar defined by the corresponding ABNF rules."
+    REQUEST_TARGET_MALFORMED = {
+        id: "request_target_malformed",
+        title: "A request-target derives from none of the four forms",
+        message: "",
+        default_severity: Severity::Error,
+        spec: &[RFC_9110_2_2],
     }
 }
 

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1470,7 +1470,7 @@ sources:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 394
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 105
+      line: 119
   - label: lint-http-rules/src/helpers/uri.rs (26)
     section: § 4.2
     snippet: A relative reference that begins with two slash characters is termed a network-path reference; such references are rarely used.
@@ -1490,7 +1490,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 282
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 79
+      line: 93
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 206
   - label: lint-http-rules/src/helpers/uri.rs (27)
@@ -5055,7 +5055,7 @@ sources:
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
       line: 377
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 258
+      line: 260
     - file: lint-http-rules/src/rules/request_version_method_valid.rs
       line: 167
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
@@ -5277,9 +5277,9 @@ sources:
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
       line: 353
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 282
+      line: 284
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 297
+      line: 298
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 415
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
@@ -5290,6 +5290,10 @@ sources:
       line: 179
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
       line: 398
+    - file: lint-http-rules/src/violations/request_target.rs
+      line: 189
+    - file: lint-http-rules/src/violations/request_target.rs
+      line: 209
   - label: Allow grammar, sender-expanded
     section: § A
     snippet: Allow = [ method *( OWS "," OWS method ) ]
@@ -6435,7 +6439,7 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 86
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 242
+      line: 244
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 201
   - label: lint-http-core/src/http_version.rs (3)
@@ -8531,13 +8535,13 @@ sources:
     snippet: For OPTIONS (Section 9.3.7), the request target can be a single asterisk ("*").
     cited_by:
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 72
+      line: 102
   - label: absolute-path
     section: § 4.1
     snippet: absolute-path = 1*( "/" segment )
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 97
+      line: 111
   - label: request_target_form_valid
     section: § 7.1
     snippet: For CONNECT (Section 9.3.6), the request target is the host name and port number of the tunnel destination, separated by a colon.
@@ -8549,7 +8553,7 @@ sources:
     snippet: For historical reasons, the parsed target URI components, collectively referred to as the "request target", are sent within the message control data and the Host header field
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 243
+      line: 245
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 151
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
@@ -8567,13 +8571,13 @@ sources:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 313
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 73
+      line: 103
   - label: request_target_form_valid (5)
     section: § 7.1
     snippet: This reconstruction is specific to each major protocol version.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 244
+      line: 246
   - label: request_target_no_fragment
     section: § 4.2.5
     snippet: Some protocol elements that refer to a URI allow inclusion of a fragment, while others do not.
@@ -9927,7 +9931,7 @@ sources:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 117
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 78
+      line: 92
   - label: http_version_syntax
     section: § 1.1
     snippet: Conformance criteria and considerations regarding error handling are defined in Section 2 of [HTTP].
@@ -9969,7 +9973,7 @@ sources:
     - file: lint-http-core/src/http_version.rs
       line: 103
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 246
+      line: 248
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 202
   - label: lint-http-core/src/http_version.rs
@@ -9989,7 +9993,7 @@ sources:
     - file: lint-http-rules/src/rules/http_version_syntax.rs
       line: 162
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 245
+      line: 247
   - label: HTTP-name
     section: § A
     snippet: HTTP-name = %x48.54.54.50 ; HTTP
@@ -10023,7 +10027,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 619
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 27
+      line: 41
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
       line: 289
   - label: lint-http-rules/src/helpers/uri.rs (2)
@@ -10141,19 +10145,21 @@ sources:
     snippet: A recipient SHOULD NOT attempt to autocorrect and then process the request without a redirect, since the invalid request-line might be deliberately crafted to bypass security filters along the request chain.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 281
+      line: 283
   - label: request_target_form_valid (2)
     section: § 3.2
     snippet: No whitespace is allowed in the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 279
+      line: 281
+    - file: lint-http-rules/src/violations/request_target.rs
+      line: 165
   - label: request_target_form_valid (3)
     section: § 3.2
     snippet: Recipients of an invalid request-line SHOULD respond with either a 400 (Bad Request) error or a 301 (Moved Permanently) redirect with the request-target properly encoded.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 298
+      line: 299
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 416
   - label: request_target_form_valid (4)
@@ -10161,7 +10167,7 @@ sources:
     snippet: Unfortunately, some user agents fail to properly encode or exclude whitespace found in hypertext references, resulting in those disallowed characters being sent as the request-target in a malformed request-line.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 280
+      line: 282
   - label: request_target_form_valid (5)
     section: § 3.2.1
     snippet: When making a request directly to an origin server, other than a CONNECT or server-wide OPTIONS request (as detailed below), a client MUST send only the absolute path and query components of the target URI as the request-target.
@@ -10173,7 +10179,7 @@ sources:
     snippet: origin-form    = absolute-path [ "?" query ]
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 76
+      line: 90
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 208
   - label: request_target_form_valid (6)
@@ -10193,7 +10199,7 @@ sources:
     snippet: absolute-form  = absolute-URI
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 77
+      line: 91
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 207
   - label: request_target_form_valid (8)
@@ -10239,7 +10245,7 @@ sources:
     snippet: asterisk-form = "*" authority = <authority, see [URI], Section 3.2>
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 85
+      line: 99
   - label: response_body_length_accuracy
     section: § 6.3
     snippet: A client MUST ignore any Content-Length or Transfer-Encoding header fields received in such a message.
@@ -10406,7 +10412,7 @@ sources:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 496
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 247
+      line: 249
   - label: host_and_authority_consistent (2)
     section: § 8.3.1
     snippet: A server SHOULD treat a request as malformed if it contains a Host header field that identifies an entity that differs from the entity in the ":authority" pseudo-header field.
@@ -10582,13 +10588,13 @@ sources:
     snippet: All HTTP/2 requests MUST include exactly one valid value for the ":method", ":scheme", and ":path" pseudo-header fields, unless they are CONNECT requests (Section 8.5).
     cited_by:
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 105
+      line: 135
   - label: request_target_form_valid
     section: § 8.3.1
     snippet: Note that request targets for CONNECT or asterisk-form OPTIONS requests never include authority information
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 248
+      line: 250
   - label: request_target_no_fragment
     section: § 8.3.1
     snippet: The ":path" pseudo-header field includes the path and query parts of the target URI
@@ -10927,13 +10933,13 @@ sources:
     snippet: This pseudo-header field MUST NOT be empty for "http" or "https" URIs; "http" or "https" URIs that do not contain a path component MUST include a value of / (ASCII 0x2f).
     cited_by:
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 106
+      line: 136
   - label: request_target_form_valid
     section: § 4.3.1
     snippet: An OPTIONS request that does not include a path component includes the value * (ASCII 0x2a) for the :path pseudo-header field
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 249
+      line: 251
   - label: request_target_no_fragment
     section: § 4.3.1
     snippet: Contains the path and query parts of the target URI


### PR DESCRIPTION
`request_target_whitespace_forbidden`, `request_target_empty` and `request_target_malformed` join the request-target subject and take the four sites `request_target_form_valid` had for a value judged before any method is: whitespace where no form admits any, a target of no characters, and a target deriving from none of the four forms.

All three are an HTTP/1.x request-line's alone, where the asterisk beside them is declared by three rules. The element is version-independent and its spelling is not: the sender writes the target out between two spaces there, so a space inside it, an empty one and one that is no form are all visible — while over HTTP/2 and HTTP/3 a capture holds the URI the transport reassembled and none of the three has evidence to be read from. One declarer is what an entry has when the defect needs the spelling.

`_empty` and `_malformed` are two entries here where the pseudo-header versions needed one. Over those an absent `:path` and a blank one come back as the same target, which is what made `request_target_path_missing` a single entry named from the recipient's side; on a request-line what the sender wrote is on the wire, so the vocabulary's split does the work it is for.

The whitespace entry is the target's whole and not any component's: the sentence excluding it is written of the request-target, and the octet *inside* a target is `request_uri_percent_encoding_valid`'s question against the alphabet a URI is written from, on every version.

Floor: 199 of 205 entries cite a sentence.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
