### PR TITLE
The other form a method may not use

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1671,6 +1671,10 @@ severity = "warn"
 # The asterisk target is sent with a method other than OPTIONS
 severity = "error"
 
+[violations.request_target_authority_form_forbidden]
+# The host-and-port target is sent with a method other than CONNECT
+severity = "error"
+
 [violations.request_target_empty]
 # A request-line carries no request-target
 severity = "error"

--- a/lint-http-rules/src/rules/request_target_form_valid.rs
+++ b/lint-http-rules/src/rules/request_target_form_valid.rs
@@ -5,8 +5,9 @@
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
 use crate::violations::request_target::{
-    REQUEST_TARGET_ASTERISK_FORBIDDEN, REQUEST_TARGET_EMPTY, REQUEST_TARGET_MALFORMED,
-    REQUEST_TARGET_WHITESPACE_FORBIDDEN, RFC_9110_2_2, RFC_9110_7_1, RFC_9112_3_2,
+    REQUEST_TARGET_ASTERISK_FORBIDDEN, REQUEST_TARGET_AUTHORITY_FORM_FORBIDDEN,
+    REQUEST_TARGET_EMPTY, REQUEST_TARGET_MALFORMED, REQUEST_TARGET_WHITESPACE_FORBIDDEN,
+    RFC_9110_2_2, RFC_9110_7_1, RFC_9112_3_2,
 };
 use crate::violations::ViolationDef;
 
@@ -15,6 +16,11 @@ use crate::violations::ViolationDef;
 /// method-specific form and is stated once for every version of HTTP. The HTTP/2
 /// and HTTP/3 pseudo-header rules declare the same entry for the same defect
 /// spelled as a `:path`.
+///
+/// **The other half of that same MUST NOT is the second**: a host and port sent
+/// with a method that is not CONNECT, which only a request-line can show — the
+/// multiplexed versions reassemble an authority into the target without saying
+/// where the client wrote it.
 ///
 /// **Three more are the target's own**, and all three are an HTTP/1.x
 /// request-line's alone: whitespace where no form admits any, a target of no
@@ -31,6 +37,7 @@ static DECLARED: &[&ViolationDef] = &[
     &REQUEST_TARGET_WHITESPACE_FORBIDDEN,
     &REQUEST_TARGET_EMPTY,
     &REQUEST_TARGET_MALFORMED,
+    &REQUEST_TARGET_AUTHORITY_FORM_FORBIDDEN,
 ];
 
 /// Which of the four productions a request-target derives from.
@@ -389,7 +396,7 @@ impl Rule for RequestTargetFormValid {
                 // port and nothing else -- and it is CONNECT's.
                 // cite(RFC 9112 § 3.2.3): "The "authority-form" of request-target is only used for CONNECT requests"
                 (Some(TargetForm::Authority { .. }), m) => (
-                    None,
+                    Some(&REQUEST_TARGET_AUTHORITY_FORM_FORBIDDEN),
                     format!(
                         "Authority-form request-target '{shown}' was sent with method '{m}'. The host-and-port form is a CONNECT's request target and no other method's, and the two method-specific forms must not be used with other methods"
                     ),
@@ -439,6 +446,33 @@ static REGISTRATION: &dyn crate::rules::Rule = &RequestTargetFormValid;
 mod tests {
     use super::*;
     use rstest::rstest;
+
+    /// The two halves of one sentence are two ids: an operator who accepts
+    /// `GET example.com:443` from some client has no reason to accept `GET *`
+    /// with it, and a capture shows which of the two arrived.
+    #[rstest]
+    #[case("GET", "192.0.2.1:443", "request_target_authority_form_forbidden")]
+    #[case("GET", ":80", "request_target_authority_form_forbidden")]
+    #[case("GET", "*", "request_target_asterisk_forbidden")]
+    fn the_two_method_specific_forms_are_two_entries(
+        #[case] method: &str,
+        #[case] target: &str,
+        #[case] violation: &str,
+    ) {
+        let rule = RequestTargetFormValid;
+        let mut tx = crate::test_helpers::make_test_transaction();
+        tx.request.method = method.into();
+        tx.request.uri = target.into();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_severity(rule.id(), "error"),
+        )
+        .expect("a finding");
+        assert_eq!(v.violation, violation, "{method} {target}");
+        assert!(v.cite.is_some(), "{}", v.message);
+    }
 
     fn judge(method: &str, uri: &str, version: &str) -> Option<String> {
         let rule = RequestTargetFormValid;
@@ -512,7 +546,9 @@ mod tests {
     #[case("GET", "tel:8005551212", "derives from two of the four forms")]
     #[case("GET", "urn:123", "derives from two of the four forms")]
     // No `scheme` opens with a digit or a bracket, so these derive from the
-    // host-and-port form alone and the finding can say so outright.
+    // host-and-port form alone and the finding can say so outright. They answer
+    // to the *other* half of § 7.1's MUST NOT — the entry the asterisk's sibling
+    // in the catalogue, and the id an operator silences separately from it.
     #[case("GET", "192.0.2.1:443", "host-and-port form is a CONNECT's")]
     #[case("GET", "[2001:db8::1]:443", "host-and-port form is a CONNECT's")]
     // `uri-host` derives the empty string, so this is an authority-form with no

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -418,7 +418,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 199;
+        const FLOOR: usize = 200;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/request_target.rs
+++ b/lint-http-rules/src/violations/request_target.rs
@@ -10,7 +10,9 @@
 //! names its target in control data, and RFC 9110 § 7.1 is where what that
 //! naming may be is written. Two of the four forms are *method-specific* — the
 //! host and port a CONNECT tunnels to, and the asterisk a server-wide OPTIONS
-//! asks about — and the section closes them both with one MUST NOT.
+//! asks about — and the section closes them both with one MUST NOT. **That one
+//! sentence is two entries here**, because the two senders wrote different
+//! mistakes and an operator silencing one has no reason to silence the other.
 //!
 //! **What makes this a subject rather than a drawer is that the element is
 //! version-independent while its spelling is not.** Over HTTP/1.x the target is
@@ -104,6 +106,40 @@ defects! {
     REQUEST_TARGET_ASTERISK_FORBIDDEN = {
         id: "request_target_asterisk_forbidden",
         title: "The asterisk target is sent with a method other than OPTIONS",
+        message: "",
+        default_severity: Severity::Error,
+        spec: &[RFC_9110_7_1],
+    }
+
+    /// A request whose target is a host and port — the authority-form — on a
+    /// method other than `CONNECT`. That form names a tunnel destination and not
+    /// a resource, so a `GET example.com:443` asks for nothing a server could
+    /// apply the method to, and a recipient reading it as an origin-form path
+    /// would route the request somewhere the client never named.
+    ///
+    /// **§ 7.1's MUST NOT closes both method-specific forms in one sentence**,
+    /// and this is its other half:
+    /// [`REQUEST_TARGET_ASTERISK_FORBIDDEN`] is the asterisk sent with a method
+    /// that is not `OPTIONS`, and this is the host-and-port sent with a method
+    /// that is not `CONNECT`. Two entries rather than one, because the fix
+    /// differs — one sender wrote the wrong method, the other wrote a target for
+    /// a tunnel it did not ask for — and because an operator silencing one has
+    /// no reason to silence the other.
+    ///
+    /// **One declarer, unlike its sibling.** The asterisk survives reassembly as
+    /// a `:path` of `*` and is reported on every version; a host and port does
+    /// not, because a capture of an HTTP/2 or HTTP/3 request holds a URI built
+    /// from `:scheme`, `:authority` and `:path`, and nothing in it says the
+    /// client wrote the authority where a path goes.
+    ///
+    /// `error`, with the rest of this subject: the request names no resource and
+    /// two recipients on one chain may disagree about what it named.
+    ///
+    // cite(RFC 9110 § 7.1): "For CONNECT (Section 9.3.6), the request target is the host name and port number of the tunnel destination, separated by a colon."
+    // cite(RFC 9110 § 7.1): "These forms MUST NOT be used with other methods."
+    REQUEST_TARGET_AUTHORITY_FORM_FORBIDDEN = {
+        id: "request_target_authority_form_forbidden",
+        title: "The host-and-port target is sent with a method other than CONNECT",
         message: "",
         default_severity: Severity::Error,
         spec: &[RFC_9110_7_1],

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1470,7 +1470,7 @@ sources:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 394
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 119
+      line: 126
   - label: lint-http-rules/src/helpers/uri.rs (26)
     section: § 4.2
     snippet: A relative reference that begins with two slash characters is termed a network-path reference; such references are rarely used.
@@ -1490,7 +1490,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 282
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 93
+      line: 100
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 206
   - label: lint-http-rules/src/helpers/uri.rs (27)
@@ -5055,7 +5055,7 @@ sources:
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
       line: 377
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 260
+      line: 267
     - file: lint-http-rules/src/rules/request_version_method_valid.rs
       line: 167
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
@@ -5277,11 +5277,11 @@ sources:
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
       line: 353
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 284
+      line: 291
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 298
+      line: 305
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 415
+      line: 422
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 221
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
@@ -5291,9 +5291,9 @@ sources:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
       line: 398
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 189
+      line: 225
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 209
+      line: 245
   - label: Allow grammar, sender-expanded
     section: § A
     snippet: Allow = [ method *( OWS "," OWS method ) ]
@@ -6439,7 +6439,7 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 86
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 244
+      line: 251
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 201
   - label: lint-http-core/src/http_version.rs (3)
@@ -8535,25 +8535,27 @@ sources:
     snippet: For OPTIONS (Section 9.3.7), the request target can be a single asterisk ("*").
     cited_by:
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 102
+      line: 104
   - label: absolute-path
     section: § 4.1
     snippet: absolute-path = 1*( "/" segment )
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 111
+      line: 118
   - label: request_target_form_valid
     section: § 7.1
     snippet: For CONNECT (Section 9.3.6), the request target is the host name and port number of the tunnel destination, separated by a colon.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 324
+      line: 331
+    - file: lint-http-rules/src/violations/request_target.rs
+      line: 138
   - label: request_target_form_valid (2)
     section: § 7.1
     snippet: For historical reasons, the parsed target URI components, collectively referred to as the "request target", are sent within the message control data and the Host header field
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 245
+      line: 252
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 151
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
@@ -8563,21 +8565,23 @@ sources:
     snippet: There are two unusual cases for which the request target components are in a method-specific form
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 312
+      line: 319
   - label: request_target_form_valid (4)
     section: § 7.1
     snippet: These forms MUST NOT be used with other methods.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 313
+      line: 320
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 103
+      line: 105
+    - file: lint-http-rules/src/violations/request_target.rs
+      line: 139
   - label: request_target_form_valid (5)
     section: § 7.1
     snippet: This reconstruction is specific to each major protocol version.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 246
+      line: 253
   - label: request_target_no_fragment
     section: § 4.2.5
     snippet: Some protocol elements that refer to a URI allow inclusion of a fragment, while others do not.
@@ -9931,7 +9935,7 @@ sources:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 117
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 92
+      line: 99
   - label: http_version_syntax
     section: § 1.1
     snippet: Conformance criteria and considerations regarding error handling are defined in Section 2 of [HTTP].
@@ -9973,7 +9977,7 @@ sources:
     - file: lint-http-core/src/http_version.rs
       line: 103
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 248
+      line: 255
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 202
   - label: lint-http-core/src/http_version.rs
@@ -9993,7 +9997,7 @@ sources:
     - file: lint-http-rules/src/rules/http_version_syntax.rs
       line: 162
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 247
+      line: 254
   - label: HTTP-name
     section: § A
     snippet: HTTP-name = %x48.54.54.50 ; HTTP
@@ -10027,7 +10031,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 619
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 41
+      line: 48
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
       line: 289
   - label: lint-http-rules/src/helpers/uri.rs (2)
@@ -10145,41 +10149,41 @@ sources:
     snippet: A recipient SHOULD NOT attempt to autocorrect and then process the request without a redirect, since the invalid request-line might be deliberately crafted to bypass security filters along the request chain.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 283
+      line: 290
   - label: request_target_form_valid (2)
     section: § 3.2
     snippet: No whitespace is allowed in the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 281
+      line: 288
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 165
+      line: 201
   - label: request_target_form_valid (3)
     section: § 3.2
     snippet: Recipients of an invalid request-line SHOULD respond with either a 400 (Bad Request) error or a 301 (Moved Permanently) redirect with the request-target properly encoded.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 299
+      line: 306
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 416
+      line: 423
   - label: request_target_form_valid (4)
     section: § 3.2
     snippet: Unfortunately, some user agents fail to properly encode or exclude whitespace found in hypertext references, resulting in those disallowed characters being sent as the request-target in a malformed request-line.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 282
+      line: 289
   - label: request_target_form_valid (5)
     section: § 3.2.1
     snippet: When making a request directly to an origin server, other than a CONNECT or server-wide OPTIONS request (as detailed below), a client MUST send only the absolute path and query components of the target URI as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 407
+      line: 414
   - label: origin-form
     section: § 3.2.1
     snippet: origin-form    = absolute-path [ "?" query ]
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 90
+      line: 97
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 208
   - label: request_target_form_valid (6)
@@ -10187,19 +10191,19 @@ sources:
     snippet: A server MUST accept the absolute-form in requests even though most HTTP/1.1 clients will only send the absolute-form to a proxy.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 409
+      line: 416
   - label: request_target_form_valid (7)
     section: § 3.2.2
     snippet: When making a request to a proxy, other than a CONNECT or server-wide OPTIONS request (as detailed below), a client MUST send the target URI in "absolute-form" as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 408
+      line: 415
   - label: absolute-form
     section: § 3.2.2
     snippet: absolute-form  = absolute-URI
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 91
+      line: 98
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 207
   - label: request_target_form_valid (8)
@@ -10207,45 +10211,45 @@ sources:
     snippet: It consists of only the uri-host and port number of the tunnel destination, separated by a colon (":").
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 325
+      line: 332
   - label: request_target_form_valid (9)
     section: § 3.2.3
     snippet: The "authority-form" of request-target is only used for CONNECT requests
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 374
+      line: 381
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 390
+      line: 397
   - label: request_target_form_valid (10)
     section: § 3.2.3
     snippet: The client obtains the host and port from the target URI's authority component, except that it sends the scheme's default port if the target URI elides the port.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 336
+      line: 343
   - label: request_target_form_valid (11)
     section: § 3.2.3
     snippet: When making a CONNECT request to establish a tunnel through one or more proxies, a client MUST send only the host and port of the tunnel destination as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 326
+      line: 333
   - label: request_target_form_valid (12)
     section: § 3.2.4
     snippet: The "asterisk-form" of request-target is only used for a server-wide OPTIONS request
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 361
+      line: 368
   - label: request_target_form_valid (13)
     section: § 3.2.4
     snippet: When a client wishes to request OPTIONS for the server as a whole, as opposed to a specific named resource of that server, the client MUST send only "*" (%x2A) as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 362
+      line: 369
   - label: asterisk-form
     section: § A
     snippet: asterisk-form = "*" authority = <authority, see [URI], Section 3.2>
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 99
+      line: 106
   - label: response_body_length_accuracy
     section: § 6.3
     snippet: A client MUST ignore any Content-Length or Transfer-Encoding header fields received in such a message.
@@ -10412,7 +10416,7 @@ sources:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 496
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 249
+      line: 256
   - label: host_and_authority_consistent (2)
     section: § 8.3.1
     snippet: A server SHOULD treat a request as malformed if it contains a Host header field that identifies an entity that differs from the entity in the ":authority" pseudo-header field.
@@ -10588,13 +10592,13 @@ sources:
     snippet: All HTTP/2 requests MUST include exactly one valid value for the ":method", ":scheme", and ":path" pseudo-header fields, unless they are CONNECT requests (Section 8.5).
     cited_by:
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 135
+      line: 171
   - label: request_target_form_valid
     section: § 8.3.1
     snippet: Note that request targets for CONNECT or asterisk-form OPTIONS requests never include authority information
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 250
+      line: 257
   - label: request_target_no_fragment
     section: § 8.3.1
     snippet: The ":path" pseudo-header field includes the path and query parts of the target URI
@@ -10933,13 +10937,13 @@ sources:
     snippet: This pseudo-header field MUST NOT be empty for "http" or "https" URIs; "http" or "https" URIs that do not contain a path component MUST include a value of / (ASCII 0x2f).
     cited_by:
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 136
+      line: 172
   - label: request_target_form_valid
     section: § 4.3.1
     snippet: An OPTIONS request that does not include a path component includes the value * (ASCII 0x2a) for the :path pseudo-header field
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 251
+      line: 258
   - label: request_target_no_fragment
     section: § 4.3.1
     snippet: Contains the path and query parts of the target URI


### PR DESCRIPTION
`request_target_authority_form_forbidden` joins the request-target subject and takes `request_target_form_valid`'s site for a host and port sent with a method that is not CONNECT. It is the other half of the sentence the asterisk entry beside it already carries: §7.1 names the two method-specific forms and closes both with one MUST NOT.

Two entries for one sentence, because the two senders wrote different mistakes. One asked a server-wide question with a method that has none to ask; this one handed a resource-fetching method the address of a tunnel, and a recipient reading it as a path routes the request somewhere the client never named. An operator who tolerates one from some client has no reason to tolerate the other, which is what an id is for.

One declarer where the asterisk has three. A `:path` of `*` survives reassembly and is reported on every version; an authority written where a path goes does not, because a capture of an HTTP/2 or HTTP/3 request holds a URI built from the three pseudo-headers and nothing in it says which one the client wrote the authority into.

Floor: 200 of 206 entries cite a sentence.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
