### PR TITLE
A tunnel destination missing a half

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1079,8 +1079,20 @@ severity = "error"
 # A request that owes an authority names none
 severity = "error"
 
+[violations.authority_tunnel_host_empty]
+# A CONNECT's destination names a port and no host
+severity = "error"
+
 [violations.authority_tunnel_missing]
 # A CONNECT names no host and port to open a tunnel to
+severity = "error"
+
+[violations.authority_tunnel_port_empty]
+# A CONNECT's destination ends at the colon with no port
+severity = "error"
+
+[violations.authority_tunnel_port_missing]
+# A CONNECT's destination names no port
 severity = "error"
 
 [violations.authority_tunnel_userinfo_forbidden]

--- a/docs/rules/request_target_form_valid.md
+++ b/docs/rules/request_target_form_valid.md
@@ -34,6 +34,7 @@ Reads an HTTP/1.x request-line's request-target and asks two things: which of th
 - [RFC 9112 §3.2.4](https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2.4): asterisk-form: the server-wide OPTIONS request's target
 - [RFC 9110 §7.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.1): Determining the Target Resource — the two method-specific forms, the MUST NOT that keeps each to its method, and the reconstruction being specific to each major protocol version
 - [RFC 9110 §2.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2): Conformance — a sender MUST NOT generate protocol elements that do not match the grammar defined by the corresponding ABNF rules
+- [RFC 9110 §9.3.6](https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.6): CONNECT — the host and port number of the tunnel destination, the absence of a default port, and the server's MUST to reject an empty or invalid one. This is where the port requirements come from; the grammar states none.
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
+++ b/lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
@@ -5,8 +5,10 @@
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
 use crate::violations::authority::{
-    AUTHORITY_TUNNEL_MISSING, AUTHORITY_TUNNEL_USERINFO_FORBIDDEN, AUTHORITY_USERINFO_FORBIDDEN,
-    RFC_9110_9_3_6, RFC_9113_8_3_1, RFC_9113_8_5, RFC_9114_4_3_1, RFC_9114_4_4,
+    AUTHORITY_TUNNEL_HOST_EMPTY, AUTHORITY_TUNNEL_MISSING, AUTHORITY_TUNNEL_PORT_EMPTY,
+    AUTHORITY_TUNNEL_PORT_MISSING, AUTHORITY_TUNNEL_USERINFO_FORBIDDEN,
+    AUTHORITY_USERINFO_FORBIDDEN, RFC_9110_9_3_6, RFC_9113_8_3_1, RFC_9113_8_5, RFC_9114_4_3_1,
+    RFC_9114_4_4,
 };
 use crate::violations::request_target::{
     REQUEST_TARGET_ASTERISK_FORBIDDEN, REQUEST_TARGET_PATH_MISSING, RFC_9110_7_1,
@@ -66,17 +68,21 @@ static DECLARED: &[&ViolationDef] = &[
     &REQUEST_TARGET_PATH_MISSING,
     &AUTHORITY_TUNNEL_MISSING,
     &URI_HOST_EMPTY,
+    &AUTHORITY_TUNNEL_PORT_MISSING,
+    &AUTHORITY_TUNNEL_PORT_EMPTY,
+    &AUTHORITY_TUNNEL_HOST_EMPTY,
 ];
 
 /// One finding from the CONNECT reading, and the defect it reports as where
 /// the catalogue names that defect.
 ///
 /// The shape `expect_header_valid` settled: a judge that is half converted says
-/// so in its type. Here the named half is the authority's grammar and the
-/// userinfo the tunnel form has no room for; the unnamed half is what § 9.3.6
-/// says a CONNECT's authority must *hold* — a port that is present, not empty
-/// and inside the transport's namespace, with a host beside it — which is prose
-/// about this method's target rather than a production's defect.
+/// so in its type — and this one is nearly whole. Named: the authority's
+/// grammar, the userinfo the tunnel form has no room for, and the three ways
+/// `uri-host ":" port` derives a value with one of its two components missing.
+/// Unnamed: a port number outside the transport's namespace, whose sentence is
+/// not § 9.3.6's at all but RFC 6335's sixteen bits, reached through the one
+/// sentence that says a proxy opens a *TCP* connection.
 struct Defect {
     def: Option<&'static ViolationDef>,
     message: String,
@@ -157,18 +163,28 @@ fn connect_authority_finding(authority: &str) -> Option<Defect> {
     // is required outright; the host is what "the host and port number of the
     // tunnel destination" leaves nothing of if it is absent.
     match port {
-        None => Some(Defect::unnamed(format!(
-            "CONNECT ':authority' '{shown}' names no port, and a CONNECT has no default port: a \
-             client sends the port number even when the URI reference it started from elided one"
-        ))),
-        Some("") => Some(Defect::unnamed(format!(
-            "CONNECT ':authority' '{shown}' ends at the colon with no port number, which a server \
-             is required to reject"
-        ))),
-        Some(port) if host.is_empty() => Some(Defect::unnamed(format!(
-            "CONNECT ':authority' '{shown}' names the port '{port}' and no host, so it names \
-             nothing to open a tunnel to"
-        ))),
+        None => Some(Defect::named(
+            &AUTHORITY_TUNNEL_PORT_MISSING,
+            format!(
+                "CONNECT ':authority' '{shown}' names no port, and a CONNECT has no default port: \
+                 a client sends the port number even when the URI reference it started from \
+                 elided one"
+            ),
+        )),
+        Some("") => Some(Defect::named(
+            &AUTHORITY_TUNNEL_PORT_EMPTY,
+            format!(
+                "CONNECT ':authority' '{shown}' ends at the colon with no port number, which a \
+                 server is required to reject"
+            ),
+        )),
+        Some(port) if host.is_empty() => Some(Defect::named(
+            &AUTHORITY_TUNNEL_HOST_EMPTY,
+            format!(
+                "CONNECT ':authority' '{shown}' names the port '{port}' and no host, so it names \
+                 nothing to open a tunnel to"
+            ),
+        )),
         Some(port) => connect_port_range_finding(port).map(|msg| {
             Defect::unnamed(format!(
                 "CONNECT ':authority' '{shown}' targets an invalid port number: {msg}"
@@ -896,6 +912,33 @@ mod tests {
     #[case("example.com:0")]
     fn a_basic_connect_names_a_host_and_a_port(#[case] target: &str) {
         assert_eq!(judge_request("CONNECT", target), None, "{target}");
+    }
+
+    /// The same three ids the HTTP/1.x rule reports for a request-target with
+    /// half an authority: `uri-host ":" port` derives all of these, and the
+    /// prose in § 9.3.6 is what refuses them.
+    #[rstest]
+    #[case("example.com", "authority_tunnel_port_missing")]
+    #[case("example.com:", "authority_tunnel_port_empty")]
+    #[case(":443", "authority_tunnel_host_empty")]
+    fn a_connect_authority_with_one_component_answers_to_the_destinations_ids(
+        #[case] target: &str,
+        #[case] violation: &str,
+    ) {
+        let mut tx = h2();
+        tx.request.method = "CONNECT".into();
+        tx.request.uri = target.into();
+        let v = crate::test_helpers::run_rule(
+            &Http2PseudoHeadersValid,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "http2_pseudo_headers_valid",
+            ]),
+        )
+        .expect("reported");
+        assert_eq!(v.violation, violation, "{target}");
+        assert!(v.cite.is_some(), "{}", v.message);
     }
 
     #[rstest]

--- a/lint-http-rules/src/rules/request_target_form_valid.rs
+++ b/lint-http-rules/src/rules/request_target_form_valid.rs
@@ -4,6 +4,9 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::authority::{
+    AUTHORITY_TUNNEL_HOST_EMPTY, AUTHORITY_TUNNEL_PORT_EMPTY, RFC_9110_9_3_6,
+};
 use crate::violations::request_target::{
     REQUEST_TARGET_ASTERISK_FORBIDDEN, REQUEST_TARGET_AUTHORITY_FORM_FORBIDDEN,
     REQUEST_TARGET_EMPTY, REQUEST_TARGET_MALFORMED, REQUEST_TARGET_WHITESPACE_FORBIDDEN,
@@ -16,6 +19,13 @@ use crate::violations::ViolationDef;
 /// method-specific form and is stated once for every version of HTTP. The HTTP/2
 /// and HTTP/3 pseudo-header rules declare the same entry for the same defect
 /// spelled as a `:path`.
+///
+/// **Two of what it reports are not the target's at all**: a CONNECT naming a
+/// port and no host, and one ending at the colon with no port, are the tunnel
+/// destination's halves — the same two defects the HTTP/2 rule reads out of an
+/// `:authority`, under the same ids and RFC 9110 § 9.3.6's sentences. The
+/// element is spelled differently on the two versions and the requirement is
+/// not, which is [`authority`](crate::violations::authority)'s to hold.
 ///
 /// **The other half of that same MUST NOT is the second**: a host and port sent
 /// with a method that is not CONNECT, which only a request-line can show — the
@@ -38,6 +48,8 @@ static DECLARED: &[&ViolationDef] = &[
     &REQUEST_TARGET_EMPTY,
     &REQUEST_TARGET_MALFORMED,
     &REQUEST_TARGET_AUTHORITY_FORM_FORBIDDEN,
+    &AUTHORITY_TUNNEL_HOST_EMPTY,
+    &AUTHORITY_TUNNEL_PORT_EMPTY,
 ];
 
 /// Which of the four productions a request-target derives from.
@@ -187,6 +199,10 @@ severity = "error"
             RFC_9112_3_2_4,
             RFC_9110_7_1,
             RFC_9110_2_2,
+            // Where the two components a CONNECT names are required, once for
+            // every version: the entries this rule borrows for a target with
+            // half an authority carry its sentences, so the docs name it here.
+            RFC_9110_9_3_6,
         ]
     }
 
@@ -332,7 +348,7 @@ impl Rule for RequestTargetFormValid {
                 // cite(RFC 9112 § 3.2.3): "It consists of only the uri-host and port number of the tunnel destination, separated by a colon (":")."
                 // cite(RFC 9112 § 3.2.3): "When making a CONNECT request to establish a tunnel through one or more proxies, a client MUST send only the host and port of the tunnel destination as the request-target."
                 (Some(TargetForm::Authority { host: "", .. }), "CONNECT") => (
-                    None,
+                    Some(&AUTHORITY_TUNNEL_HOST_EMPTY),
                     format!(
                         "CONNECT request-target '{shown}' names no host. `uri-host` derives the empty string -- `reg-name` is `*( unreserved / pct-encoded / sub-delims )` -- so the grammar admits this, and the tunnel destination is a host name and a port number, of which a recipient here has at most one"
                     ),
@@ -342,7 +358,7 @@ impl Rule for RequestTargetFormValid {
                 // client does when the target URI has no port to copy.
                 // cite(RFC 9112 § 3.2.3): "The client obtains the host and port from the target URI's authority component, except that it sends the scheme's default port if the target URI elides the port."
                 (Some(TargetForm::Authority { port: "", .. }), "CONNECT") => (
-                    None,
+                    Some(&AUTHORITY_TUNNEL_PORT_EMPTY),
                     format!(
                         "CONNECT request-target '{shown}' carries the port's delimiter and no port. `port` is `*DIGIT`, so the grammar admits this, and a client with no port to copy sends the scheme's default one -- a recipient reading this has a host and no number to open the tunnel on"
                     ),
@@ -446,6 +462,33 @@ static REGISTRATION: &dyn crate::rules::Rule = &RequestTargetFormValid;
 mod tests {
     use super::*;
     use rstest::rstest;
+
+    /// A CONNECT with half an authority answers to the tunnel destination's ids,
+    /// which the HTTP/2 rule reports for the same two shapes out of an
+    /// `:authority` — the element is spelled differently on the two versions and
+    /// § 9.3.6's sentences are not.
+    #[rstest]
+    #[case(":80", "authority_tunnel_host_empty")]
+    #[case(":", "authority_tunnel_host_empty")]
+    #[case("example.com:", "authority_tunnel_port_empty")]
+    fn a_connect_with_half_an_authority_answers_to_the_destinations_ids(
+        #[case] target: &str,
+        #[case] violation: &str,
+    ) {
+        let rule = RequestTargetFormValid;
+        let mut tx = crate::test_helpers::make_test_transaction();
+        tx.request.method = "CONNECT".into();
+        tx.request.uri = target.into();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_severity(rule.id(), "error"),
+        )
+        .expect("a finding");
+        assert_eq!(v.violation, violation, "{target}");
+        assert!(v.cite.is_some(), "{}", v.message);
+    }
 
     /// The two halves of one sentence are two ids: an operator who accepts
     /// `GET example.com:443` from some client has no reason to accept `GET *`

--- a/lint-http-rules/src/violations/authority.rs
+++ b/lint-http-rules/src/violations/authority.rs
@@ -15,8 +15,11 @@
 //!
 //! What is left, and what this subject holds, is what the two documents say
 //! about the field *beyond* the syntax: components the field may not carry, and
-//! the halves a CONNECT owes. Those are prose requirements about a field, which
-//! is what makes the field the subject.
+//! the halves a CONNECT owes — three of the entries below are exactly those
+//! halves, and all three are `uri-host ":" port` deriving something the prose
+//! then refuses, since both halves of that production are `*`-quantified. Those
+//! are prose requirements about a field, which is what makes the field the
+//! subject.
 //!
 //! **The first entry is the shape the `spec` slice was made for.** RFC 9113
 //! § 8.3.1 and RFC 9114 § 4.3.1 forbid the same subcomponent in the same field
@@ -180,6 +183,69 @@ defects! {
     AUTHORITY_TUNNEL_USERINFO_FORBIDDEN = {
         id: "authority_tunnel_userinfo_forbidden",
         title: "A CONNECT's :authority carries a userinfo subcomponent",
+        message: "",
+        default_severity: Severity::Error,
+        spec: &[RFC_9110_9_3_6],
+    }
+
+    /// A CONNECT whose destination names a port and no host — `:443`, or the
+    /// colon alone. `uri-host` derives the empty string, so the grammar admits
+    /// it and the prose is what does not: the target is *the host name and port
+    /// number* of the tunnel destination, and a recipient with only the number
+    /// has nothing to open a connection to.
+    ///
+    /// `_empty` rather than `_missing`, and the delimiter is what decides it: the
+    /// colon says the sender knew the component was there and wrote nothing in
+    /// it. [`AUTHORITY_TUNNEL_PORT_MISSING`] is the same line drawn on the other
+    /// component, where a value with no colon at all names no port to be empty.
+    ///
+    // cite(RFC 9110 § 9.3.6): "CONNECT uses a special form of request target, unique to this method, consisting of only the host and port number of the tunnel destination, separated by a colon."
+    AUTHORITY_TUNNEL_HOST_EMPTY = {
+        id: "authority_tunnel_host_empty",
+        title: "A CONNECT's destination names a port and no host",
+        message: "",
+        default_severity: Severity::Error,
+        spec: &[RFC_9110_9_3_6],
+    }
+
+    /// A CONNECT whose destination carries the port's delimiter and no digits
+    /// after it — `example.com:`. `port` is `*DIGIT`, so this derives too, and
+    /// again the prose is the requirement: there is no default port for this
+    /// method, and a server is told to reject a request targeting an empty one.
+    ///
+    /// **The sentence naming the empty port is the server's**, and it is why
+    /// this is worth reporting at all rather than treating the colon as a typo:
+    /// a recipient is required to answer 400 to it, so a client that sends it
+    /// gets no tunnel and no useful diagnosis.
+    ///
+    // cite(RFC 9110 § 9.3.6): "A server MUST reject a CONNECT request that targets an empty or invalid port number, typically by responding with a 400 (Bad Request) status code."
+    AUTHORITY_TUNNEL_PORT_EMPTY = {
+        id: "authority_tunnel_port_empty",
+        title: "A CONNECT's destination ends at the colon with no port",
+        message: "",
+        default_severity: Severity::Error,
+        spec: &[RFC_9110_9_3_6],
+    }
+
+    /// A CONNECT whose destination names a host and no port at all — no colon
+    /// anywhere in it. Every other request-target elides a port and lets the
+    /// scheme supply one; this method has no scheme and no default, so the
+    /// number is the client's to send even when the URI reference it started
+    /// from left it out.
+    ///
+    /// Separate from [`AUTHORITY_TUNNEL_PORT_EMPTY`] because the senders are
+    /// different and the document addresses them separately: one copied an
+    /// authority whose port was elided and stopped, and the other built
+    /// `host ":" port` from a port it did not have. **Over HTTP/1.1 only one of
+    /// the two arrives here** — a request-target with no colon derives from no
+    /// form at all and is [`request_target`](crate::violations::request_target)'s
+    /// `_malformed` — which is a difference in the *spelling* and not in the
+    /// defect, and is why the entry is the field's rather than the target's.
+    ///
+    // cite(RFC 9110 § 9.3.6): "There is no default port; a client MUST send the port number even if the CONNECT request is based on a URI reference that contains an authority component with an elided port (Section 4.1)."
+    AUTHORITY_TUNNEL_PORT_MISSING = {
+        id: "authority_tunnel_port_missing",
+        title: "A CONNECT's destination names no port",
         message: "",
         default_severity: Severity::Error,
         spec: &[RFC_9110_9_3_6],

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -418,7 +418,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 200;
+        const FLOOR: usize = 203;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1470,7 +1470,7 @@ sources:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 394
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 126
+      line: 138
   - label: lint-http-rules/src/helpers/uri.rs (26)
     section: § 4.2
     snippet: A relative reference that begins with two slash characters is termed a network-path reference; such references are rarely used.
@@ -1490,7 +1490,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 282
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 100
+      line: 112
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 206
   - label: lint-http-rules/src/helpers/uri.rs (27)
@@ -2445,7 +2445,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 336
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 196
+      line: 212
   - label: lint-http-rules/src/helpers/uri.rs (2)
     section: § 6
     snippet: TCP, UDP, UDP-Lite, SCTP, and DCCP use 16-bit namespaces for their port number registries.
@@ -2455,7 +2455,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 335
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 195
+      line: 211
 - label: RFC 6454
   url: https://www.rfc-editor.org/rfc/rfc6454.html
   fragments:
@@ -4441,13 +4441,13 @@ sources:
     snippet: A new pseudo-header field :protocol MAY be included on request HEADERS indicating the desired protocol to be spoken on the tunnel created by CONNECT.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 440
+      line: 456
   - label: http2_pseudo_headers_valid (2)
     section: § 4
     snippet: On requests that contain the :protocol pseudo-header field, the :scheme and :path pseudo-header fields of the target URI (see Section 5) MUST also be included.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 441
+      line: 457
   - label: lint-http-rules/src/helpers/websocket.rs
     section: § 5
     snippet: Implementations using this extended CONNECT to bootstrap WebSockets do not do the processing of the Sec-WebSocket-Key and Sec-WebSocket-Accept header fields of [RFC6455] as that functionality has been superseded by the :protocol pseudo-header field.
@@ -5037,7 +5037,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 355
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 430
+      line: 446
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
       line: 259
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
@@ -5055,7 +5055,7 @@ sources:
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
       line: 377
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 267
+      line: 283
     - file: lint-http-rules/src/rules/request_version_method_valid.rs
       line: 167
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
@@ -5277,11 +5277,11 @@ sources:
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
       line: 353
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 291
+      line: 307
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 305
+      line: 321
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 422
+      line: 438
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 221
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
@@ -5307,7 +5307,7 @@ sources:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 126
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 407
+      line: 423
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
       line: 245
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
@@ -6241,21 +6241,27 @@ sources:
     snippet: A server MUST reject a CONNECT request that targets an empty or invalid port number, typically by responding with a 400 (Bad Request) status code.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 120
+      line: 126
+    - file: lint-http-rules/src/violations/authority.rs
+      line: 221
   - label: http2_pseudo_headers_valid (2)
     section: § 9.3.6
     snippet: CONNECT uses a special form of request target, unique to this method, consisting of only the host and port number of the tunnel destination, separated by a colon.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 118
+      line: 124
     - file: lint-http-rules/src/violations/authority.rs
-      line: 179
+      line: 182
+    - file: lint-http-rules/src/violations/authority.rs
+      line: 202
   - label: http2_pseudo_headers_valid (3)
     section: § 9.3.6
     snippet: There is no default port; a client MUST send the port number even if the CONNECT request is based on a URI reference that contains an authority component with an elided port (Section 4.1).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 119
+      line: 125
+    - file: lint-http-rules/src/violations/authority.rs
+      line: 245
   - label: if_match_etag_syntax
     section: § 13.1.1
     snippet: 'If-Match = "*" / #entity-tag'
@@ -6439,7 +6445,7 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 86
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 251
+      line: 267
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 201
   - label: lint-http-core/src/http_version.rs (3)
@@ -7645,7 +7651,7 @@ sources:
     - file: lint-http-rules/src/rules/host_header.rs
       line: 52
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 458
+      line: 474
   - label: lint-http-rules/src/helpers/uri.rs (6)
     section: § 7.2
     snippet: The "Host" header field in a request provides the host and port information from the target URI, enabling the origin server to distinguish among resources while servicing requests for multiple host names.
@@ -8541,13 +8547,13 @@ sources:
     snippet: absolute-path = 1*( "/" segment )
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 118
+      line: 130
   - label: request_target_form_valid
     section: § 7.1
     snippet: For CONNECT (Section 9.3.6), the request target is the host name and port number of the tunnel destination, separated by a colon.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 331
+      line: 347
     - file: lint-http-rules/src/violations/request_target.rs
       line: 138
   - label: request_target_form_valid (2)
@@ -8555,7 +8561,7 @@ sources:
     snippet: For historical reasons, the parsed target URI components, collectively referred to as the "request target", are sent within the message control data and the Host header field
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 252
+      line: 268
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 151
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
@@ -8565,13 +8571,13 @@ sources:
     snippet: There are two unusual cases for which the request target components are in a method-specific form
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 319
+      line: 335
   - label: request_target_form_valid (4)
     section: § 7.1
     snippet: These forms MUST NOT be used with other methods.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 320
+      line: 336
     - file: lint-http-rules/src/violations/request_target.rs
       line: 105
     - file: lint-http-rules/src/violations/request_target.rs
@@ -8581,7 +8587,7 @@ sources:
     snippet: This reconstruction is specific to each major protocol version.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 253
+      line: 269
   - label: request_target_no_fragment
     section: § 4.2.5
     snippet: Some protocol elements that refer to a URI allow inclusion of a fragment, while others do not.
@@ -9933,9 +9939,9 @@ sources:
     snippet: authority-form = uri-host ":" port
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 117
+      line: 123
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 99
+      line: 111
   - label: http_version_syntax
     section: § 1.1
     snippet: Conformance criteria and considerations regarding error handling are defined in Section 2 of [HTTP].
@@ -9977,7 +9983,7 @@ sources:
     - file: lint-http-core/src/http_version.rs
       line: 103
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 255
+      line: 271
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 202
   - label: lint-http-core/src/http_version.rs
@@ -9997,7 +10003,7 @@ sources:
     - file: lint-http-rules/src/rules/http_version_syntax.rs
       line: 162
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 254
+      line: 270
   - label: HTTP-name
     section: § A
     snippet: HTTP-name = %x48.54.54.50 ; HTTP
@@ -10031,7 +10037,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 619
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 48
+      line: 60
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
       line: 289
   - label: lint-http-rules/src/helpers/uri.rs (2)
@@ -10149,13 +10155,13 @@ sources:
     snippet: A recipient SHOULD NOT attempt to autocorrect and then process the request without a redirect, since the invalid request-line might be deliberately crafted to bypass security filters along the request chain.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 290
+      line: 306
   - label: request_target_form_valid (2)
     section: § 3.2
     snippet: No whitespace is allowed in the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 288
+      line: 304
     - file: lint-http-rules/src/violations/request_target.rs
       line: 201
   - label: request_target_form_valid (3)
@@ -10163,27 +10169,27 @@ sources:
     snippet: Recipients of an invalid request-line SHOULD respond with either a 400 (Bad Request) error or a 301 (Moved Permanently) redirect with the request-target properly encoded.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 306
+      line: 322
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 423
+      line: 439
   - label: request_target_form_valid (4)
     section: § 3.2
     snippet: Unfortunately, some user agents fail to properly encode or exclude whitespace found in hypertext references, resulting in those disallowed characters being sent as the request-target in a malformed request-line.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 289
+      line: 305
   - label: request_target_form_valid (5)
     section: § 3.2.1
     snippet: When making a request directly to an origin server, other than a CONNECT or server-wide OPTIONS request (as detailed below), a client MUST send only the absolute path and query components of the target URI as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 414
+      line: 430
   - label: origin-form
     section: § 3.2.1
     snippet: origin-form    = absolute-path [ "?" query ]
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 97
+      line: 109
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 208
   - label: request_target_form_valid (6)
@@ -10191,19 +10197,19 @@ sources:
     snippet: A server MUST accept the absolute-form in requests even though most HTTP/1.1 clients will only send the absolute-form to a proxy.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 416
+      line: 432
   - label: request_target_form_valid (7)
     section: § 3.2.2
     snippet: When making a request to a proxy, other than a CONNECT or server-wide OPTIONS request (as detailed below), a client MUST send the target URI in "absolute-form" as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 415
+      line: 431
   - label: absolute-form
     section: § 3.2.2
     snippet: absolute-form  = absolute-URI
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 98
+      line: 110
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 207
   - label: request_target_form_valid (8)
@@ -10211,45 +10217,45 @@ sources:
     snippet: It consists of only the uri-host and port number of the tunnel destination, separated by a colon (":").
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 332
+      line: 348
   - label: request_target_form_valid (9)
     section: § 3.2.3
     snippet: The "authority-form" of request-target is only used for CONNECT requests
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 381
-    - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 397
+    - file: lint-http-rules/src/rules/request_target_form_valid.rs
+      line: 413
   - label: request_target_form_valid (10)
     section: § 3.2.3
     snippet: The client obtains the host and port from the target URI's authority component, except that it sends the scheme's default port if the target URI elides the port.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 343
+      line: 359
   - label: request_target_form_valid (11)
     section: § 3.2.3
     snippet: When making a CONNECT request to establish a tunnel through one or more proxies, a client MUST send only the host and port of the tunnel destination as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 333
+      line: 349
   - label: request_target_form_valid (12)
     section: § 3.2.4
     snippet: The "asterisk-form" of request-target is only used for a server-wide OPTIONS request
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 368
+      line: 384
   - label: request_target_form_valid (13)
     section: § 3.2.4
     snippet: When a client wishes to request OPTIONS for the server as a whole, as opposed to a specific named resource of that server, the client MUST send only "*" (%x2A) as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 369
+      line: 385
   - label: asterisk-form
     section: § A
     snippet: asterisk-form = "*" authority = <authority, see [URI], Section 3.2>
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 106
+      line: 118
   - label: response_body_length_accuracy
     section: § 6.3
     snippet: A client MUST ignore any Content-Length or Transfer-Encoding header fields received in such a message.
@@ -10394,7 +10400,7 @@ sources:
     snippet: '":authority" MUST NOT include the deprecated userinfo subcomponent for "http" or "https" schemed URIs.'
     cited_by:
     - file: lint-http-rules/src/violations/authority.rs
-      line: 147
+      line: 150
   - label: field
     section: § 8.2.2
     snippet: Any message containing connection-specific header fields MUST be treated as malformed (Section 8.1.1).
@@ -10414,9 +10420,9 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 354
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 496
+      line: 512
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 256
+      line: 272
   - label: host_and_authority_consistent (2)
     section: § 8.3.1
     snippet: A server SHOULD treat a request as malformed if it contains a Host header field that identifies an entity that differs from the entity in the ":authority" pseudo-header field.
@@ -10444,7 +10450,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 337
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 536
+      line: 552
   - label: host_and_authority_consistent (6)
     section: § 8.3.1
     snippet: The values of fields need to be normalized to compare them (see Section 6.2 of [RFC3986]).
@@ -10456,25 +10462,25 @@ sources:
     snippet: A field value MUST NOT start or end with an ASCII whitespace character (ASCII SP or HTAB, 0x20 or 0x09).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 420
+      line: 436
   - label: http2_pseudo_headers_valid (2)
     section: § 8.3
     snippet: Endpoints MUST treat a request or response that contains undefined or invalid pseudo-header fields as malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 408
+      line: 424
   - label: http2_pseudo_headers_valid (3)
     section: § 8.3.1
     snippet: '":scheme" is not restricted to "http" and "https" schemed URIs.'
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 541
+      line: 557
   - label: http2_pseudo_headers_valid (4)
     section: § 8.3.1
     snippet: The ":method" pseudo-header field includes the HTTP method (Section 9 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 403
+      line: 419
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
       line: 320
   - label: http2_pseudo_headers_valid (5)
@@ -10482,49 +10488,49 @@ sources:
     snippet: The ":scheme" pseudo-header field includes the scheme portion of the request target.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 535
+      line: 551
   - label: http2_pseudo_headers_valid (6)
     section: § 8.3.2
     snippet: For HTTP/2 responses, a single ":status" pseudo-header field is defined that carries the HTTP status code field (see Section 15 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 651
+      line: 667
   - label: http2_pseudo_headers_valid (7)
     section: § 8.3.2
     snippet: This pseudo-header field MUST be included in all responses, including interim responses; otherwise, the response is malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 652
+      line: 668
   - label: http2_pseudo_headers_valid (8)
     section: § 8.5
     snippet: A CONNECT request that does not conform to these restrictions is malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 480
+      line: 496
     - file: lint-http-rules/src/violations/authority.rs
-      line: 221
+      line: 287
   - label: http2_pseudo_headers_valid (9)
     section: § 8.5
     snippet: A proxy that supports CONNECT establishes a TCP connection [TCP] to the host and port identified in the ":authority" pseudo-header field.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 194
+      line: 210
   - label: http2_pseudo_headers_valid (10)
     section: § 8.5
     snippet: The ":authority" pseudo-header field contains the host and port to connect to (equivalent to the authority-form of the request-target of CONNECT requests; see Section 3.2.3 of [HTTP/1.1]).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 116
+      line: 122
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 479
+      line: 495
     - file: lint-http-rules/src/violations/authority.rs
-      line: 220
+      line: 286
   - label: http2_pseudo_headers_valid (11)
     section: § 8.5
     snippet: The ":method" pseudo-header field is set to CONNECT.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 431
+      line: 447
   - label: lint-http-core/src/http_version.rs
     section: § 8.3.1
     snippet: All HTTP/2 requests implicitly have a protocol version of "2.0"
@@ -10598,7 +10604,7 @@ sources:
     snippet: Note that request targets for CONNECT or asterisk-form OPTIONS requests never include authority information
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 257
+      line: 273
   - label: request_target_no_fragment
     section: § 8.3.1
     snippet: The ":path" pseudo-header field includes the path and query parts of the target URI
@@ -10635,19 +10641,19 @@ sources:
     snippet: The authority MUST NOT include the deprecated userinfo subcomponent for URIs of scheme "http" or "https".
     cited_by:
     - file: lint-http-rules/src/violations/authority.rs
-      line: 148
+      line: 151
   - label: authority (2)
     section: § 4.4
     snippet: 'A CONNECT request MUST be constructed as follows:'
     cited_by:
     - file: lint-http-rules/src/violations/authority.rs
-      line: 222
+      line: 288
   - label: authority (3)
     section: § 4.4
     snippet: The :authority pseudo-header field contains the host and port to connect to (equivalent to the authority-form of the request-target of CONNECT requests; see Section 7.1 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/violations/authority.rs
-      line: 223
+      line: 289
   - label: extension_headers_registered
     section: § 4.2
     snippet: A request or response containing uppercase characters in field names MUST be treated as malformed
@@ -10679,7 +10685,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 415
     - file: lint-http-rules/src/violations/authority.rs
-      line: 266
+      line: 332
   - label: host_and_authority_consistent (3)
     section: § 4.3.1
     snippet: If these fields are present, they MUST NOT be empty.
@@ -10689,7 +10695,7 @@ sources:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
       line: 435
     - file: lint-http-rules/src/violations/authority.rs
-      line: 304
+      line: 370
   - label: http3_goaway_semantics
     section: § 5.2
     snippet: Endpoints MUST NOT initiate new requests or promise new pushes on the connection after receipt of a GOAWAY frame from the peer.
@@ -10943,7 +10949,7 @@ sources:
     snippet: An OPTIONS request that does not include a path component includes the value * (ASCII 0x2a) for the :path pseudo-header field
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 258
+      line: 274
   - label: request_target_no_fragment
     section: § 4.3.1
     snippet: Contains the path and query parts of the target URI


### PR DESCRIPTION
`authority_tunnel_host_empty`, `authority_tunnel_port_empty` and `authority_tunnel_port_missing` join the authority subject and take five sites across two rules: the HTTP/1.x rule's CONNECT arms for a request-target with half an authority, and the HTTP/2 rule's for the same halves read out of an `:authority`. Both rules had worded them separately and neither had named them.

`uri-host ":" port` derives every one of these — both halves are `*`-quantified — so the grammar admits `:443`, `example.com:` and `example.com`, and RFC 9110 §9.3.6 is what refuses them: the target is the host name *and* port number of the tunnel destination, there is no default port for a client to fall back on, and a server is required to reject a request targeting an empty one. One version-independent section, so every finding cites it whichever spelling carried the value.

Three entries, and the delimiter is what splits them. A colon with nothing after it is a sender who knew the component was there and wrote nothing in it; no colon at all is one who copied an authority whose port was elided and stopped. The document addresses those two separately and so does the catalogue.

Over HTTP/1.1 only two of the three can arrive: a request-target with no colon derives from none of the four forms and is the target's `_malformed`, not this field's. That is a difference in the spelling and not in the defect, which is why the entries are the destination's rather than the target's.

What is left unnamed in the HTTP/2 judge is a port outside the transport's namespace, whose sentence is RFC 6335's sixteen bits rather than §9.3.6's.

Floor: 203 of 209 entries cite a sentence.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
