### PR TITLE
A CONNECT that names no destination

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1687,6 +1687,10 @@ severity = "error"
 # The host-and-port target is sent with a method other than CONNECT
 severity = "error"
 
+[violations.request_target_connect_form_invalid]
+# A CONNECT's request-target is not a host and port
+severity = "error"
+
 [violations.request_target_empty]
 # A request-line carries no request-target
 severity = "error"

--- a/docs/rules/request_target_form_valid.md
+++ b/docs/rules/request_target_form_valid.md
@@ -30,7 +30,7 @@ Reads an HTTP/1.x request-line's request-target and asks two things: which of th
 ## Specifications
 
 - [RFC 9112 §3.2](https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2): Request Target — `request-target = origin-form / absolute-form / authority-form / asterisk-form`, no whitespace allowed in any of them, the recipient's SHOULD to answer 400 rather than autocorrect, and why: a request-line like that might be crafted to bypass a filter along the chain
-- [RFC 9112 §3.2.3](https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2.3): authority-form: CONNECT's target, and where the port number is asked for in prose rather than in the grammar
+- [RFC 9112 §3.2.3](https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2.3): authority-form — `authority-form = uri-host ":" port`, the MUST that a CONNECT send only the host and port of the tunnel destination as its request-target, and the form being used for CONNECT requests only
 - [RFC 9112 §3.2.4](https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2.4): asterisk-form: the server-wide OPTIONS request's target
 - [RFC 9110 §7.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.1): Determining the Target Resource — the two method-specific forms, the MUST NOT that keeps each to its method, and the reconstruction being specific to each major protocol version
 - [RFC 9110 §2.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2): Conformance — a sender MUST NOT generate protocol elements that do not match the grammar defined by the corresponding ABNF rules

--- a/lint-http-rules/src/rules/request_target_form_valid.rs
+++ b/lint-http-rules/src/rules/request_target_form_valid.rs
@@ -9,8 +9,8 @@ use crate::violations::authority::{
 };
 use crate::violations::request_target::{
     REQUEST_TARGET_ASTERISK_FORBIDDEN, REQUEST_TARGET_AUTHORITY_FORM_FORBIDDEN,
-    REQUEST_TARGET_EMPTY, REQUEST_TARGET_MALFORMED, REQUEST_TARGET_WHITESPACE_FORBIDDEN,
-    RFC_9110_2_2, RFC_9110_7_1, RFC_9112_3_2,
+    REQUEST_TARGET_CONNECT_FORM_INVALID, REQUEST_TARGET_EMPTY, REQUEST_TARGET_MALFORMED,
+    REQUEST_TARGET_WHITESPACE_FORBIDDEN, RFC_9110_2_2, RFC_9110_7_1, RFC_9112_3_2, RFC_9112_3_2_3,
 };
 use crate::violations::ViolationDef;
 
@@ -19,6 +19,13 @@ use crate::violations::ViolationDef;
 /// method-specific form and is stated once for every version of HTTP. The HTTP/2
 /// and HTTP/3 pseudo-header rules declare the same entry for the same defect
 /// spelled as a `:path`.
+///
+/// **A CONNECT in some other form is the third**, and it is the mirror of the
+/// second: § 7.1 forbids another method from reaching for CONNECT's form, and
+/// RFC 9112 § 3.2.3 requires CONNECT to use it. Two directions, two sentences,
+/// two ids — and this one can only ever have this declarer, because the
+/// multiplexed versions cannot tell a basic CONNECT with a `:path` from RFC
+/// 8441's extended one.
 ///
 /// **Two of what it reports are not the target's at all**: a CONNECT naming a
 /// port and no host, and one ending at the colon with no port, are the tunnel
@@ -50,6 +57,7 @@ static DECLARED: &[&ViolationDef] = &[
     &REQUEST_TARGET_AUTHORITY_FORM_FORBIDDEN,
     &AUTHORITY_TUNNEL_HOST_EMPTY,
     &AUTHORITY_TUNNEL_PORT_EMPTY,
+    &REQUEST_TARGET_CONNECT_FORM_INVALID,
 ];
 
 /// Which of the four productions a request-target derives from.
@@ -164,12 +172,6 @@ pub struct RequestTargetFormValid;
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_9112_3_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9112",
-    section: Some("3.2.3"),
-    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2.3",
-    note: "authority-form: CONNECT's target, and where the port number is asked for in prose rather than in the grammar",
-};
 const RFC_9112_3_2_4: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9112",
     section: Some("3.2.4"),
@@ -365,7 +367,7 @@ impl Rule for RequestTargetFormValid {
                 ),
                 (Some(TargetForm::Authority { .. }), "CONNECT") => return None,
                 (Some(other), "CONNECT") => (
-                    None,
+                    Some(&REQUEST_TARGET_CONNECT_FORM_INVALID),
                     format!(
                         "CONNECT request-target '{shown}' is {}, and a CONNECT sends only the host and port of the tunnel destination, separated by a colon. A recipient has nowhere to open the tunnel to",
                         other.named()
@@ -462,6 +464,33 @@ static REGISTRATION: &dyn crate::rules::Rule = &RequestTargetFormValid;
 mod tests {
     use super::*;
     use rstest::rstest;
+
+    /// A CONNECT whose target is one of the other three forms names no tunnel
+    /// destination. `_invalid` rather than `_malformed`: the value derives from
+    /// a form, and from the wrong one — where a target deriving from none of the
+    /// four is the same defect whatever method carried it.
+    #[rstest]
+    #[case("/path", "request_target_connect_form_invalid")]
+    #[case("https://example.com/", "request_target_connect_form_invalid")]
+    #[case("*", "request_target_connect_form_invalid")]
+    #[case("example.com", "request_target_malformed")]
+    fn a_connect_in_another_form_names_no_destination(
+        #[case] target: &str,
+        #[case] violation: &str,
+    ) {
+        let rule = RequestTargetFormValid;
+        let mut tx = crate::test_helpers::make_test_transaction();
+        tx.request.method = "CONNECT".into();
+        tx.request.uri = target.into();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_severity(rule.id(), "error"),
+        )
+        .expect("a finding");
+        assert_eq!(v.violation, violation, "{target}");
+    }
 
     /// A CONNECT with half an authority answers to the tunnel destination's ids,
     /// which the HTTP/2 rule reports for the same two shapes out of an

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -418,7 +418,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 203;
+        const FLOOR: usize = 204;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/request_target.rs
+++ b/lint-http-rules/src/violations/request_target.rs
@@ -71,6 +71,18 @@ pub const RFC_9110_2_2: SpecRef = SpecRef {
     note: "Conformance — a sender MUST NOT generate protocol elements that do not match the grammar defined by the corresponding ABNF rules",
 };
 
+/// The authority-form's own section: what a CONNECT's request-target consists
+/// of, the MUST that a client send only that, and where the port comes from when
+/// the target URI elided one. HTTP/1.1's, because it is HTTP/1.1 that writes a
+/// request-target out — the entry citing it is one no pseudo-header rule can
+/// report.
+pub const RFC_9112_3_2_3: SpecRef = SpecRef {
+    spec: "RFC 9112",
+    section: Some("3.2.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2.3",
+    note: "authority-form — `authority-form = uri-host \":\" port`, the MUST that a CONNECT send only the host and port of the tunnel destination as its request-target, and the form being used for CONNECT requests only",
+};
+
 /// Where the four forms are named, what each is for, and the one MUST NOT that
 /// keeps the two method-specific ones to their methods. Shared by the three
 /// rules that read a request target, which had grown three notes for it.
@@ -143,6 +155,40 @@ defects! {
         message: "",
         default_severity: Severity::Error,
         spec: &[RFC_9110_7_1],
+    }
+
+    /// A CONNECT whose request-target is in one of the other three forms — a
+    /// path, a full URI with a scheme, the asterisk. The target of a CONNECT
+    /// *is* the tunnel destination, so a value that is some other form names no
+    /// destination at all and a recipient has nowhere to open the tunnel to.
+    ///
+    /// **`_invalid` and not `_malformed`**: the value derives from a form, just
+    /// not from the one this method requires, which is the line the closed
+    /// vocabulary draws between grammar and everything past it.
+    /// [`REQUEST_TARGET_MALFORMED`] is for a value that derives from no form at
+    /// all, and a CONNECT gets that one too — the method changes the wording of
+    /// the finding and not which defect it is.
+    ///
+    /// **The mirror of [`REQUEST_TARGET_AUTHORITY_FORM_FORBIDDEN`], and not the
+    /// same entry.** That one is another method reaching for CONNECT's form,
+    /// which § 7.1 prohibits in so many words; this one is CONNECT failing to
+    /// use it, which § 3.2.3 states as a positive requirement. Two directions,
+    /// two sentences, two things a sender has to change.
+    ///
+    /// **One declarer, and it can only ever have one.** Over HTTP/2 and HTTP/3 a
+    /// CONNECT with a `:scheme` and a `:path` is a conforming *extended* CONNECT
+    /// (RFC 8441) and a malformed basic one, with nothing in a capture to choose
+    /// between them — both pseudo-header rules decline it for that reason. The
+    /// request-line has no such ambiguity: RFC 8441's mechanism is not part of
+    /// HTTP/1.1.
+    ///
+    // cite(RFC 9112 § 3.2.3): "When making a CONNECT request to establish a tunnel through one or more proxies, a client MUST send only the host and port of the tunnel destination as the request-target."
+    REQUEST_TARGET_CONNECT_FORM_INVALID = {
+        id: "request_target_connect_form_invalid",
+        title: "A CONNECT's request-target is not a host and port",
+        message: "",
+        default_severity: Severity::Error,
+        spec: &[RFC_9112_3_2_3],
     }
 
     /// A request whose target carries no path component, on a method that owes

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1470,7 +1470,7 @@ sources:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 394
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 138
+      line: 146
   - label: lint-http-rules/src/helpers/uri.rs (26)
     section: § 4.2
     snippet: A relative reference that begins with two slash characters is termed a network-path reference; such references are rarely used.
@@ -1490,7 +1490,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 282
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 112
+      line: 120
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 206
   - label: lint-http-rules/src/helpers/uri.rs (27)
@@ -5055,7 +5055,7 @@ sources:
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
       line: 377
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 283
+      line: 285
     - file: lint-http-rules/src/rules/request_version_method_valid.rs
       line: 167
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
@@ -5277,11 +5277,11 @@ sources:
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
       line: 353
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 307
+      line: 309
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 321
+      line: 323
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 438
+      line: 440
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 221
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
@@ -5291,9 +5291,9 @@ sources:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
       line: 398
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 225
+      line: 271
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 245
+      line: 291
   - label: Allow grammar, sender-expanded
     section: § A
     snippet: Allow = [ method *( OWS "," OWS method ) ]
@@ -6445,7 +6445,7 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 86
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 267
+      line: 269
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 201
   - label: lint-http-core/src/http_version.rs (3)
@@ -8541,27 +8541,27 @@ sources:
     snippet: For OPTIONS (Section 9.3.7), the request target can be a single asterisk ("*").
     cited_by:
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 104
+      line: 116
   - label: absolute-path
     section: § 4.1
     snippet: absolute-path = 1*( "/" segment )
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 130
+      line: 138
   - label: request_target_form_valid
     section: § 7.1
     snippet: For CONNECT (Section 9.3.6), the request target is the host name and port number of the tunnel destination, separated by a colon.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 347
+      line: 349
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 138
+      line: 150
   - label: request_target_form_valid (2)
     section: § 7.1
     snippet: For historical reasons, the parsed target URI components, collectively referred to as the "request target", are sent within the message control data and the Host header field
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 268
+      line: 270
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 151
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
@@ -8571,23 +8571,23 @@ sources:
     snippet: There are two unusual cases for which the request target components are in a method-specific form
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 335
+      line: 337
   - label: request_target_form_valid (4)
     section: § 7.1
     snippet: These forms MUST NOT be used with other methods.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 336
+      line: 338
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 105
+      line: 117
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 139
+      line: 151
   - label: request_target_form_valid (5)
     section: § 7.1
     snippet: This reconstruction is specific to each major protocol version.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 269
+      line: 271
   - label: request_target_no_fragment
     section: § 4.2.5
     snippet: Some protocol elements that refer to a URI allow inclusion of a fragment, while others do not.
@@ -9941,7 +9941,7 @@ sources:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 123
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 111
+      line: 119
   - label: http_version_syntax
     section: § 1.1
     snippet: Conformance criteria and considerations regarding error handling are defined in Section 2 of [HTTP].
@@ -9983,7 +9983,7 @@ sources:
     - file: lint-http-core/src/http_version.rs
       line: 103
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 271
+      line: 273
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 202
   - label: lint-http-core/src/http_version.rs
@@ -10003,7 +10003,7 @@ sources:
     - file: lint-http-rules/src/rules/http_version_syntax.rs
       line: 162
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 270
+      line: 272
   - label: HTTP-name
     section: § A
     snippet: HTTP-name = %x48.54.54.50 ; HTTP
@@ -10037,7 +10037,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 619
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 60
+      line: 68
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
       line: 289
   - label: lint-http-rules/src/helpers/uri.rs (2)
@@ -10155,41 +10155,41 @@ sources:
     snippet: A recipient SHOULD NOT attempt to autocorrect and then process the request without a redirect, since the invalid request-line might be deliberately crafted to bypass security filters along the request chain.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 306
+      line: 308
   - label: request_target_form_valid (2)
     section: § 3.2
     snippet: No whitespace is allowed in the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 304
+      line: 306
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 201
+      line: 247
   - label: request_target_form_valid (3)
     section: § 3.2
     snippet: Recipients of an invalid request-line SHOULD respond with either a 400 (Bad Request) error or a 301 (Moved Permanently) redirect with the request-target properly encoded.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 322
+      line: 324
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 439
+      line: 441
   - label: request_target_form_valid (4)
     section: § 3.2
     snippet: Unfortunately, some user agents fail to properly encode or exclude whitespace found in hypertext references, resulting in those disallowed characters being sent as the request-target in a malformed request-line.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 305
+      line: 307
   - label: request_target_form_valid (5)
     section: § 3.2.1
     snippet: When making a request directly to an origin server, other than a CONNECT or server-wide OPTIONS request (as detailed below), a client MUST send only the absolute path and query components of the target URI as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 430
+      line: 432
   - label: origin-form
     section: § 3.2.1
     snippet: origin-form    = absolute-path [ "?" query ]
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 109
+      line: 117
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 208
   - label: request_target_form_valid (6)
@@ -10197,19 +10197,19 @@ sources:
     snippet: A server MUST accept the absolute-form in requests even though most HTTP/1.1 clients will only send the absolute-form to a proxy.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 432
+      line: 434
   - label: request_target_form_valid (7)
     section: § 3.2.2
     snippet: When making a request to a proxy, other than a CONNECT or server-wide OPTIONS request (as detailed below), a client MUST send the target URI in "absolute-form" as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 431
+      line: 433
   - label: absolute-form
     section: § 3.2.2
     snippet: absolute-form  = absolute-URI
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 110
+      line: 118
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 207
   - label: request_target_form_valid (8)
@@ -10217,45 +10217,47 @@ sources:
     snippet: It consists of only the uri-host and port number of the tunnel destination, separated by a colon (":").
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 348
+      line: 350
   - label: request_target_form_valid (9)
     section: § 3.2.3
     snippet: The "authority-form" of request-target is only used for CONNECT requests
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 397
+      line: 399
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 413
+      line: 415
   - label: request_target_form_valid (10)
     section: § 3.2.3
     snippet: The client obtains the host and port from the target URI's authority component, except that it sends the scheme's default port if the target URI elides the port.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 359
+      line: 361
   - label: request_target_form_valid (11)
     section: § 3.2.3
     snippet: When making a CONNECT request to establish a tunnel through one or more proxies, a client MUST send only the host and port of the tunnel destination as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 349
+      line: 351
+    - file: lint-http-rules/src/violations/request_target.rs
+      line: 185
   - label: request_target_form_valid (12)
     section: § 3.2.4
     snippet: The "asterisk-form" of request-target is only used for a server-wide OPTIONS request
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 384
+      line: 386
   - label: request_target_form_valid (13)
     section: § 3.2.4
     snippet: When a client wishes to request OPTIONS for the server as a whole, as opposed to a specific named resource of that server, the client MUST send only "*" (%x2A) as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 385
+      line: 387
   - label: asterisk-form
     section: § A
     snippet: asterisk-form = "*" authority = <authority, see [URI], Section 3.2>
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 118
+      line: 126
   - label: response_body_length_accuracy
     section: § 6.3
     snippet: A client MUST ignore any Content-Length or Transfer-Encoding header fields received in such a message.
@@ -10422,7 +10424,7 @@ sources:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 512
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 272
+      line: 274
   - label: host_and_authority_consistent (2)
     section: § 8.3.1
     snippet: A server SHOULD treat a request as malformed if it contains a Host header field that identifies an entity that differs from the entity in the ":authority" pseudo-header field.
@@ -10598,13 +10600,13 @@ sources:
     snippet: All HTTP/2 requests MUST include exactly one valid value for the ":method", ":scheme", and ":path" pseudo-header fields, unless they are CONNECT requests (Section 8.5).
     cited_by:
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 171
+      line: 217
   - label: request_target_form_valid
     section: § 8.3.1
     snippet: Note that request targets for CONNECT or asterisk-form OPTIONS requests never include authority information
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 273
+      line: 275
   - label: request_target_no_fragment
     section: § 8.3.1
     snippet: The ":path" pseudo-header field includes the path and query parts of the target URI
@@ -10943,13 +10945,13 @@ sources:
     snippet: This pseudo-header field MUST NOT be empty for "http" or "https" URIs; "http" or "https" URIs that do not contain a path component MUST include a value of / (ASCII 0x2f).
     cited_by:
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 172
+      line: 218
   - label: request_target_form_valid
     section: § 4.3.1
     snippet: An OPTIONS request that does not include a path component includes the value * (ASCII 0x2a) for the :path pseudo-header field
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 274
+      line: 276
   - label: request_target_no_fragment
     section: § 4.3.1
     snippet: Contains the path and query parts of the target URI


### PR DESCRIPTION
`request_target_connect_form_invalid` joins the request-target subject and takes the arm for a CONNECT whose target is a path, a full URI or the asterisk. The target of a CONNECT is the tunnel destination itself, so a value in some other form names nothing to open a tunnel to.

`_invalid` and not `_malformed`: the value derives from a form, just not the one this method requires, which is the line the vocabulary draws between the grammar and everything past it. A target deriving from none of the four is the other entry, and a CONNECT reaches it too — the method changes the wording of the finding and not which defect it is.

The mirror of the entry beside it and deliberately not the same one. RFC 9110 §7.1 forbids another method from reaching for CONNECT's form; RFC 9112 §3.2.3 requires CONNECT to use it. Two directions, two sentences, two things a sender has to change.

It can only ever have this one declarer. Over HTTP/2 and HTTP/3 a CONNECT carrying a `:scheme` and a `:path` is a conforming extended CONNECT and a malformed basic one with nothing in a capture to choose between them, which is why both pseudo-header rules decline it; a request-line has no such ambiguity.

Floor: 204 of 210 entries cite a sentence.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
