### PR TITLE
One target, two forms, no verdict

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1695,6 +1695,10 @@ severity = "error"
 # A request-line carries no request-target
 severity = "error"
 
+[violations.request_target_form_ambiguous]
+# A request-target derives from two of the four forms at once
+severity = "warn"
+
 [violations.request_target_malformed]
 # A request-target derives from none of the four forms
 severity = "error"

--- a/docs/development.md
+++ b/docs/development.md
@@ -126,6 +126,7 @@ member is malformed".
 | Permitted, and almost certainly not what was meant | `_redundant` | — |
 | Sent in answer to something the other side never asked for | `_unsolicited` | — |
 | Sent in the direction its definition does not describe | `_misdirected` | — |
+| Derives from two productions at once, and nothing chooses | `_ambiguous` | — |
 | Retired by a later specification | `_obsolete` | — |
 
 `_redundant` is the one ending that condemns nothing: it names work a message
@@ -144,6 +145,23 @@ code; not `_invalid`, since no value is being measured past its grammar; and not
 status code's definition is written in terms of a request that did not happen. A
 rule reporting one of these has to read both messages, which is why the subject
 is the status code and never the field it is read against.
+
+`_ambiguous` is the one ending that reports no verdict about the message. An
+alternation's alternatives are usually told apart by a committing delimiter — a
+`quoted-string` opens with a `"`, an `IP-literal` with a `[` — and where one
+exists, a value belongs to exactly one alternative and any defect is that
+alternative's. Where none exists, a value can derive from two at once, and
+`GET example.com:443` is the case worth naming: read as an authority-form it is
+CONNECT's request-target used by a method that may not, and read as an
+absolute-URI it is a perfectly ordinary proxy request for a resource under a
+scheme named `example.com`. Nothing else in the request-line chooses. So it is
+not `_malformed` (it derives), not `_invalid` (under one reading it is
+acceptable), not `_forbidden` (no sentence prohibits what it may be), and not
+`_conflicting` (nothing in the message disagrees with anything else in it — the
+message disagrees with itself only in the reading). What the finding says is that
+two recipients on one chain may route it two ways, which is why an entry ending
+this way defaults to `warn` and never to `error`: **the report is about the
+ambiguity and not about a defect the message can be shown to have.**
 
 `_misdirected` is the ending for a field that landed on the wrong side of the
 exchange. RFC 9110 §10 sorts nine fields into the ones that say something about

--- a/lint-http-rules/src/rules/request_target_form_valid.rs
+++ b/lint-http-rules/src/rules/request_target_form_valid.rs
@@ -9,8 +9,9 @@ use crate::violations::authority::{
 };
 use crate::violations::request_target::{
     REQUEST_TARGET_ASTERISK_FORBIDDEN, REQUEST_TARGET_AUTHORITY_FORM_FORBIDDEN,
-    REQUEST_TARGET_CONNECT_FORM_INVALID, REQUEST_TARGET_EMPTY, REQUEST_TARGET_MALFORMED,
-    REQUEST_TARGET_WHITESPACE_FORBIDDEN, RFC_9110_2_2, RFC_9110_7_1, RFC_9112_3_2, RFC_9112_3_2_3,
+    REQUEST_TARGET_CONNECT_FORM_INVALID, REQUEST_TARGET_EMPTY, REQUEST_TARGET_FORM_AMBIGUOUS,
+    REQUEST_TARGET_MALFORMED, REQUEST_TARGET_WHITESPACE_FORBIDDEN, RFC_9110_2_2, RFC_9110_7_1,
+    RFC_9112_3_2, RFC_9112_3_2_3,
 };
 use crate::violations::ViolationDef;
 
@@ -19,6 +20,12 @@ use crate::violations::ViolationDef;
 /// method-specific form and is stated once for every version of HTTP. The HTTP/2
 /// and HTTP/3 pseudo-header rules declare the same entry for the same defect
 /// spelled as a `:path`.
+///
+/// **The overlap is the last of them, and the only one that condemns nothing**:
+/// a target deriving from the authority-form and the absolute-form at once is
+/// reported as the ambiguity it is, because one of its two readings is
+/// conforming and the request-line says nothing that chooses. With it this rule
+/// declares an entry for every finding it makes.
 ///
 /// **A CONNECT in some other form is the third**, and it is the mirror of the
 /// second: § 7.1 forbids another method from reaching for CONNECT's form, and
@@ -58,6 +65,7 @@ static DECLARED: &[&ViolationDef] = &[
     &AUTHORITY_TUNNEL_HOST_EMPTY,
     &AUTHORITY_TUNNEL_PORT_EMPTY,
     &REQUEST_TARGET_CONNECT_FORM_INVALID,
+    &REQUEST_TARGET_FORM_AMBIGUOUS,
 ];
 
 /// Which of the four productions a request-target derives from.
@@ -336,11 +344,12 @@ impl Rule for RequestTargetFormValid {
             // defined rather than in either version's syntax.
             // cite(RFC 9110 § 7.1): "There are two unusual cases for which the request target components are in a method-specific form"
             // cite(RFC 9110 § 7.1): "These forms MUST NOT be used with other methods."
-            // The judge yields the defect the catalogue names beside the wording,
-            // which is the shape `expect_header_valid` settled for a half-converted
-            // one: exactly one arm has an entry, and the rest are readings of the
-            // request-line that no id names yet.
-            let (def, message) = match (&form, method) {
+            // The judge yields the defect the catalogue names beside the wording.
+            // Every arm has one now, so the pair is a `&ViolationDef` and not an
+            // `Option` of one: the half-converted shape `expect_header_valid`
+            // settled is gone from here, and with it the arm that reported at the
+            // rule's own severity.
+            let (def, message): (&'static ViolationDef, String) = match (&form, method) {
                 // A CONNECT is judged against the one form it may be in, whichever of
                 // the others it is in instead -- and against the *contents* of that
                 // form, because both halves of `uri-host ":" port` are `*`-quantified
@@ -350,7 +359,7 @@ impl Rule for RequestTargetFormValid {
                 // cite(RFC 9112 § 3.2.3): "It consists of only the uri-host and port number of the tunnel destination, separated by a colon (":")."
                 // cite(RFC 9112 § 3.2.3): "When making a CONNECT request to establish a tunnel through one or more proxies, a client MUST send only the host and port of the tunnel destination as the request-target."
                 (Some(TargetForm::Authority { host: "", .. }), "CONNECT") => (
-                    Some(&AUTHORITY_TUNNEL_HOST_EMPTY),
+                    &AUTHORITY_TUNNEL_HOST_EMPTY,
                     format!(
                         "CONNECT request-target '{shown}' names no host. `uri-host` derives the empty string -- `reg-name` is `*( unreserved / pct-encoded / sub-delims )` -- so the grammar admits this, and the tunnel destination is a host name and a port number, of which a recipient here has at most one"
                     ),
@@ -360,21 +369,21 @@ impl Rule for RequestTargetFormValid {
                 // client does when the target URI has no port to copy.
                 // cite(RFC 9112 § 3.2.3): "The client obtains the host and port from the target URI's authority component, except that it sends the scheme's default port if the target URI elides the port."
                 (Some(TargetForm::Authority { port: "", .. }), "CONNECT") => (
-                    Some(&AUTHORITY_TUNNEL_PORT_EMPTY),
+                    &AUTHORITY_TUNNEL_PORT_EMPTY,
                     format!(
                         "CONNECT request-target '{shown}' carries the port's delimiter and no port. `port` is `*DIGIT`, so the grammar admits this, and a client with no port to copy sends the scheme's default one -- a recipient reading this has a host and no number to open the tunnel on"
                     ),
                 ),
                 (Some(TargetForm::Authority { .. }), "CONNECT") => return None,
                 (Some(other), "CONNECT") => (
-                    Some(&REQUEST_TARGET_CONNECT_FORM_INVALID),
+                    &REQUEST_TARGET_CONNECT_FORM_INVALID,
                     format!(
                         "CONNECT request-target '{shown}' is {}, and a CONNECT sends only the host and port of the tunnel destination, separated by a colon. A recipient has nowhere to open the tunnel to",
                         other.named()
                     ),
                 ),
                 (None, "CONNECT") => (
-                    Some(&REQUEST_TARGET_MALFORMED),
+                    &REQUEST_TARGET_MALFORMED,
                     format!(
                         "CONNECT request-target '{shown}' derives from none of the four forms, and a CONNECT sends only the host and port of the tunnel destination, separated by a colon. A recipient has nowhere to open the tunnel to"
                     ),
@@ -386,7 +395,7 @@ impl Rule for RequestTargetFormValid {
                 // cite(RFC 9112 § 3.2.4): "The "asterisk-form" of request-target is only used for a server-wide OPTIONS request"
                 // cite(RFC 9112 § 3.2.4): "When a client wishes to request OPTIONS for the server as a whole, as opposed to a specific named resource of that server, the client MUST send only "*" (%x2A) as the request-target."
                 (Some(TargetForm::Asterisk), m) if m != "OPTIONS" => (
-                    Some(&REQUEST_TARGET_ASTERISK_FORBIDDEN),
+                    &REQUEST_TARGET_ASTERISK_FORBIDDEN,
                     format!(
                         "Asterisk-form request-target '*' was sent with method '{m}'. The asterisk is the request target of a server-wide OPTIONS request and of nothing else, and the two method-specific forms must not be used with other methods, so '{m} *' names nothing for the request to be applied to"
                     ),
@@ -405,7 +414,7 @@ impl Rule for RequestTargetFormValid {
                     }),
                     m,
                 ) => (
-                    None,
+                    &REQUEST_TARGET_FORM_AMBIGUOUS,
                     format!(
                         "Request-target '{shown}' was sent with method '{m}' and derives from two of the four forms: as a host and port it is the host '{host}' on port '{port}', which is a CONNECT's request target and no other method's, and as an absolute-URI it asks a proxy for a resource in a scheme named '{host}'. Nothing else in the request-line chooses between them, so two recipients on the same chain may route it two ways"
                     ),
@@ -414,7 +423,7 @@ impl Rule for RequestTargetFormValid {
                 // port and nothing else -- and it is CONNECT's.
                 // cite(RFC 9112 § 3.2.3): "The "authority-form" of request-target is only used for CONNECT requests"
                 (Some(TargetForm::Authority { .. }), m) => (
-                    Some(&REQUEST_TARGET_AUTHORITY_FORM_FORBIDDEN),
+                    &REQUEST_TARGET_AUTHORITY_FORM_FORBIDDEN,
                     format!(
                         "Authority-form request-target '{shown}' was sent with method '{m}'. The host-and-port form is a CONNECT's request target and no other method's, and the two method-specific forms must not be used with other methods"
                     ),
@@ -440,17 +449,14 @@ impl Rule for RequestTargetFormValid {
                 // cite(RFC 9110 § 2.2): "A sender MUST NOT generate protocol elements that do not match the grammar defined by the corresponding ABNF rules."
                 // cite(RFC 9112 § 3.2): "Recipients of an invalid request-line SHOULD respond with either a 400 (Bad Request) error or a 301 (Moved Permanently) redirect with the request-target properly encoded."
                 (None, _) => (
-                    Some(&REQUEST_TARGET_MALFORMED),
+                    &REQUEST_TARGET_MALFORMED,
                     format!(
                         "Request-target '{shown}' derives from none of the four forms: it is not an absolute path, not a full target URI with a scheme, not a host and port, and not the asterisk. The request-line carrying it is invalid, and a recipient is asked to answer 400 (Bad Request) rather than guess which was meant"
                     ),
                 ),
             };
 
-            Some(match def {
-                Some(def) => ctx.report_with(def, message),
-                None => self.violation(ctx.severity, message),
-            })
+            Some(ctx.report_with(def, message))
         };
         Vec::from_iter(finding())
     }
@@ -464,6 +470,40 @@ static REGISTRATION: &dyn crate::rules::Rule = &RequestTargetFormValid;
 mod tests {
     use super::*;
     use rstest::rstest;
+
+    /// A value that derives from both the authority-form and the absolute-form
+    /// reports the ambiguity rather than either reading of it: `example.com` is
+    /// a `scheme` as well as a `reg-name`, and nothing else in the request-line
+    /// chooses. The unambiguous case beside it — a left half no `scheme` can
+    /// open — is the entry that says the MUST NOT was broken.
+    #[rstest]
+    #[case("example.com:443", "request_target_form_ambiguous")]
+    #[case("tel:8005551212", "request_target_form_ambiguous")]
+    #[case("192.0.2.1:443", "request_target_authority_form_forbidden")]
+    fn an_overlap_reports_the_ambiguity_and_not_a_verdict(
+        #[case] target: &str,
+        #[case] violation: &str,
+    ) {
+        let rule = RequestTargetFormValid;
+        let mut tx = crate::test_helpers::make_test_transaction();
+        tx.request.method = "GET".into();
+        tx.request.uri = target.into();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_severity(rule.id(), "error"),
+        )
+        .expect("a finding");
+        assert_eq!(v.violation, violation, "{target}");
+        // The ambiguous one carries no citation, because no sentence is known to
+        // have been broken; its neighbour carries § 7.1's.
+        assert_eq!(
+            v.cite.is_some(),
+            violation != "request_target_form_ambiguous",
+            "{target}"
+        );
+    }
 
     /// A CONNECT whose target is one of the other three forms names no tunnel
     /// destination. `_invalid` rather than `_malformed`: the value derives from

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -431,6 +431,7 @@ mod tests {
     /// "Violation ids" in `docs/development.md`, beside the claim it breaks;
     /// this array and that table are extended in one commit or not at all.
     const DEFECT_ENDINGS: &[&str] = &[
+        "ambiguous",
         "conflicting",
         "duplicated",
         "empty",

--- a/lint-http-rules/src/violations/request_target.rs
+++ b/lint-http-rules/src/violations/request_target.rs
@@ -157,6 +157,40 @@ defects! {
         spec: &[RFC_9110_7_1],
     }
 
+    /// A request-target that derives from the authority-form *and* from the
+    /// absolute-form, sent with a method that is not CONNECT — `example.com:443`,
+    /// `tel:8005551212`, `urn:123`. Read one way it is a host and a port, which
+    /// is CONNECT's target and no other method's; read the other it is a full
+    /// URI asking a proxy for a resource under a scheme named `example.com`.
+    /// Nothing else in the request-line chooses between them.
+    ///
+    /// **The first entry in this catalogue that reports no verdict about the
+    /// message**, and the ending exists for it. Both readings derive, so it is
+    /// not `_malformed`; one of them is conforming, so it is not `_invalid` and
+    /// not `_forbidden`; and nothing in the message disagrees with anything else
+    /// in it, so it is not `_conflicting`. What is being reported is that two
+    /// recipients on one chain may route the request two ways — which is the
+    /// shape a request-smuggling attempt has, and is also what an ordinary
+    /// `tel:` URI in the wrong field looks like.
+    ///
+    /// **Separate from [`REQUEST_TARGET_AUTHORITY_FORM_FORBIDDEN`] because the
+    /// evidence is weaker, not because the defect is different.** That entry is
+    /// for a value only the authority-form generates — `192.0.2.1:443`,
+    /// `[2001:db8::1]:443`, `:80`, none of which any `scheme` can open — where
+    /// § 7.1's MUST NOT is established. Here it may not have been broken at all,
+    /// so the entry carries no sentence and ranks below its neighbour.
+    ///
+    /// `warn`, which the ending requires: an entry that cannot say the message
+    /// is wrong may not rank with the ones that can.
+    ///
+    REQUEST_TARGET_FORM_AMBIGUOUS = {
+        id: "request_target_form_ambiguous",
+        title: "A request-target derives from two of the four forms at once",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[],
+    }
+
     /// A CONNECT whose request-target is in one of the other three forms — a
     /// path, a full URI with a scheme, the asterisk. The target of a CONNECT
     /// *is* the tunnel destination, so a value that is some other form names no

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1470,7 +1470,7 @@ sources:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 394
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 146
+      line: 154
   - label: lint-http-rules/src/helpers/uri.rs (26)
     section: § 4.2
     snippet: A relative reference that begins with two slash characters is termed a network-path reference; such references are rarely used.
@@ -1490,7 +1490,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 282
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 120
+      line: 128
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 206
   - label: lint-http-rules/src/helpers/uri.rs (27)
@@ -5055,7 +5055,7 @@ sources:
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
       line: 377
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 285
+      line: 293
     - file: lint-http-rules/src/rules/request_version_method_valid.rs
       line: 167
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
@@ -5277,11 +5277,11 @@ sources:
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
       line: 353
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 309
+      line: 317
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 323
+      line: 331
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 440
+      line: 449
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 221
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
@@ -5291,9 +5291,9 @@ sources:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
       line: 398
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 271
+      line: 305
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 291
+      line: 325
   - label: Allow grammar, sender-expanded
     section: § A
     snippet: Allow = [ method *( OWS "," OWS method ) ]
@@ -6445,7 +6445,7 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 86
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 269
+      line: 277
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 201
   - label: lint-http-core/src/http_version.rs (3)
@@ -8547,13 +8547,13 @@ sources:
     snippet: absolute-path = 1*( "/" segment )
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 138
+      line: 146
   - label: request_target_form_valid
     section: § 7.1
     snippet: For CONNECT (Section 9.3.6), the request target is the host name and port number of the tunnel destination, separated by a colon.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 349
+      line: 358
     - file: lint-http-rules/src/violations/request_target.rs
       line: 150
   - label: request_target_form_valid (2)
@@ -8561,7 +8561,7 @@ sources:
     snippet: For historical reasons, the parsed target URI components, collectively referred to as the "request target", are sent within the message control data and the Host header field
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 270
+      line: 278
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 151
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
@@ -8571,13 +8571,13 @@ sources:
     snippet: There are two unusual cases for which the request target components are in a method-specific form
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 337
+      line: 345
   - label: request_target_form_valid (4)
     section: § 7.1
     snippet: These forms MUST NOT be used with other methods.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 338
+      line: 346
     - file: lint-http-rules/src/violations/request_target.rs
       line: 117
     - file: lint-http-rules/src/violations/request_target.rs
@@ -8587,7 +8587,7 @@ sources:
     snippet: This reconstruction is specific to each major protocol version.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 271
+      line: 279
   - label: request_target_no_fragment
     section: § 4.2.5
     snippet: Some protocol elements that refer to a URI allow inclusion of a fragment, while others do not.
@@ -9941,7 +9941,7 @@ sources:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 123
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 119
+      line: 127
   - label: http_version_syntax
     section: § 1.1
     snippet: Conformance criteria and considerations regarding error handling are defined in Section 2 of [HTTP].
@@ -9983,7 +9983,7 @@ sources:
     - file: lint-http-core/src/http_version.rs
       line: 103
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 273
+      line: 281
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 202
   - label: lint-http-core/src/http_version.rs
@@ -10003,7 +10003,7 @@ sources:
     - file: lint-http-rules/src/rules/http_version_syntax.rs
       line: 162
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 272
+      line: 280
   - label: HTTP-name
     section: § A
     snippet: HTTP-name = %x48.54.54.50 ; HTTP
@@ -10037,7 +10037,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 619
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 68
+      line: 76
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
       line: 289
   - label: lint-http-rules/src/helpers/uri.rs (2)
@@ -10155,41 +10155,41 @@ sources:
     snippet: A recipient SHOULD NOT attempt to autocorrect and then process the request without a redirect, since the invalid request-line might be deliberately crafted to bypass security filters along the request chain.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 308
+      line: 316
   - label: request_target_form_valid (2)
     section: § 3.2
     snippet: No whitespace is allowed in the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 306
+      line: 314
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 247
+      line: 281
   - label: request_target_form_valid (3)
     section: § 3.2
     snippet: Recipients of an invalid request-line SHOULD respond with either a 400 (Bad Request) error or a 301 (Moved Permanently) redirect with the request-target properly encoded.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 324
+      line: 332
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 441
+      line: 450
   - label: request_target_form_valid (4)
     section: § 3.2
     snippet: Unfortunately, some user agents fail to properly encode or exclude whitespace found in hypertext references, resulting in those disallowed characters being sent as the request-target in a malformed request-line.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 307
+      line: 315
   - label: request_target_form_valid (5)
     section: § 3.2.1
     snippet: When making a request directly to an origin server, other than a CONNECT or server-wide OPTIONS request (as detailed below), a client MUST send only the absolute path and query components of the target URI as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 432
+      line: 441
   - label: origin-form
     section: § 3.2.1
     snippet: origin-form    = absolute-path [ "?" query ]
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 117
+      line: 125
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 208
   - label: request_target_form_valid (6)
@@ -10197,19 +10197,19 @@ sources:
     snippet: A server MUST accept the absolute-form in requests even though most HTTP/1.1 clients will only send the absolute-form to a proxy.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 434
+      line: 443
   - label: request_target_form_valid (7)
     section: § 3.2.2
     snippet: When making a request to a proxy, other than a CONNECT or server-wide OPTIONS request (as detailed below), a client MUST send the target URI in "absolute-form" as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 433
+      line: 442
   - label: absolute-form
     section: § 3.2.2
     snippet: absolute-form  = absolute-URI
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 118
+      line: 126
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 207
   - label: request_target_form_valid (8)
@@ -10217,47 +10217,47 @@ sources:
     snippet: It consists of only the uri-host and port number of the tunnel destination, separated by a colon (":").
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 350
+      line: 359
   - label: request_target_form_valid (9)
     section: § 3.2.3
     snippet: The "authority-form" of request-target is only used for CONNECT requests
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 399
+      line: 408
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 415
+      line: 424
   - label: request_target_form_valid (10)
     section: § 3.2.3
     snippet: The client obtains the host and port from the target URI's authority component, except that it sends the scheme's default port if the target URI elides the port.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 361
+      line: 370
   - label: request_target_form_valid (11)
     section: § 3.2.3
     snippet: When making a CONNECT request to establish a tunnel through one or more proxies, a client MUST send only the host and port of the tunnel destination as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 351
+      line: 360
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 185
+      line: 219
   - label: request_target_form_valid (12)
     section: § 3.2.4
     snippet: The "asterisk-form" of request-target is only used for a server-wide OPTIONS request
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 386
+      line: 395
   - label: request_target_form_valid (13)
     section: § 3.2.4
     snippet: When a client wishes to request OPTIONS for the server as a whole, as opposed to a specific named resource of that server, the client MUST send only "*" (%x2A) as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 387
+      line: 396
   - label: asterisk-form
     section: § A
     snippet: asterisk-form = "*" authority = <authority, see [URI], Section 3.2>
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 126
+      line: 134
   - label: response_body_length_accuracy
     section: § 6.3
     snippet: A client MUST ignore any Content-Length or Transfer-Encoding header fields received in such a message.
@@ -10424,7 +10424,7 @@ sources:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 512
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 274
+      line: 282
   - label: host_and_authority_consistent (2)
     section: § 8.3.1
     snippet: A server SHOULD treat a request as malformed if it contains a Host header field that identifies an entity that differs from the entity in the ":authority" pseudo-header field.
@@ -10600,13 +10600,13 @@ sources:
     snippet: All HTTP/2 requests MUST include exactly one valid value for the ":method", ":scheme", and ":path" pseudo-header fields, unless they are CONNECT requests (Section 8.5).
     cited_by:
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 217
+      line: 251
   - label: request_target_form_valid
     section: § 8.3.1
     snippet: Note that request targets for CONNECT or asterisk-form OPTIONS requests never include authority information
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 275
+      line: 283
   - label: request_target_no_fragment
     section: § 8.3.1
     snippet: The ":path" pseudo-header field includes the path and query parts of the target URI
@@ -10945,13 +10945,13 @@ sources:
     snippet: This pseudo-header field MUST NOT be empty for "http" or "https" URIs; "http" or "https" URIs that do not contain a path component MUST include a value of / (ASCII 0x2f).
     cited_by:
     - file: lint-http-rules/src/violations/request_target.rs
-      line: 218
+      line: 252
   - label: request_target_form_valid
     section: § 4.3.1
     snippet: An OPTIONS request that does not include a path component includes the value * (ASCII 0x2a) for the :path pseudo-header field
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 276
+      line: 284
   - label: request_target_no_fragment
     section: § 4.3.1
     snippet: Contains the path and query parts of the target URI


### PR DESCRIPTION
`request_target_form_ambiguous` joins the request-target subject and takes the last site `request_target_form_valid` had: a target deriving from the authority-form and the absolute-form at once. `example.com` is a `scheme` as well as a `reg-name`, so `GET example.com:443` is CONNECT's target used by a method that may not use it *and* an ordinary proxy request for a resource under a scheme named `example.com`, and nothing else in the request-line chooses between them.

The closed vocabulary grows by `_ambiguous`, and the trigger is the one that tells an ending is missing rather than awkward: every existing word makes a claim this finding cannot support. Not `_malformed` — both readings derive. Not `_invalid` or `_forbidden` — one of them is conforming. Not `_conflicting` — nothing in the message disagrees with anything else in it; the message disagrees with itself only in the reading. What is being reported is that two recipients on one chain may route the request two ways.

So it is the first entry here that reports no verdict about the message, and the ending carries that in its rank: `warn`, never `error`, because an entry that cannot say the message is wrong may not rank with the ones that can. It carries no sentence for the same reason. Its neighbour does — a left half no `scheme` can open is §7.1's MUST NOT established, and that is a different id.

The rule now declares an entry for every finding it makes, so its judge yields a `&ViolationDef` rather than an `Option` of one, and the arm that reported at the rule's own severity is gone.

`DEFECT_ENDINGS` and the table in docs/development.md move together, as that page requires.

Floor: 204 of 211 entries cite a sentence.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
