### PR TITLE
A port no transport could open

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1091,6 +1091,10 @@ severity = "error"
 # A CONNECT's destination ends at the colon with no port
 severity = "error"
 
+[violations.authority_tunnel_port_invalid]
+# A CONNECT's destination names a port no transport has
+severity = "error"
+
 [violations.authority_tunnel_port_missing]
 # A CONNECT's destination names no port
 severity = "error"

--- a/docs/rules/request_target_form_valid.md
+++ b/docs/rules/request_target_form_valid.md
@@ -35,6 +35,7 @@ Reads an HTTP/1.x request-line's request-target and asks two things: which of th
 - [RFC 9110 §7.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.1): Determining the Target Resource — the two method-specific forms, the MUST NOT that keeps each to its method, and the reconstruction being specific to each major protocol version
 - [RFC 9110 §2.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2): Conformance — a sender MUST NOT generate protocol elements that do not match the grammar defined by the corresponding ABNF rules
 - [RFC 9110 §9.3.6](https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.6): CONNECT — the host and port number of the tunnel destination, the absence of a default port, and the server's MUST to reject an empty or invalid one. This is where the port requirements come from; the grammar states none.
+- [RFC 6335 §6](https://www.rfc-editor.org/rfc/rfc6335.html#section-6): Port Number Ranges — the 16-bit namespace that bounds a CONNECT's port above, and the reserved edge values that are why `0` is not reported
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
+++ b/lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
@@ -6,9 +6,9 @@ use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
 use crate::violations::authority::{
     AUTHORITY_TUNNEL_HOST_EMPTY, AUTHORITY_TUNNEL_MISSING, AUTHORITY_TUNNEL_PORT_EMPTY,
-    AUTHORITY_TUNNEL_PORT_MISSING, AUTHORITY_TUNNEL_USERINFO_FORBIDDEN,
-    AUTHORITY_USERINFO_FORBIDDEN, RFC_9110_9_3_6, RFC_9113_8_3_1, RFC_9113_8_5, RFC_9114_4_3_1,
-    RFC_9114_4_4,
+    AUTHORITY_TUNNEL_PORT_INVALID, AUTHORITY_TUNNEL_PORT_MISSING,
+    AUTHORITY_TUNNEL_USERINFO_FORBIDDEN, AUTHORITY_USERINFO_FORBIDDEN, RFC_9110_9_3_6,
+    RFC_9113_8_3_1, RFC_9113_8_5, RFC_9114_4_3_1, RFC_9114_4_4,
 };
 use crate::violations::request_target::{
     REQUEST_TARGET_ASTERISK_FORBIDDEN, REQUEST_TARGET_PATH_MISSING, RFC_9110_7_1,
@@ -71,36 +71,27 @@ static DECLARED: &[&ViolationDef] = &[
     &AUTHORITY_TUNNEL_PORT_MISSING,
     &AUTHORITY_TUNNEL_PORT_EMPTY,
     &AUTHORITY_TUNNEL_HOST_EMPTY,
+    &AUTHORITY_TUNNEL_PORT_INVALID,
 ];
 
 /// One finding from the CONNECT reading, and the defect it reports as where
 /// the catalogue names that defect.
 ///
-/// The shape `expect_header_valid` settled: a judge that is half converted says
-/// so in its type — and this one is nearly whole. Named: the authority's
-/// grammar, the userinfo the tunnel form has no room for, and the three ways
-/// `uri-host ":" port` derives a value with one of its two components missing.
-/// Unnamed: a port number outside the transport's namespace, whose sentence is
-/// not § 9.3.6's at all but RFC 6335's sixteen bits, reached through the one
-/// sentence that says a proxy opens a *TCP* connection.
+/// One finding from the CONNECT reading, and the entry the catalogue names it
+/// by. Every arm has one now — the authority's grammar, the userinfo the tunnel
+/// form has no room for, the three ways `uri-host ":" port` derives a value
+/// missing one of its two components, and a port number outside the transport's
+/// namespace — so what is left of the half-converted shape
+/// `expect_header_valid` settled is a plain pair.
 struct Defect {
-    def: Option<&'static ViolationDef>,
+    def: &'static ViolationDef,
     message: String,
 }
 
 impl Defect {
-    /// A defect the catalogue names.
+    /// A defect the catalogue names, which by now is all of them.
     fn named(def: &'static ViolationDef, message: String) -> Self {
-        Self {
-            def: Some(def),
-            message,
-        }
-    }
-
-    /// A defect no subject has claimed yet, reported at the rule's severity the
-    /// way every finding here was before the catalogue existed.
-    fn unnamed(message: String) -> Self {
-        Self { def: None, message }
+        Self { def, message }
     }
 }
 
@@ -186,9 +177,10 @@ fn connect_authority_finding(authority: &str) -> Option<Defect> {
             ),
         )),
         Some(port) => connect_port_range_finding(port).map(|msg| {
-            Defect::unnamed(format!(
-                "CONNECT ':authority' '{shown}' targets an invalid port number: {msg}"
-            ))
+            Defect::named(
+                &AUTHORITY_TUNNEL_PORT_INVALID,
+                format!("CONNECT ':authority' '{shown}' targets an invalid port number: {msg}"),
+            )
         }),
     }
 }
@@ -496,10 +488,7 @@ impl Rule for Http2PseudoHeadersValid {
                 // cite(RFC 9113 § 8.5): "A CONNECT request that does not conform to these restrictions is malformed (Section 8.1.1)."
                 if target_authority.is_some() && absolute_form.is_none() {
                     if let Some(defect) = connect_authority_finding(target) {
-                        return Some(match defect.def {
-                            Some(def) => ctx.report_with(def, defect.message),
-                            None => self.violation(ctx.severity, defect.message),
-                        });
+                        return Some(ctx.report_with(defect.def, defect.message));
                     }
                 }
             } else {

--- a/lint-http-rules/src/rules/request_target_form_valid.rs
+++ b/lint-http-rules/src/rules/request_target_form_valid.rs
@@ -5,7 +5,8 @@
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
 use crate::violations::authority::{
-    AUTHORITY_TUNNEL_HOST_EMPTY, AUTHORITY_TUNNEL_PORT_EMPTY, RFC_9110_9_3_6,
+    AUTHORITY_TUNNEL_HOST_EMPTY, AUTHORITY_TUNNEL_PORT_EMPTY, AUTHORITY_TUNNEL_PORT_INVALID,
+    RFC_9110_9_3_6,
 };
 use crate::violations::request_target::{
     REQUEST_TARGET_ASTERISK_FORBIDDEN, REQUEST_TARGET_AUTHORITY_FORM_FORBIDDEN,
@@ -26,6 +27,12 @@ use crate::violations::ViolationDef;
 /// reported as the ambiguity it is, because one of its two readings is
 /// conforming and the request-line says nothing that chooses. With it this rule
 /// declares an entry for every finding it makes.
+///
+/// **A port outside the transport's namespace is the fourth**, and it is the
+/// destination's too: `port = *DIGIT` bounds nothing, so what refuses `70000` is
+/// the sentence saying this method opens a *TCP* connection and the sixteen bits
+/// TCP's registry uses. The HTTP/2 twin has read it that way since it was
+/// converted; this rule had not read it at all.
 ///
 /// **A CONNECT in some other form is the third**, and it is the mirror of the
 /// second: § 7.1 forbids another method from reaching for CONNECT's form, and
@@ -64,6 +71,7 @@ static DECLARED: &[&ViolationDef] = &[
     &REQUEST_TARGET_AUTHORITY_FORM_FORBIDDEN,
     &AUTHORITY_TUNNEL_HOST_EMPTY,
     &AUTHORITY_TUNNEL_PORT_EMPTY,
+    &AUTHORITY_TUNNEL_PORT_INVALID,
     &REQUEST_TARGET_CONNECT_FORM_INVALID,
     &REQUEST_TARGET_FORM_AMBIGUOUS,
 ];
@@ -180,6 +188,12 @@ pub struct RequestTargetFormValid;
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
+const RFC_6335_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6335",
+    section: Some("6"),
+    url: "https://www.rfc-editor.org/rfc/rfc6335.html#section-6",
+    note: "Port Number Ranges — the 16-bit namespace that bounds a CONNECT's port above, and the reserved edge values that are why `0` is not reported",
+};
 const RFC_9112_3_2_4: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9112",
     section: Some("3.2.4"),
@@ -213,6 +227,10 @@ severity = "error"
             // every version: the entries this rule borrows for a target with
             // half an authority carry its sentences, so the docs name it here.
             RFC_9110_9_3_6,
+            // The width the port number is measured against, which no HTTP
+            // document states: § 9.3.6 says a server rejects an invalid port and
+            // this is what says which numbers those are.
+            RFC_6335_6,
         ]
     }
 
@@ -374,6 +392,26 @@ impl Rule for RequestTargetFormValid {
                         "CONNECT request-target '{shown}' carries the port's delimiter and no port. `port` is `*DIGIT`, so the grammar admits this, and a client with no port to copy sends the scheme's default one -- a recipient reading this has a host and no number to open the tunnel on"
                     ),
                 ),
+                // The number is inside the grammar and outside the transport.
+                // `port` is `*DIGIT` and bounds nothing, so what refuses `70000`
+                // is that this method opens a TCP connection to the host and
+                // port — sixteen bits of namespace — and that a server is
+                // required to reject a request targeting an invalid port number.
+                // The same reading the HTTP/2 twin makes of an `:authority`, and
+                // the same reader carrying the width; `0` is inside the
+                // namespace and is not reported.
+                // cite(RFC 9112 § 3.2.3): "When making a CONNECT request to establish a tunnel through one or more proxies, a client MUST send only the host and port of the tunnel destination as the request-target."
+                // cite(RFC 6335 § 6): "TCP, UDP, UDP-Lite, SCTP, and DCCP use 16-bit namespaces for their port number registries."
+                (Some(TargetForm::Authority { port, .. }), "CONNECT")
+                    if crate::helpers::uri::port_number(port).is_none() =>
+                {
+                    (
+                        &AUTHORITY_TUNNEL_PORT_INVALID,
+                        format!(
+                            "CONNECT request-target '{shown}' targets the port '{port}', and a TCP port number is one of 65536 values: `port` is `*DIGIT` and bounds nothing, so the number is the transport's to refuse and a server is required to reject a CONNECT targeting an invalid one"
+                        ),
+                    )
+                }
                 (Some(TargetForm::Authority { .. }), "CONNECT") => return None,
                 (Some(other), "CONNECT") => (
                     &REQUEST_TARGET_CONNECT_FORM_INVALID,
@@ -503,6 +541,37 @@ mod tests {
             violation != "request_target_form_ambiguous",
             "{target}"
         );
+    }
+
+    /// The port a tunnel cannot be opened on. `port = *DIGIT` bounds nothing, so
+    /// the number answers to the transport this method names — and `0` is inside
+    /// that namespace, a reserved value rather than an invalid one.
+    #[rstest]
+    #[case("example.com:70000", Some("authority_tunnel_port_invalid"))]
+    #[case(
+        "example.com:99999999999999999999",
+        Some("authority_tunnel_port_invalid")
+    )]
+    #[case("example.com:0", None)]
+    #[case("example.com:65535", None)]
+    fn a_port_outside_the_transports_namespace_is_reported(
+        #[case] target: &str,
+        #[case] violation: Option<&str>,
+    ) {
+        let rule = RequestTargetFormValid;
+        let mut tx = crate::test_helpers::make_test_transaction();
+        tx.request.method = "CONNECT".into();
+        tx.request.uri = target.into();
+        let finding = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_severity(rule.id(), "error"),
+        );
+        match violation {
+            Some(id) => assert_eq!(finding.expect("a finding").violation, id, "{target}"),
+            None => assert!(finding.is_none(), "{target}"),
+        }
     }
 
     /// A CONNECT whose target is one of the other three forms names no tunnel

--- a/lint-http-rules/src/violations/authority.rs
+++ b/lint-http-rules/src/violations/authority.rs
@@ -227,6 +227,41 @@ defects! {
         spec: &[RFC_9110_9_3_6],
     }
 
+    /// A CONNECT whose destination names a port number no transport has. `port`
+    /// is `*DIGIT` and bounds nothing at either end, so `70000` and
+    /// `99999999999999999999` both derive — and the sentence beside the empty
+    /// port refuses them in the same breath: a server is told to reject a
+    /// request targeting an *empty or invalid* port number.
+    ///
+    /// **What makes a number invalid is not in either sentence, and that is the
+    /// reading.** § 9.3.6 says a server rejects one and says nothing about which
+    /// numbers those are; what supplies the bound is that this method opens a
+    /// *TCP* connection to the host and port, and TCP's port namespace is
+    /// sixteen bits wide (RFC 6335 § 6). So the entry names the sentence that
+    /// makes it a defect and the rule declaring it names the two that supply the
+    /// width — **a bound reached through a transport is still the requirement's
+    /// defect, not the transport's.**
+    ///
+    /// **`0` is not reported.** It is inside the namespace: a reserved value at
+    /// the edge of a range, held back for extending the ranges later, and no
+    /// sentence here makes a reserved port an invalid one. The check this entry
+    /// replaced in one rule rejected it under the same message as `70000`.
+    ///
+    /// **Not the same as a port outside a `Host` field's range, which is
+    /// nobody's finding.** There the only sentence is `port = *DIGIT`, which
+    /// bounds nothing, and `host_header` says so in its description; here the
+    /// method's own section names the transport, which is what licenses the
+    /// bound.
+    ///
+    // cite(RFC 9110 § 9.3.6): "A server MUST reject a CONNECT request that targets an empty or invalid port number, typically by responding with a 400 (Bad Request) status code."
+    AUTHORITY_TUNNEL_PORT_INVALID = {
+        id: "authority_tunnel_port_invalid",
+        title: "A CONNECT's destination names a port no transport has",
+        message: "",
+        default_severity: Severity::Error,
+        spec: &[RFC_9110_9_3_6],
+    }
+
     /// A CONNECT whose destination names a host and no port at all — no colon
     /// anywhere in it. Every other request-target elides a port and lets the
     /// scheme supply one; this method has no scheme and no default, so the

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -418,7 +418,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 204;
+        const FLOOR: usize = 205;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1470,7 +1470,7 @@ sources:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 394
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 154
+      line: 162
   - label: lint-http-rules/src/helpers/uri.rs (26)
     section: § 4.2
     snippet: A relative reference that begins with two slash characters is termed a network-path reference; such references are rarely used.
@@ -1490,7 +1490,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 282
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 128
+      line: 136
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 206
   - label: lint-http-rules/src/helpers/uri.rs (27)
@@ -2445,7 +2445,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 336
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 212
+      line: 204
   - label: lint-http-rules/src/helpers/uri.rs (2)
     section: § 6
     snippet: TCP, UDP, UDP-Lite, SCTP, and DCCP use 16-bit namespaces for their port number registries.
@@ -2455,7 +2455,9 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 335
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 211
+      line: 203
+    - file: lint-http-rules/src/rules/request_target_form_valid.rs
+      line: 404
 - label: RFC 6454
   url: https://www.rfc-editor.org/rfc/rfc6454.html
   fragments:
@@ -4441,13 +4443,13 @@ sources:
     snippet: A new pseudo-header field :protocol MAY be included on request HEADERS indicating the desired protocol to be spoken on the tunnel created by CONNECT.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 456
+      line: 448
   - label: http2_pseudo_headers_valid (2)
     section: § 4
     snippet: On requests that contain the :protocol pseudo-header field, the :scheme and :path pseudo-header fields of the target URI (see Section 5) MUST also be included.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 457
+      line: 449
   - label: lint-http-rules/src/helpers/websocket.rs
     section: § 5
     snippet: Implementations using this extended CONNECT to bootstrap WebSockets do not do the processing of the Sec-WebSocket-Key and Sec-WebSocket-Accept header fields of [RFC6455] as that functionality has been superseded by the :protocol pseudo-header field.
@@ -5037,7 +5039,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 355
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 446
+      line: 438
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
       line: 259
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
@@ -5055,7 +5057,7 @@ sources:
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
       line: 377
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 293
+      line: 311
     - file: lint-http-rules/src/rules/request_version_method_valid.rs
       line: 167
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
@@ -5277,11 +5279,11 @@ sources:
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
       line: 353
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 317
+      line: 335
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 331
+      line: 349
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 449
+      line: 487
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 221
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
@@ -5307,7 +5309,7 @@ sources:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 126
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 423
+      line: 415
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
       line: 245
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
@@ -6241,15 +6243,17 @@ sources:
     snippet: A server MUST reject a CONNECT request that targets an empty or invalid port number, typically by responding with a 400 (Bad Request) status code.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 126
+      line: 117
     - file: lint-http-rules/src/violations/authority.rs
       line: 221
+    - file: lint-http-rules/src/violations/authority.rs
+      line: 256
   - label: http2_pseudo_headers_valid (2)
     section: § 9.3.6
     snippet: CONNECT uses a special form of request target, unique to this method, consisting of only the host and port number of the tunnel destination, separated by a colon.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 124
+      line: 115
     - file: lint-http-rules/src/violations/authority.rs
       line: 182
     - file: lint-http-rules/src/violations/authority.rs
@@ -6259,9 +6263,9 @@ sources:
     snippet: There is no default port; a client MUST send the port number even if the CONNECT request is based on a URI reference that contains an authority component with an elided port (Section 4.1).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 125
+      line: 116
     - file: lint-http-rules/src/violations/authority.rs
-      line: 245
+      line: 280
   - label: if_match_etag_syntax
     section: § 13.1.1
     snippet: 'If-Match = "*" / #entity-tag'
@@ -6445,7 +6449,7 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 86
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 277
+      line: 295
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 201
   - label: lint-http-core/src/http_version.rs (3)
@@ -7651,7 +7655,7 @@ sources:
     - file: lint-http-rules/src/rules/host_header.rs
       line: 52
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 474
+      line: 466
   - label: lint-http-rules/src/helpers/uri.rs (6)
     section: § 7.2
     snippet: The "Host" header field in a request provides the host and port information from the target URI, enabling the origin server to distinguish among resources while servicing requests for multiple host names.
@@ -8547,13 +8551,13 @@ sources:
     snippet: absolute-path = 1*( "/" segment )
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 146
+      line: 154
   - label: request_target_form_valid
     section: § 7.1
     snippet: For CONNECT (Section 9.3.6), the request target is the host name and port number of the tunnel destination, separated by a colon.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 358
+      line: 376
     - file: lint-http-rules/src/violations/request_target.rs
       line: 150
   - label: request_target_form_valid (2)
@@ -8561,7 +8565,7 @@ sources:
     snippet: For historical reasons, the parsed target URI components, collectively referred to as the "request target", are sent within the message control data and the Host header field
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 278
+      line: 296
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 151
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
@@ -8571,13 +8575,13 @@ sources:
     snippet: There are two unusual cases for which the request target components are in a method-specific form
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 345
+      line: 363
   - label: request_target_form_valid (4)
     section: § 7.1
     snippet: These forms MUST NOT be used with other methods.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 346
+      line: 364
     - file: lint-http-rules/src/violations/request_target.rs
       line: 117
     - file: lint-http-rules/src/violations/request_target.rs
@@ -8587,7 +8591,7 @@ sources:
     snippet: This reconstruction is specific to each major protocol version.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 279
+      line: 297
   - label: request_target_no_fragment
     section: § 4.2.5
     snippet: Some protocol elements that refer to a URI allow inclusion of a fragment, while others do not.
@@ -9939,9 +9943,9 @@ sources:
     snippet: authority-form = uri-host ":" port
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 123
+      line: 114
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 127
+      line: 135
   - label: http_version_syntax
     section: § 1.1
     snippet: Conformance criteria and considerations regarding error handling are defined in Section 2 of [HTTP].
@@ -9983,7 +9987,7 @@ sources:
     - file: lint-http-core/src/http_version.rs
       line: 103
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 281
+      line: 299
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 202
   - label: lint-http-core/src/http_version.rs
@@ -10003,7 +10007,7 @@ sources:
     - file: lint-http-rules/src/rules/http_version_syntax.rs
       line: 162
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 280
+      line: 298
   - label: HTTP-name
     section: § A
     snippet: HTTP-name = %x48.54.54.50 ; HTTP
@@ -10037,7 +10041,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 619
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 76
+      line: 84
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
       line: 289
   - label: lint-http-rules/src/helpers/uri.rs (2)
@@ -10155,13 +10159,13 @@ sources:
     snippet: A recipient SHOULD NOT attempt to autocorrect and then process the request without a redirect, since the invalid request-line might be deliberately crafted to bypass security filters along the request chain.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 316
+      line: 334
   - label: request_target_form_valid (2)
     section: § 3.2
     snippet: No whitespace is allowed in the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 314
+      line: 332
     - file: lint-http-rules/src/violations/request_target.rs
       line: 281
   - label: request_target_form_valid (3)
@@ -10169,27 +10173,27 @@ sources:
     snippet: Recipients of an invalid request-line SHOULD respond with either a 400 (Bad Request) error or a 301 (Moved Permanently) redirect with the request-target properly encoded.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 332
+      line: 350
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 450
+      line: 488
   - label: request_target_form_valid (4)
     section: § 3.2
     snippet: Unfortunately, some user agents fail to properly encode or exclude whitespace found in hypertext references, resulting in those disallowed characters being sent as the request-target in a malformed request-line.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 315
+      line: 333
   - label: request_target_form_valid (5)
     section: § 3.2.1
     snippet: When making a request directly to an origin server, other than a CONNECT or server-wide OPTIONS request (as detailed below), a client MUST send only the absolute path and query components of the target URI as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 441
+      line: 479
   - label: origin-form
     section: § 3.2.1
     snippet: origin-form    = absolute-path [ "?" query ]
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 125
+      line: 133
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 208
   - label: request_target_form_valid (6)
@@ -10197,19 +10201,19 @@ sources:
     snippet: A server MUST accept the absolute-form in requests even though most HTTP/1.1 clients will only send the absolute-form to a proxy.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 443
+      line: 481
   - label: request_target_form_valid (7)
     section: § 3.2.2
     snippet: When making a request to a proxy, other than a CONNECT or server-wide OPTIONS request (as detailed below), a client MUST send the target URI in "absolute-form" as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 442
+      line: 480
   - label: absolute-form
     section: § 3.2.2
     snippet: absolute-form  = absolute-URI
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 126
+      line: 134
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
       line: 207
   - label: request_target_form_valid (8)
@@ -10217,27 +10221,29 @@ sources:
     snippet: It consists of only the uri-host and port number of the tunnel destination, separated by a colon (":").
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 359
+      line: 377
   - label: request_target_form_valid (9)
     section: § 3.2.3
     snippet: The "authority-form" of request-target is only used for CONNECT requests
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 408
+      line: 446
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 424
+      line: 462
   - label: request_target_form_valid (10)
     section: § 3.2.3
     snippet: The client obtains the host and port from the target URI's authority component, except that it sends the scheme's default port if the target URI elides the port.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 370
+      line: 388
   - label: request_target_form_valid (11)
     section: § 3.2.3
     snippet: When making a CONNECT request to establish a tunnel through one or more proxies, a client MUST send only the host and port of the tunnel destination as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 360
+      line: 378
+    - file: lint-http-rules/src/rules/request_target_form_valid.rs
+      line: 403
     - file: lint-http-rules/src/violations/request_target.rs
       line: 219
   - label: request_target_form_valid (12)
@@ -10245,19 +10251,19 @@ sources:
     snippet: The "asterisk-form" of request-target is only used for a server-wide OPTIONS request
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 395
+      line: 433
   - label: request_target_form_valid (13)
     section: § 3.2.4
     snippet: When a client wishes to request OPTIONS for the server as a whole, as opposed to a specific named resource of that server, the client MUST send only "*" (%x2A) as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 396
+      line: 434
   - label: asterisk-form
     section: § A
     snippet: asterisk-form = "*" authority = <authority, see [URI], Section 3.2>
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 134
+      line: 142
   - label: response_body_length_accuracy
     section: § 6.3
     snippet: A client MUST ignore any Content-Length or Transfer-Encoding header fields received in such a message.
@@ -10422,9 +10428,9 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 354
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 512
+      line: 501
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 282
+      line: 300
   - label: host_and_authority_consistent (2)
     section: § 8.3.1
     snippet: A server SHOULD treat a request as malformed if it contains a Host header field that identifies an entity that differs from the entity in the ":authority" pseudo-header field.
@@ -10452,7 +10458,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 337
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 552
+      line: 541
   - label: host_and_authority_consistent (6)
     section: § 8.3.1
     snippet: The values of fields need to be normalized to compare them (see Section 6.2 of [RFC3986]).
@@ -10464,25 +10470,25 @@ sources:
     snippet: A field value MUST NOT start or end with an ASCII whitespace character (ASCII SP or HTAB, 0x20 or 0x09).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 436
+      line: 428
   - label: http2_pseudo_headers_valid (2)
     section: § 8.3
     snippet: Endpoints MUST treat a request or response that contains undefined or invalid pseudo-header fields as malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 424
+      line: 416
   - label: http2_pseudo_headers_valid (3)
     section: § 8.3.1
     snippet: '":scheme" is not restricted to "http" and "https" schemed URIs.'
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 557
+      line: 546
   - label: http2_pseudo_headers_valid (4)
     section: § 8.3.1
     snippet: The ":method" pseudo-header field includes the HTTP method (Section 9 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 419
+      line: 411
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
       line: 320
   - label: http2_pseudo_headers_valid (5)
@@ -10490,49 +10496,49 @@ sources:
     snippet: The ":scheme" pseudo-header field includes the scheme portion of the request target.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 551
+      line: 540
   - label: http2_pseudo_headers_valid (6)
     section: § 8.3.2
     snippet: For HTTP/2 responses, a single ":status" pseudo-header field is defined that carries the HTTP status code field (see Section 15 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 667
+      line: 656
   - label: http2_pseudo_headers_valid (7)
     section: § 8.3.2
     snippet: This pseudo-header field MUST be included in all responses, including interim responses; otherwise, the response is malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 668
+      line: 657
   - label: http2_pseudo_headers_valid (8)
     section: § 8.5
     snippet: A CONNECT request that does not conform to these restrictions is malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 496
+      line: 488
     - file: lint-http-rules/src/violations/authority.rs
-      line: 287
+      line: 322
   - label: http2_pseudo_headers_valid (9)
     section: § 8.5
     snippet: A proxy that supports CONNECT establishes a TCP connection [TCP] to the host and port identified in the ":authority" pseudo-header field.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 210
+      line: 202
   - label: http2_pseudo_headers_valid (10)
     section: § 8.5
     snippet: The ":authority" pseudo-header field contains the host and port to connect to (equivalent to the authority-form of the request-target of CONNECT requests; see Section 3.2.3 of [HTTP/1.1]).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 122
+      line: 113
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 495
+      line: 487
     - file: lint-http-rules/src/violations/authority.rs
-      line: 286
+      line: 321
   - label: http2_pseudo_headers_valid (11)
     section: § 8.5
     snippet: The ":method" pseudo-header field is set to CONNECT.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 447
+      line: 439
   - label: lint-http-core/src/http_version.rs
     section: § 8.3.1
     snippet: All HTTP/2 requests implicitly have a protocol version of "2.0"
@@ -10606,7 +10612,7 @@ sources:
     snippet: Note that request targets for CONNECT or asterisk-form OPTIONS requests never include authority information
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 283
+      line: 301
   - label: request_target_no_fragment
     section: § 8.3.1
     snippet: The ":path" pseudo-header field includes the path and query parts of the target URI
@@ -10649,13 +10655,13 @@ sources:
     snippet: 'A CONNECT request MUST be constructed as follows:'
     cited_by:
     - file: lint-http-rules/src/violations/authority.rs
-      line: 288
+      line: 323
   - label: authority (3)
     section: § 4.4
     snippet: The :authority pseudo-header field contains the host and port to connect to (equivalent to the authority-form of the request-target of CONNECT requests; see Section 7.1 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/violations/authority.rs
-      line: 289
+      line: 324
   - label: extension_headers_registered
     section: § 4.2
     snippet: A request or response containing uppercase characters in field names MUST be treated as malformed
@@ -10687,7 +10693,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 415
     - file: lint-http-rules/src/violations/authority.rs
-      line: 332
+      line: 367
   - label: host_and_authority_consistent (3)
     section: § 4.3.1
     snippet: If these fields are present, they MUST NOT be empty.
@@ -10697,7 +10703,7 @@ sources:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
       line: 435
     - file: lint-http-rules/src/violations/authority.rs
-      line: 370
+      line: 405
   - label: http3_goaway_semantics
     section: § 5.2
     snippet: Endpoints MUST NOT initiate new requests or promise new pushes on the connection after receipt of a GOAWAY frame from the peer.
@@ -10951,7 +10957,7 @@ sources:
     snippet: An OPTIONS request that does not include a path component includes the value * (ASCII 0x2a) for the :path pseudo-header field
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 284
+      line: 302
   - label: request_target_no_fragment
     section: § 4.3.1
     snippet: Contains the path and query parts of the target URI


### PR DESCRIPTION
`authority_tunnel_port_invalid` joins the authority subject and takes the last unnamed arm of the HTTP/2 rule's CONNECT judge — and the reading it carries goes to the HTTP/1.x rule too, which had never made it.

`port = *DIGIT` bounds nothing at either end, so `70000` derives and the grammar has nothing to say. What refuses it is that this method opens a TCP connection to the host and port, and TCP's port namespace is sixteen bits wide; what makes that a defect rather than an observation is RFC 9110 §9.3.6's requirement that a server reject a CONNECT targeting an empty or invalid port number. The entry names the sentence that condemns it and the rules name the two that supply the width — a bound reached through a transport is still the requirement's defect.

`0` is not reported. It is inside the namespace, a reserved value at the edge of a range, and no sentence here makes a reserved port an invalid one.

Not the same as a port out of range in a `Host` field, which is nobody's finding: there the only sentence is the production, which bounds nothing, and `host_header` says so. The method's own section naming the transport is what licenses the bound.

With this arm named, the HTTP/2 rule's judge carries a `&ViolationDef` rather than an `Option` of one, and its unnamed constructor is gone.

Floor: 205 of 212 entries cite a sentence.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
