### PR TITLE
What a Via member says about its parts

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1899,6 +1899,22 @@ severity = "warn"
 # URI scheme does not begin with a letter
 severity = "warn"
 
+[violations.via_comment_duplicated]
+# Via member carries more than one comment
+severity = "warn"
+
+[violations.via_member_malformed]
+# Via member does not end where the production ends it
+severity = "warn"
+
+[violations.via_received_by_missing]
+# Via member names no received-by
+severity = "warn"
+
+[violations.via_received_by_obsolete]
+# Via received-by is spelled as a uri-host
+severity = "warn"
+
 [violations.weight_equals_whitespace_forbidden]
 # Whitespace is written beside the weight's '='
 severity = "warn"

--- a/docs/rules/via_header_syntax.md
+++ b/docs/rules/via_header_syntax.md
@@ -18,7 +18,7 @@ What the rule does not judge: whether a proxy sent a `Via` at all. §7.6.3's MUS
 
 ## Specifications
 
-- [RFC 9110 §7.6.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.3): The `Via` grammar this rule parses, the sentence that puts the field in both directions, and the requirements about forwarding and combining that a single captured message cannot answer
+- [RFC 9110 §7.6.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.3): The `Via` grammar — `Via = #( received-protocol RWS received-by [ RWS comment ] )` — the sentence that puts the field in both directions, and the requirements about forwarding and combining that a single captured message cannot answer
 - [RFC 9110 §7.8](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8): `received-protocol` points here for its two halves: `protocol-name = token` and `protocol-version = token`
 - [RFC 9110 §B.2](https://www.rfc-editor.org/rfc/rfc9110.html#appendix-B.2): Why a `received-by` is a token: RFC 9110 removed `uri-host` from the production, which is what makes a bracketed IPv6 literal a finding here and not under RFC 7230
 - [RFC 9110 §5.6.5](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.5): Comments — `comment = "(" *( ctext / quoted-pair / comment ) ")"`, the `ctext` class, and the self-reference that makes a comment nestable

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1370,7 +1370,18 @@ severity = "warn"
         /// *trailer* sentence rather than the requirement it reports — the entry
         /// names § 15.5.22 and the trailer nuance stays in the message, where it
         /// was always the aside.
-        const FLOOR: usize = 106;
+        ///
+        /// **The `via` subject took one more, and it is one site standing for
+        /// seven.** `via_header_syntax` cited § 7.6.3 once, from the arm that
+        /// reported everything the member's *assembly* got wrong — a missing
+        /// `received-by`, a second comment, trailing content, a `received-by`
+        /// spelled as the `uri-host` § B.2 removed. Four entries now hold those,
+        /// each naming the sentence it enforces, so every one of those findings
+        /// is still cited and three of them are cited by a reference the site
+        /// never carried. **A count of cited sites falls fastest where one site
+        /// was standing in for several defects**, which is the shape a
+        /// half-converted judge has by construction.
+        const FLOOR: usize = 105;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/rules/via_header_syntax.rs
+++ b/lint-http-rules/src/rules/via_header_syntax.rs
@@ -19,11 +19,15 @@ use crate::violations::token::{
     TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
 };
 use crate::violations::uri::{RFC_3986_3_2_3, URI_PORT_CHARACTER_FORBIDDEN};
+use crate::violations::via::{
+    RFC_9110_7_6_3, RFC_9110_B_2, VIA_COMMENT_DUPLICATED, VIA_MEMBER_MALFORMED,
+    VIA_RECEIVED_BY_MISSING, VIA_RECEIVED_BY_OBSOLETE,
+};
 use crate::violations::ViolationDef;
 
 pub struct ViaHeaderSyntax;
 
-/// Every production this field is assembled from, and none of its assembly.
+/// Every production this field is assembled from, and its assembly beside them.
 ///
 /// `Via = #( received-protocol RWS received-by [ RWS comment ] )` names four
 /// things and defines none of them: the `#` list, the two `token`s a
@@ -32,12 +36,14 @@ pub struct ViaHeaderSyntax;
 /// holding a bad octet answers with the same id an `Upgrade`, a `Server` or a
 /// `Content-Type` parameter would.
 ///
-/// What stays this rule's own is what the *member* says about its parts: a
-/// `received-by` that is missing, a second comment where the production
-/// permits one, content after a member that has ended, and the bracketed IPv6
-/// literal § B.2 took out of this production when it removed `uri-host` from
-/// it. Every one of those is a statement about assembly, and no borrowed
-/// production has a defect for it.
+/// What the *member* says about its parts is the four entries after them: a
+/// `received-by` that is missing, a second comment where the production permits
+/// one, content after a member that has ended, and the bracketed IPv6 literal
+/// § B.2 took out of this production when it removed `uri-host` from it. Every
+/// one of those is a statement about assembly, no borrowed production has a
+/// defect for any of them, and they are the [`via`](crate::violations::via)
+/// subject — this rule being their only reader does not make them the rule's,
+/// since what an operator configures is a defect in the traffic.
 static DECLARED: &[&ViolationDef] = &[
     &LIST_MEMBER_EMPTY,
     &TOKEN_EMPTY,
@@ -47,33 +53,27 @@ static DECLARED: &[&ViolationDef] = &[
     &COMMENT_DELIMITER_MISSING,
     &COMMENT_CHARACTER_FORBIDDEN,
     &QUOTED_PAIR_MALFORMED,
+    &VIA_RECEIVED_BY_MISSING,
+    &VIA_MEMBER_MALFORMED,
+    &VIA_COMMENT_DUPLICATED,
+    &VIA_RECEIVED_BY_OBSOLETE,
 ];
 
-/// One finding from the reading, and the defect it reports as where the
-/// catalogue names that defect.
+/// One finding from the reading, and the defect the catalogue names it.
 ///
-/// The shape `expect_header_valid` settled. Here the unnamed half is the
-/// member's assembly, and it is the larger half by count — which is what a
-/// field that borrows every production it is made of looks like from the
-/// inside.
+/// The shape `expect_header_valid` settled — a judge that is half converted
+/// carries an `Option` here — is not this rule's any more: the member's
+/// assembly became a subject of its own, so every arm names an entry and the
+/// def is a reference.
 struct Defect {
-    def: Option<&'static ViolationDef>,
+    def: &'static ViolationDef,
     message: String,
 }
 
 impl Defect {
     /// A defect the catalogue names.
     fn named(def: &'static ViolationDef, message: String) -> Self {
-        Self {
-            def: Some(def),
-            message,
-        }
-    }
-
-    /// A defect no subject has claimed: this production's own statement about
-    /// how its parts go together.
-    fn unnamed(message: String) -> Self {
-        Self { def: None, message }
+        Self { def, message }
     }
 
     /// The same defect with its message read from further out — the direction
@@ -89,28 +89,17 @@ impl Defect {
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_9110_7_6_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("7.6.3"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.3",
-    note: "The `Via` grammar this rule parses, the sentence that puts the field in both \
-           directions, and the requirements about forwarding and combining that a single \
-           captured message cannot answer",
-};
+///
+/// Two of them are not written here: the field's own section and the appendix
+/// that retired `uri-host` from `received-by` are what the
+/// [`via`](crate::violations::via) entries enforce, so they live beside those
+/// entries and are imported back for `specifications()`.
 const RFC_9110_7_8: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
     section: Some("7.8"),
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8",
     note: "`received-protocol` points here for its two halves: `protocol-name = token` \
            and `protocol-version = token`",
-};
-const RFC_9110_B_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("B.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-B.2",
-    note: "Why a `received-by` is a token: RFC 9110 removed `uri-host` from the \
-           production, which is what makes a bracketed IPv6 literal a finding here and \
-           not under RFC 7230",
 };
 const RFC_9110_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
@@ -242,10 +231,7 @@ impl Rule for ViaHeaderSyntax {
         // one finding (or none) becomes the vector.
         let finding = || -> Option<Violation> {
             // cite(RFC 9110 § 7.6.3): "A proxy MUST send an appropriate Via header field, as described below, in each message that it forwards."
-            let report = |defect: Defect| match defect.def {
-                Some(def) => ctx.report_with(def, defect.message),
-                None => self.cited(&RFC_9110_7_6_3, ctx.severity, defect.message),
-            };
+            let report = |defect: Defect| ctx.report_with(defect.def, defect.message);
 
             if let Some(defect) = judge(&tx.request.headers, "Request") {
                 return Some(report(defect));
@@ -356,19 +342,31 @@ fn validate_via(value: &[u8]) -> Result<(), Defect> {
             // member, so whatever is here followed a complete one. A `(` can only
             // be a second comment: an unspaced one is not a comment at all and
             // has already been reported against the `received-by` it ran into.
-            return Err(Defect::unnamed(if v[i] == b'(' {
-                format!("member {n} carries more than one comment, and the production permits one")
-            } else if commented {
-                format!(
-                    "member {n} has content after its comment, starting {}",
-                    describe_octet(v[i])
+            // That is the one shape here with an entry of its own — a repeated
+            // optional group is not the same sender as trailing content, even
+            // though the parser is stopped in the same place by both.
+            return Err(if v[i] == b'(' {
+                Defect::named(
+                    &VIA_COMMENT_DUPLICATED,
+                    format!(
+                        "member {n} carries more than one comment, and the production permits one"
+                    ),
                 )
             } else {
-                format!(
-                    "member {n} has content after its received-by, starting {}",
-                    describe_octet(v[i])
+                Defect::named(
+                    &VIA_MEMBER_MALFORMED,
+                    match commented {
+                        true => format!(
+                            "member {n} has content after its comment, starting {}",
+                            describe_octet(v[i])
+                        ),
+                        false => format!(
+                            "member {n} has content after its received-by, starting {}",
+                            describe_octet(v[i])
+                        ),
+                    },
                 )
-            }));
+            });
         }
         i += 1;
     }
@@ -426,15 +424,11 @@ fn validate_member(v: &[u8], start: usize, n: usize) -> Result<(usize, bool), De
     // cite(RFC 9110 § 5.6.3): "The RWS rule is used when at least one linear whitespace octet is required to separate field tokens."
     // cite(RFC 9110 § 5.6.3): "RWS = 1*( SP / HTAB )"
     match v.get(i) {
-        None => {
-            return Err(Defect::unnamed(format!(
-                "member {n} has a received-protocol and no received-by"
-            )))
-        }
-        Some(&b',') => {
-            return Err(Defect::unnamed(format!(
-                "member {n} has a received-protocol and no received-by"
-            )))
+        None | Some(&b',') => {
+            return Err(Defect::named(
+                &VIA_RECEIVED_BY_MISSING,
+                format!("member {n} has a received-protocol and no received-by"),
+            ))
         }
         Some(&b) if b != b' ' && b != b'\t' => {
             return Err(Defect::named(
@@ -458,20 +452,21 @@ fn validate_member(v: &[u8], start: usize, n: usize) -> Result<(usize, bool), De
     let pseudonym = scan_token(v, i);
     if pseudonym == i {
         return Err(match v.get(i) {
-            None => Defect::unnamed(format!(
-                "member {n} has a received-protocol and no received-by"
-            )),
+            None | Some(&b',') => Defect::named(
+                &VIA_RECEIVED_BY_MISSING,
+                format!("member {n} has a received-protocol and no received-by"),
+            ),
             // The brackets are § B.2's statement rather than the token's: the
             // production used to admit a `uri-host` and does not, so what is
             // wrong is which production the sender wrote, not which octet.
-            Some(&b'[') => Defect::unnamed(format!(
-                "member {n} spells its received-by as a bracketed IPv6 literal, which is not a \
-                 pseudonym; RFC 9110 removed uri-host from this production, so \"[\" cannot appear \
-                 in a received-by"
-            )),
-            Some(&b',') => Defect::unnamed(format!(
-                "member {n} has a received-protocol and no received-by"
-            )),
+            Some(&b'[') => Defect::named(
+                &VIA_RECEIVED_BY_OBSOLETE,
+                format!(
+                    "member {n} spells its received-by as a bracketed IPv6 literal, which is not \
+                     a pseudonym; RFC 9110 removed uri-host from this production, so \"[\" cannot \
+                     appear in a received-by"
+                ),
+            ),
             Some(&b) => Defect::named(
                 &TOKEN_EMPTY,
                 format!(
@@ -667,25 +662,38 @@ mod tests {
     /// Every production this field is made of, answering with the id it
     /// answers with everywhere else: the list's empty member, both `token`s of
     /// the `received-protocol`, the `pseudonym`, RFC 3986's port, and the
-    /// comment with its escape. The rows ending in `None` are the member's own
-    /// assembly, which no borrowed production has a defect for.
+    /// comment with its escape. The last four rows are the member's own
+    /// assembly, which no borrowed production has a defect for and which the
+    /// `via` subject holds.
     #[rstest]
-    #[case("1.1 fred, , 1.0 lucy", Some("list_member_empty"))]
-    #[case("1.1 fr@ed", Some("token_character_forbidden"))]
-    #[case("1.1@ fred", Some("token_character_forbidden"))]
-    #[case("(cached) 1.1 fred", Some("token_empty"))]
-    #[case("1.1/ fred", Some("token_empty"))]
-    #[case("1.1 fred:80x", Some("uri_port_character_forbidden"))]
-    #[case("1.1 fred (unterminated", Some("comment_delimiter_missing"))]
-    #[case("1.1 fred (a\\", Some("quoted_pair_malformed"))]
-    #[case("1.1 [::1]", None)]
-    #[case("1.1", None)]
-    fn a_via_member_borrows_every_production_it_is_made_of(
-        #[case] value: &str,
-        #[case] id: Option<&str>,
-    ) {
+    #[case("1.1 fred, , 1.0 lucy", "list_member_empty")]
+    #[case("1.1 fr@ed", "token_character_forbidden")]
+    #[case("1.1@ fred", "token_character_forbidden")]
+    #[case("(cached) 1.1 fred", "token_empty")]
+    #[case("1.1/ fred", "token_empty")]
+    #[case("1.1 fred:80x", "uri_port_character_forbidden")]
+    #[case("1.1 fred (unterminated", "comment_delimiter_missing")]
+    #[case("1.1 fred (a\\", "quoted_pair_malformed")]
+    #[case("1.1 [::1]", "via_received_by_obsolete")]
+    #[case("1.1", "via_received_by_missing")]
+    #[case("1.1 fred (a) (b)", "via_comment_duplicated")]
+    #[case("1.1 exa mple", "via_member_malformed")]
+    fn a_via_member_borrows_every_production_it_is_made_of(#[case] value: &str, #[case] id: &str) {
         let defect = judge(&headers(&[("via", value)]), "Request").expect("a finding");
-        assert_eq!(defect.def.map(|def| def.id), id, "{value}");
+        assert_eq!(defect.def.id, id, "{value}");
+    }
+
+    /// The four sites that ask whether a member has a recipient after its
+    /// protocol are one defect: the value stops, or the list's comma arrives,
+    /// with or without the `RWS` that would have introduced the `received-by`.
+    #[rstest]
+    #[case("1.1")]
+    #[case("1.1 ")]
+    #[case("1.1, 1.0 fred")]
+    #[case("1.1 , 1.0 fred")]
+    fn every_way_of_stopping_after_the_protocol_is_one_entry(#[case] value: &str) {
+        let defect = judge(&headers(&[("via", value)]), "Request").expect("a finding");
+        assert_eq!(defect.def.id, "via_received_by_missing", "{value}");
     }
 
     /// The lines of one field section are one list, so a member written empty
@@ -695,7 +703,7 @@ mod tests {
     fn an_empty_member_at_a_line_boundary_is_found() {
         let hm = headers(&[("via", "1.1 fred"), ("via", "")]);
         let defect = judge(&hm, "Request").expect("an empty member");
-        assert_eq!(defect.def.expect("the list's id").id, "list_member_empty");
+        assert_eq!(defect.def.id, "list_member_empty");
         let err = defect.message;
         assert!(err.contains("member 2 is empty"), "got {err}");
     }

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -71,6 +71,7 @@ pub mod transfer_coding;
 pub mod transfer_encoding;
 pub mod upgrade;
 pub mod uri;
+pub mod via;
 
 /// One reportable defect.
 ///
@@ -418,7 +419,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 205;
+        const FLOOR: usize = 209;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/via.rs
+++ b/lint-http-rules/src/violations/via.rs
@@ -1,0 +1,187 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `Via` defects — what a member says about its own parts.
+//!
+//! `Via = #( received-protocol RWS received-by [ RWS comment ] )` names five
+//! things and defines none of them: the list construct, the two `token`s a
+//! `received-protocol` is, the `token` a `pseudonym` is, the `port` RFC 3986
+//! writes, and § 5.6.5's comment with the escape inside it. Every octet-level
+//! defect a `Via` can hold is therefore some other subject's, and a bad
+//! character here answers with the id an `Upgrade`, a `Server` or a
+//! `Content-Type` parameter would.
+//!
+//! **What is left is the assembly, and that is this subject.** A member with a
+//! protocol and no recipient after it, a member that goes on past the point
+//! where it ended, a second comment where the production writes one, and a
+//! `received-by` spelled as the host form a later document took out of the
+//! production — none of those is a defect of any part; each is a statement
+//! about how the parts go together, and the field's own section is where all of
+//! it is written.
+//!
+//! **The subject is flat at `warn`, which is worth saying rather than
+//! assuming.** Nothing here is an `error`: `Via` is a trace, so a member that
+//! does not derive costs a recipient the identity of one hop and never the
+//! exchange — the question [`status`](crate::violations::status) ranks by is
+//! answered the same way for all four. And nothing here is `info` either,
+//! because each of them leaves a member a strict recipient cannot split: the
+//! chain a proxy is required to append to is the thing that stops being
+//! readable, whichever of the four went wrong.
+//!
+//! **The obsolete spelling is the entry to read twice.** It is the third use of
+//! the `_obsolete` ending and the first where no sentence obliges a recipient to
+//! accept the retired form — which is exactly why it does *not* default to
+//! `info` the way [`http_date`](crate::violations::http_date)'s does. An RFC 850
+//! timestamp is a spelling every recipient must still read; a bracketed IPv6
+//! literal in a `received-by` is one that no current production generates and
+//! nothing asks a recipient to parse.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// The field's own section: the grammar every entry here is measured against,
+/// what each of the three parts is for, and the forwarding requirements a
+/// single captured message cannot answer.
+pub const RFC_9110_7_6_3: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.6.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.3",
+    note: "The `Via` grammar — `Via = #( received-protocol RWS received-by [ RWS comment ] )` — \
+           the sentence that puts the field in both directions, and the requirements about \
+           forwarding and combining that a single captured message cannot answer",
+};
+
+/// The change that makes one host spelling a defect rather than a choice.
+/// RFC 7230's `received-by` admitted a `uri-host`; this one does not, and the
+/// appendix that removed it is the only place the removal is stated.
+pub const RFC_9110_B_2: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("B.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-B.2",
+    note: "Why a `received-by` is a token: RFC 9110 removed `uri-host` from the \
+           production, which is what makes a bracketed IPv6 literal a finding here and \
+           not under RFC 7230",
+};
+
+defects! {
+    /// A member that names the protocol it was received over and no recipient
+    /// after it — `Via: 1.1`, or `Via: 1.1, 1.0 fred` where the comma arrives
+    /// before the `RWS` does.
+    ///
+    /// The `received-by` is the half the field exists for: it is what says
+    /// *who* forwarded the message, and a chain of hops that cannot be named is
+    /// a chain no loop detection can walk. The optional half is the comment,
+    /// and the production writes the `RWS` between the two required ones with
+    /// no brackets around either.
+    ///
+    /// `_missing` and not `_empty`: there is no delimiter here to write and
+    /// leave blank. `RWS` is the separator, so a sender who stopped after the
+    /// protocol stopped before anything announced the recipient was coming —
+    /// which is the line `docs/development.md` draws between the two words.
+    ///
+    // cite(RFC 9110 § 7.6.3): "Via = #( received-protocol RWS received-by [ RWS comment ] )"
+    VIA_RECEIVED_BY_MISSING = {
+        id: "via_received_by_missing",
+        title: "Via member names no received-by",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_9110_7_6_3],
+    }
+
+    /// A member that has ended and is followed by something that is neither the
+    /// list's comma nor the whitespace before it: `Via: 1.1 exa mple`, where a
+    /// space inside what was meant as a pseudonym ends the member two
+    /// characters early, or a member whose comment is followed by more text.
+    ///
+    /// The catalogue cannot say which of the two the sender meant — a missing
+    /// comma or a `pseudonym` holding an octet no `token` admits — and neither
+    /// can a recipient. What both have in common is the only thing the finding
+    /// claims: from here on, the value does not derive from the production, so
+    /// the hops after this point are not readable either.
+    ///
+    // cite(RFC 9110 § 7.6.3): "Via = #( received-protocol RWS received-by [ RWS comment ] )"
+    VIA_MEMBER_MALFORMED = {
+        id: "via_member_malformed",
+        title: "Via member does not end where the production ends it",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_9110_7_6_3],
+    }
+
+    /// Two comments in one member: `Via: 1.1 fred (a) (b)`. The optional group
+    /// is written once and is not repeated, so the second one derives from
+    /// nothing — most often a chain where one intermediary appended its
+    /// software identification beside another's instead of adding a hop.
+    ///
+    /// Ranked with its siblings rather than below them, though the construct is
+    /// the one part of a member a recipient is licensed to *delete*. What is
+    /// reported is not the comment's content but the member it stopped: a
+    /// parser that has taken the optional group has taken the whole member, and
+    /// what follows is outside the production either way.
+    ///
+    // cite(RFC 9110 § 7.6.3): "Via = #( received-protocol RWS received-by [ RWS comment ] )"
+    VIA_COMMENT_DUPLICATED = {
+        id: "via_comment_duplicated",
+        title: "Via member carries more than one comment",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_9110_7_6_3],
+    }
+
+    /// A `received-by` written as a bracketed IPv6 literal —
+    /// `Via: 1.1 [2001:db8::1]:8080` — which RFC 7230's grammar admitted as a
+    /// `uri-host` and this one does not: `pseudonym = token`, and `[` is not a
+    /// `tchar`.
+    ///
+    /// **The defect is which production the sender wrote, not which octet.** A
+    /// bracket reported as a character outside `token` would send an operator
+    /// to a typo; what happened is that an intermediary is generating the field
+    /// against a document that was replaced, and the fix is a name or a bare
+    /// address rather than a different character.
+    ///
+    /// **`warn`, where the catalogue's other obsolete spellings are `info`.**
+    /// An RFC 850 timestamp is retired for senders and every recipient is still
+    /// required to read it, so the message works; nothing anywhere requires a
+    /// recipient to parse a host form this production no longer generates. The
+    /// ending says the sender was conforming under a document that has been
+    /// replaced — it does not promise that the value still arrives.
+    ///
+    // cite(RFC 9110 § B.2): "For simplicity, we have removed uri-host from the received-by production because it can be encompassed by the existing grammar for pseudonym."
+    VIA_RECEIVED_BY_OBSOLETE = {
+        id: "via_received_by_obsolete",
+        title: "Via received-by is spelled as a uri-host",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_9110_B_2],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The subject is flat, and both directions of the flatness are the
+    /// reading: no entry ends the exchange, and no entry leaves a member a
+    /// strict recipient can still split.
+    #[test]
+    fn every_entry_ranks_with_its_siblings() {
+        for def in [
+            &VIA_RECEIVED_BY_MISSING,
+            &VIA_MEMBER_MALFORMED,
+            &VIA_COMMENT_DUPLICATED,
+            &VIA_RECEIVED_BY_OBSOLETE,
+        ] {
+            assert_eq!(def.default_severity, Severity::Warn, "{}", def.id);
+        }
+    }
+
+    /// The one entry whose sentence is not the grammar: the removal is stated
+    /// in the appendix that records what changed, and nowhere else.
+    #[test]
+    fn the_retired_spelling_cites_the_document_that_retired_it() {
+        assert_eq!(VIA_RECEIVED_BY_OBSOLETE.spec, [RFC_9110_B_2]);
+        assert_eq!(VIA_RECEIVED_BY_MISSING.spec, [RFC_9110_7_6_3]);
+    }
+}

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1442,7 +1442,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 52
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 490
+      line: 485
     - file: lint-http-rules/src/violations/uri.rs
       line: 297
   - label: lint-http-rules/src/helpers/uri.rs (24)
@@ -6757,7 +6757,7 @@ sources:
     - file: lint-http-rules/src/rules/upgrade_header_syntax.rs
       line: 232
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 339
+      line: 325
     - file: lint-http-rules/src/violations/list.rs
       line: 72
   - label: lint-http-rules/src/helpers/cache_control.rs
@@ -6975,7 +6975,7 @@ sources:
     - file: lint-http-rules/src/rules/trace_method_echo.rs
       line: 46
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 314
+      line: 300
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
       line: 400
   - label: lint-http-rules/src/helpers/field_placement.rs
@@ -7503,7 +7503,7 @@ sources:
     - file: lint-http-rules/src/helpers/product.rs
       line: 192
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 427
+      line: 425
   - label: lint-http-rules/src/helpers/product.rs (5)
     section: § 5.6.3
     snippet: The RWS rule is used when at least one linear whitespace octet is required to separate field tokens.
@@ -7511,7 +7511,7 @@ sources:
     - file: lint-http-rules/src/helpers/product.rs
       line: 191
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 426
+      line: 424
   - label: lint-http-rules/src/helpers/product.rs (6)
     section: § A
     snippet: Server = product *( RWS ( product / comment ) )
@@ -7593,7 +7593,7 @@ sources:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 276
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 292
+      line: 278
     - file: lint-http-rules/src/violations/token.rs
       line: 58
     - file: lint-http-rules/src/violations/token.rs
@@ -9235,7 +9235,7 @@ sources:
     - file: lint-http-rules/src/rules/upgrade_header_syntax.rs
       line: 217
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 328
+      line: 314
   - label: upgrade_header_syntax (3)
     section: § 7.8
     snippet: A client MAY send a list of protocol names in the Upgrade header field of a request to invite the server to switch to one or more of the named protocols, in order of descending preference, before sending the final response.
@@ -9289,75 +9289,81 @@ sources:
     snippet: port = <port, see [URI], Section 3.2.3>
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 489
+      line: 484
   - label: via_header_syntax (2)
     section: § 5.6.3
     snippet: OWS = *( SP / HTAB )
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 280
+      line: 266
   - label: via_header_syntax (3)
     section: § 7.6.3
     snippet: A proxy MUST send an appropriate Via header field, as described below, in each message that it forwards.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 244
+      line: 233
   - label: via_header_syntax (4)
     section: § 7.6.3
     snippet: A sender MAY generate comments to identify the software of each recipient, analogous to the User-Agent and Server header fields.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 520
+      line: 515
   - label: via_header_syntax (5)
     section: § 7.6.3
     snippet: An HTTP-to-HTTP gateway MUST send an appropriate Via header field in each inbound request message and MAY send a Via header field in forwarded response messages.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 254
+      line: 240
   - label: via_header_syntax (6)
     section: § 7.6.3
     snippet: For brevity, the protocol-name is omitted when the received protocol is HTTP.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 393
+      line: 391
   - label: via_header_syntax (7)
     section: § 7.6.3
     snippet: However, comments in Via are optional, and a recipient MAY remove them prior to forwarding the message.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 521
+      line: 516
   - label: via_header_syntax (8)
     section: § 7.6.3
     snippet: However, if the real host is considered to be sensitive information, a sender MAY replace it with a pseudonym.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 457
+      line: 451
   - label: via_header_syntax (9)
     section: § 7.6.3
     snippet: The "Via" header field indicates the presence of intermediate protocols and recipients between the user agent and the server (on requests) or between the origin server and the client (on responses)
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 230
+      line: 219
   - label: via_header_syntax (10)
     section: § 7.6.3
     snippet: The received-by portion is normally the host and optional port number of a recipient server or client that subsequently forwarded the message.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 456
+      line: 450
   - label: via_header_syntax (11)
     section: § 7.6.3
     snippet: 'Via = #( received-protocol RWS received-by [ RWS comment ] )'
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 327
+      line: 313
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 384
+      line: 382
+    - file: lint-http-rules/src/violations/via.rs
+      line: 84
+    - file: lint-http-rules/src/violations/via.rs
+      line: 104
+    - file: lint-http-rules/src/violations/via.rs
+      line: 124
   - label: via_header_syntax (12)
     section: § 7.6.3
     snippet: received-by = pseudonym [ ":" port ] pseudonym = token
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 454
+      line: 448
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
       line: 604
   - label: via_header_syntax (13)
@@ -9365,25 +9371,27 @@ sources:
     snippet: received-protocol = [ protocol-name "/" ] protocol-version
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 390
+      line: 388
   - label: via_header_syntax (14)
     section: § 7.8
     snippet: protocol-name = token
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 391
+      line: 389
   - label: via_header_syntax (15)
     section: § 7.8
     snippet: protocol-version = token
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 392
+      line: 390
   - label: via_header_syntax (16)
     section: § B.2
     snippet: For simplicity, we have removed uri-host from the received-by production because it can be encompassed by the existing grammar for pseudonym.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 455
+      line: 449
+    - file: lint-http-rules/src/violations/via.rs
+      line: 151
   - label: warning_header_syntax
     section: § 5.6.7
     snippet: Prior to 1995, there were three different formats commonly used by servers to communicate timestamps.


### PR DESCRIPTION
`violations/via.rs` opens with four entries and `via_header_syntax` converts whole. Every octet-level defect a `Via` can hold was already borrowed — the list construct, both `token`s of a `received-protocol`, the `pseudonym`, RFC 3986's port, §5.6.5's comment and its escape — so what was left reporting at the rule's own severity was the *assembly*: a member with a protocol and no recipient after it, a member that goes on past where it ended, a second comment where the production writes one, and a `received-by` spelled as the `uri-host` RFC 9110 Appendix B.2 removed.

Those are the field's defects and not the rule's, even though one rule is the only reader of them: an operator configures a defect in the traffic. Four sites asking whether anything follows the `received-protocol` become one entry, since the value stopping and the list's comma arriving are the same absent half.

The obsolete spelling is the entry to read twice. It is the third use of that ending and the first where no sentence obliges a recipient to accept the retired form, so it does *not* default to `info` the way an RFC 850 timestamp does: a date every recipient must still parse is a message that works, and a host form no current production generates is not.

The subject is flat at `warn` in both directions — nothing here can end an exchange, and nothing here leaves a member a strict recipient can still split.

§7.6.3 and §B.2 move onto the entries and the rule imports them back for `specifications()`.

Floors: 209 of 216 entries cite a sentence; citation coverage 105, where one site had been standing in for seven findings and each is now cited by its entry.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
