### PR TITLE
Three absences the extension list owns

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1715,6 +1715,18 @@ severity = "error"
 # A request-target carries whitespace
 severity = "error"
 
+[violations.sec_websocket_extensions_empty]
+# Sec-WebSocket-Extensions names no extension
+severity = "error"
+
+[violations.sec_websocket_extensions_parameter_missing]
+# Sec-WebSocket-Extensions writes a ';' with no parameter after it
+severity = "error"
+
+[violations.sec_websocket_extensions_parameter_value_empty]
+# Sec-WebSocket-Extensions writes a parameter '=' with no value after it
+severity = "error"
+
 [violations.status_101_ignored]
 # HTTP continues on a connection a 101 handed off
 severity = "warn"

--- a/lint-http-rules/src/rules/sec_websocket_extensions_syntax.rs
+++ b/lint-http-rules/src/rules/sec_websocket_extensions_syntax.rs
@@ -16,6 +16,10 @@ use crate::violations::quoted_string::{
     quoted_string_defect, QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
     QUOTED_STRING_DELIMITER_MISSING, QUOTED_STRING_QUOTE_ESCAPE_MISSING, RFC_9110_5_6_4,
 };
+use crate::violations::sec_websocket_extensions::{
+    RFC_2616_2_1, RFC_6455_9_1, SEC_WEBSOCKET_EXTENSIONS_EMPTY,
+    SEC_WEBSOCKET_EXTENSIONS_PARAMETER_MISSING, SEC_WEBSOCKET_EXTENSIONS_PARAMETER_VALUE_EMPTY,
+};
 use crate::violations::token::{
     token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN, TOKEN_EMPTY,
     TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
@@ -24,8 +28,8 @@ use crate::violations::ViolationDef;
 
 pub struct SecWebsocketExtensionsSyntax;
 
-/// Six defs over two subjects, and this field's own list construct is
-/// deliberately not among them.
+/// Ten defs over three subjects, and this field's own list construct is
+/// deliberately not borrowed from any of them.
 ///
 /// `extension-token = registered-token = token` and `extension-param = token [
 /// "=" (token | quoted-string) ]`, so the name, the parameter name and an
@@ -39,11 +43,15 @@ pub struct SecWebsocketExtensionsSyntax;
 /// non-null; RFC 9110's forbids them outright. `list_member_empty` reports a
 /// sender's MUST NOT that does not apply here, so a field allowing what it
 /// forbids must not borrow it — and the floor, though it says the same thing,
-/// is stated by a different document for a different construct. Both findings
-/// stay in this rule's words.
+/// is stated by a different document for a different construct.
 ///
-/// The parameter that is nothing at all — a `;` with nothing after it — is this
-/// grammar's own repetition group and stays unnamed beside them.
+/// Neither is the parameter that is nothing at all — a `;` with nothing after
+/// it — nor the `=` with nothing after it: the production is § 9.1's own and
+/// not § 5.6.6's `parameters`, which brackets its parameter and requires its
+/// value. Those three are the
+/// [`sec_websocket_extensions`](crate::violations::sec_websocket_extensions)
+/// subject, and they rank above the seven borrowed ones because § 9.1 says
+/// what a recipient does with a value that does not conform.
 static DECLARED: &[&ViolationDef] = &[
     &TOKEN_EMPTY,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
@@ -52,32 +60,26 @@ static DECLARED: &[&ViolationDef] = &[
     &QUOTED_PAIR_MALFORMED,
     &QUOTED_STRING_QUOTE_ESCAPE_MISSING,
     &QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
+    &SEC_WEBSOCKET_EXTENSIONS_EMPTY,
+    &SEC_WEBSOCKET_EXTENSIONS_PARAMETER_MISSING,
+    &SEC_WEBSOCKET_EXTENSIONS_PARAMETER_VALUE_EMPTY,
 ];
 
 /// One finding from the reading, and the defect it reports as where the
 /// catalogue names that defect.
 ///
-/// The shape `expect_header_valid` settled. The unnamed half here is everything
-/// RFC 2616's notation owns: the list construct, its null elements, and the
-/// repetition group a `;` opens.
+/// The shape `expect_header_valid` settled — a judge that is half converted
+/// carries an `Option` here — is not this rule's any more: what RFC 2616's
+/// notation owns became a subject of its own, so every arm names an entry.
 struct Defect {
-    def: Option<&'static ViolationDef>,
+    def: &'static ViolationDef,
     message: String,
 }
 
 impl Defect {
     /// A defect the catalogue names.
     fn named(def: &'static ViolationDef, message: String) -> Self {
-        Self {
-            def: Some(def),
-            message,
-        }
-    }
-
-    /// A defect no subject has claimed, reported at the rule's severity the way
-    /// every finding here was before the catalogue existed.
-    fn unnamed(message: String) -> Self {
-        Self { def: None, message }
+        Self { def, message }
     }
 
     /// The same defect with its message read from further out — the direction
@@ -147,11 +149,14 @@ fn extension_defect(member: &str) -> Option<Defect> {
         // null-element permission is the `#rule`'s, and the `#rule` here is the
         // comma-separated list of extensions above.
         if param.is_empty() {
-            return Some(Defect::unnamed(format!(
-                "member '{}' has an empty parameter: every \";\" in an extension is followed by an \
-                 extension-param, which begins with a token",
-                shown_in_finding(member)
-            )));
+            return Some(Defect::named(
+                &SEC_WEBSOCKET_EXTENSIONS_PARAMETER_MISSING,
+                format!(
+                    "member '{}' has an empty parameter: every \";\" in an extension is followed \
+                     by an extension-param, which begins with a token",
+                    shown_in_finding(member)
+                ),
+            ));
         }
 
         // The `=` is optional, and where it is absent the parameter is a bare
@@ -260,11 +265,15 @@ fn extension_defect(member: &str) -> Option<Defect> {
             // The alternation's empty value, which the catalogue declines: six
             // fields settled that verdict four different ways and two of them
             // tolerate it outright.
-            return Some(Defect::unnamed(format!(
-                "member '{}' has a parameter whose \"=\" is followed by no value; the alternation \
-                 is a token or a quoted-string, and neither derives the empty string",
-                shown_in_finding(member)
-            )));
+            return Some(Defect::named(
+                &SEC_WEBSOCKET_EXTENSIONS_PARAMETER_VALUE_EMPTY,
+                format!(
+                    "member '{}' has a parameter whose \"=\" is followed by no value; the \
+                     alternation is a token or a quoted-string, and neither derives the empty \
+                     string",
+                    shown_in_finding(member)
+                ),
+            ));
         }
         if let Some(c) = find_invalid_token_char(value) {
             return Some(Defect::named(
@@ -327,12 +336,15 @@ impl SecWebsocketExtensionsSyntax {
             // worked example, and the construct here is RFC 2616's, which
             // permits the null elements RFC 9110 forbids. Same words, different
             // document, different list.
-            return Some(Defect::unnamed(format!(
-                "{direction} Sec-WebSocket-Extensions names no extension: '{}'. The field is \
-                 `1#extension`, and RFC 2616's list construct — the one this grammar uses — allows \
-                 null elements but requires at least one that is not",
-                shown_in_finding(&value)
-            )));
+            return Some(Defect::named(
+                &SEC_WEBSOCKET_EXTENSIONS_EMPTY,
+                format!(
+                    "{direction} Sec-WebSocket-Extensions names no extension: '{}'. The field is \
+                     `1#extension`, and RFC 2616's list construct — the one this grammar uses — \
+                     allows null elements but requires at least one that is not",
+                    shown_in_finding(&value)
+                ),
+            ));
         }
 
         for member in members {
@@ -355,23 +367,11 @@ impl SecWebsocketExtensionsSyntax {
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_6455_9_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 6455",
-    section: Some("9.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-9.1",
-    note: "Negotiating Extensions — the grammar, the MUST that makes a non-conforming \
-           value a failure of the connection, the note that the notation is RFC \
-           2616's, and the requirement on a quoted-string value after unescaping",
-};
-const RFC_2616_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 2616",
-    section: Some("2.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc2616.html#section-2.1",
-    note: "Augmented BNF — the notation §9.1 imports by name: the `#rule` whose null \
-           elements are allowed (RFC 9110 §5.6.1.1 forbids them) and the implied \
-           *LWS rule that permits whitespace beside the separators. Obsolete and \
-           correct: the current document is what sends the reader here",
-};
+///
+/// Two of them are not written here: the field's section and the notation it
+/// imports are what the
+/// [`sec_websocket_extensions`](crate::violations::sec_websocket_extensions)
+/// entries enforce, so they live beside those entries and are imported back.
 const RFC_6455_11_4: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 6455",
     section: Some("11.4"),
@@ -471,10 +471,7 @@ impl Rule for SecWebsocketExtensionsSyntax {
                 Self::defect(&resp.headers, "Response")
             })?;
 
-            Some(match defect.def {
-                Some(def) => ctx.report_with(def, defect.message),
-                None => self.violation(ctx.severity, defect.message),
-            })
+            Some(ctx.report_with(defect.def, defect.message))
         };
         Vec::from_iter(finding())
     }
@@ -510,9 +507,10 @@ mod tests {
     /// unescaped value must conform to `token` in as many words. The
     /// `quoted-string` itself reports the shared ids too.
     ///
-    /// What does not convert is asserted here as well: this field's `#rule` is
+    /// What is not borrowed is asserted here as well: this field's `#rule` is
     /// RFC 2616's, which permits the null elements RFC 9110's forbids, so
-    /// neither list id may be borrowed however alike the sentences read.
+    /// neither list id may be taken however alike the sentences read — the
+    /// floor is this subject's own entry instead.
     #[test]
     fn the_token_is_the_same_token_at_five_positions() {
         let id = |line: &[u8]| {
@@ -529,8 +527,14 @@ mod tests {
         assert_eq!(id(b";name=1"), "token_empty");
         assert_eq!(id(br#"x;name="a"#), "quoted_string_delimiter_missing");
 
-        // RFC 2616's list construct, which permits what RFC 9110's forbids.
-        assert_eq!(id(b","), "");
+        // RFC 2616's list construct, which permits what RFC 9110's forbids:
+        // the floor is the field's, not the list subject's.
+        assert_eq!(id(b","), "sec_websocket_extensions_empty");
+        assert_eq!(id(b"x;"), "sec_websocket_extensions_parameter_missing");
+        assert_eq!(
+            id(b"x;name="),
+            "sec_websocket_extensions_parameter_value_empty"
+        );
     }
 
     fn extensions(section: Section, lines: &[&[u8]]) -> Option<Violation> {

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -62,6 +62,7 @@ pub mod quoted_pair;
 pub mod quoted_string;
 pub mod qvalue;
 pub mod request_target;
+pub mod sec_websocket_extensions;
 pub mod status;
 pub mod strict_transport_security;
 pub mod te;
@@ -419,7 +420,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 209;
+        const FLOOR: usize = 212;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/sec_websocket_extensions.rs
+++ b/lint-http-rules/src/violations/sec_websocket_extensions.rs
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `Sec-WebSocket-Extensions` defects — what RFC 6455's own notation owns.
+//!
+//! Almost everything in this field is borrowed. `extension-token`,
+//! `extension-param`'s name and an unquoted value are all `token`, a quoted
+//! value is § 5.6.4's `quoted-string` with the escape inside it, and § 9.1 goes
+//! further than most fields do by requiring the value *after* unescaping to
+//! conform to `token` as well — one id at five positions of a single member.
+//!
+//! **What is left is what the 1997 notation says and RFC 9110's does not.**
+//! § 9.1 imports RFC 2616's ABNF by name, and two of this subject's three
+//! entries exist because of what that import changes: the `#rule` here *allows*
+//! null elements, so an empty member is not [`list`](crate::violations::list)'s
+//! MUST NOT and a value of nothing but commas is the finding instead; and the
+//! parameter production is not § 5.6.6's `parameters`, so neither
+//! [`parameter`](crate::violations::parameter) entry can be borrowed for the
+//! same two absences here. **Same words, different document, different list** —
+//! borrowing either would put a citation on a finding whose grammar the cited
+//! sentence does not govern.
+//!
+//! **Every entry here is an `error`, and one sentence is why.** § 9.1 does not
+//! leave the consequence of a malformed value to a recipient's judgement: *the
+//! recipient of such malformed data MUST immediately _Fail the WebSocket
+//! Connection_*. So the question [`status`](crate::violations::status) ranks by
+//! — whether the exchange can continue — is answered by the document itself,
+//! and answered the same way for all three.
+//!
+//! **The borrowed ids stay at their own rank, and that is not an
+//! inconsistency to fix.** `token_empty` answers for eighty other fields and
+//! cannot carry this field's consequence; an operator who wants the whole
+//! handshake at `error` raises the entries this subject owns and leaves the
+//! productions alone. A shared entry's rank belongs to its subject, which is the
+//! whole reason a defect has an id rather than a severity per reader.
+//!
+// cite(RFC 6455 § 9.1): "If a value is received by either the client or the server during negotiation that does not conform to the ABNF below, the recipient of such malformed data MUST immediately _Fail the WebSocket Connection_."
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// Negotiating Extensions: the grammar, the MUST that makes a non-conforming
+/// value a failure of the connection, and the note that the notation is RFC
+/// 2616's.
+pub const RFC_6455_9_1: SpecRef = SpecRef {
+    spec: "RFC 6455",
+    section: Some("9.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-9.1",
+    note: "Negotiating Extensions — the grammar, the MUST that makes a non-conforming \
+           value a failure of the connection, the note that the notation is RFC \
+           2616's, and the requirement on a quoted-string value after unescaping",
+};
+
+/// The notation § 9.1 imports by name, and the only place the list construct
+/// this field uses is written. Obsolete and correct: the document in force is
+/// what sends the reader here.
+pub const RFC_2616_2_1: SpecRef = SpecRef {
+    spec: "RFC 2616",
+    section: Some("2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc2616.html#section-2.1",
+    note: "Augmented BNF — the notation §9.1 imports by name: the `#rule` whose null \
+           elements are allowed (RFC 9110 §5.6.1.1 forbids them) and the implied \
+           *LWS rule that permits whitespace beside the separators. Obsolete and \
+           correct: the current document is what sends the reader here",
+};
+
+defects! {
+    /// A field naming no extension at all: written empty, or written as
+    /// nothing but commas and the whitespace around them.
+    ///
+    /// **This is the `1#` floor and not an empty member**, which is the one
+    /// place this field parts company with every other list in the catalogue.
+    /// RFC 2616's `#rule` permits null elements — `foo,,bar` is two extensions
+    /// and conforms — and pays for it by requiring one that is not null. So
+    /// [`list_member_empty`](crate::violations::list) reports a MUST NOT this
+    /// grammar does not make, and [`list_member_missing`](crate::violations::list)
+    /// carries § 5.6.1.2's worked example for a construct this field does not
+    /// use.
+    ///
+    /// `_empty` and not `_missing`: the sender wrote the field. A message with
+    /// no `Sec-WebSocket-Extensions` at all is a client offering none, which is
+    /// what most handshakes are.
+    ///
+    // cite(RFC 2616 § 2.1): "Therefore, where at least one element is required, at least one non-null element MUST be present."
+    SEC_WEBSOCKET_EXTENSIONS_EMPTY = {
+        id: "sec_websocket_extensions_empty",
+        title: "Sec-WebSocket-Extensions names no extension",
+        message: "",
+        default_severity: Severity::Error,
+        spec: &[RFC_2616_2_1],
+    }
+
+    /// A `;` inside a member with no parameter after it. The repetition prints
+    /// the delimiter and an `extension-param` together and brackets neither, so
+    /// `permessage-deflate;` generates no `extension` at all.
+    ///
+    /// **The three characters that are a defect here and are not one after a
+    /// media type**, which is the line
+    /// [`transfer_coding`](crate::violations::transfer_coding) drew for the
+    /// same shape: § 5.6.6 writes `*( OWS ";" OWS [ parameter ] )`, whose
+    /// brackets make a trailing semicolon a conforming zero-parameter
+    /// repetition. This production has no brackets to hide behind, and it is
+    /// not § 5.6.6's production in the first place.
+    ///
+    // cite(RFC 6455 § 9.1, label: extension repetition): "extension = extension-token *( ";" extension-param )"
+    SEC_WEBSOCKET_EXTENSIONS_PARAMETER_MISSING = {
+        id: "sec_websocket_extensions_parameter_missing",
+        title: "Sec-WebSocket-Extensions writes a ';' with no parameter after it",
+        message: "",
+        default_severity: Severity::Error,
+        spec: &[RFC_6455_9_1],
+    }
+
+    /// An `=` with nothing after it. The value is optional in this production —
+    /// `client_no_context_takeover` is a parameter and a whole one — but the
+    /// `=` is what says a value was due, and neither arm of the alternation
+    /// derives the empty string: a `token` has a one-character floor and the
+    /// shortest `quoted-string` is its two DQUOTEs.
+    ///
+    /// **The catalogue declines the alternation's empty value in general and
+    /// answers it per production**, which is what
+    /// [`parameter_value_empty`](crate::violations::parameter) already is for
+    /// § 5.6.6. `word_defect` leaves `WordDefect::Empty` unnamed because six
+    /// fields had settled it four ways and two tolerate it outright; a
+    /// production that writes the `=` outside the brackets settles it for
+    /// itself, and this one does.
+    ///
+    /// `x=""` is a different value and conforms as far as this entry goes: it
+    /// is a `quoted-string` the production derives. What it fails is § 9.1's
+    /// trailing requirement that the *unescaped* value be a `token`, which is
+    /// [`token_empty`](crate::violations::token)'s finding and not this one.
+    ///
+    // cite(RFC 6455 § 9.1, label: extension-param alternation): "extension-param = token [ "=" (token | quoted-string) ]"
+    SEC_WEBSOCKET_EXTENSIONS_PARAMETER_VALUE_EMPTY = {
+        id: "sec_websocket_extensions_parameter_value_empty",
+        title: "Sec-WebSocket-Extensions writes a parameter '=' with no value after it",
+        message: "",
+        default_severity: Severity::Error,
+        spec: &[RFC_6455_9_1],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The rank is the document's rather than the subject's judgement: a value
+    /// that does not conform to § 9.1's ABNF is a connection a recipient MUST
+    /// fail, so nothing here can be the milder half of anything.
+    #[test]
+    fn a_value_this_field_cannot_read_ends_the_connection() {
+        for def in [
+            &SEC_WEBSOCKET_EXTENSIONS_EMPTY,
+            &SEC_WEBSOCKET_EXTENSIONS_PARAMETER_MISSING,
+            &SEC_WEBSOCKET_EXTENSIONS_PARAMETER_VALUE_EMPTY,
+        ] {
+            assert_eq!(def.default_severity, Severity::Error, "{}", def.id);
+        }
+    }
+
+    /// The list floor is the 1997 notation's and the two parameter absences are
+    /// § 9.1's own, which is why the first entry cites a document the field's
+    /// section only points at.
+    #[test]
+    fn the_list_floor_cites_the_notation_and_the_parameters_cite_the_field() {
+        assert_eq!(SEC_WEBSOCKET_EXTENSIONS_EMPTY.spec, [RFC_2616_2_1]);
+        assert_eq!(
+            SEC_WEBSOCKET_EXTENSIONS_PARAMETER_MISSING.spec,
+            [RFC_6455_9_1]
+        );
+        assert_eq!(
+            SEC_WEBSOCKET_EXTENSIONS_PARAMETER_VALUE_EMPTY.spec,
+            [RFC_6455_9_1]
+        );
+    }
+}

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1107,21 +1107,23 @@ sources:
     snippet: Except where noted otherwise, linear white space (LWS) can be included between any two adjacent words (token or quoted-string), and between adjacent words and separators, without changing the interpretation of a field.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_extensions_syntax.rs
-      line: 111
+      line: 113
   - label: sec_websocket_extensions_syntax (2)
     section: § 2.1
     snippet: Therefore, where at least one element is required, at least one non-null element MUST be present.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_extensions_syntax.rs
-      line: 303
+      line: 312
     - file: lint-http-rules/src/rules/sec_websocket_version_advertised.rs
       line: 48
+    - file: lint-http-rules/src/violations/sec_websocket_extensions.rs
+      line: 86
   - label: sec_websocket_extensions_syntax (3)
     section: § 2.1
     snippet: Wherever this construct is used, null elements are allowed, but do not contribute to the count of elements present.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_extensions_syntax.rs
-      line: 302
+      line: 311
     - file: lint-http-rules/src/rules/sec_websocket_version_advertised.rs
       line: 24
 - label: RFC 2617
@@ -2638,12 +2640,24 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 47
+  - label: extension repetition
+    section: § 9.1
+    snippet: extension = extension-token *( ";" extension-param )
+    cited_by:
+    - file: lint-http-rules/src/violations/sec_websocket_extensions.rs
+      line: 107
+  - label: extension-param alternation
+    section: § 9.1
+    snippet: extension-param = token [ "=" (token | quoted-string) ]
+    cited_by:
+    - file: lint-http-rules/src/violations/sec_websocket_extensions.rs
+      line: 135
   - label: quoted-string parameter note
     section: § 9.1
     snippet: ;When using the quoted-string syntax variant, the value ;after quoted-string unescaping MUST conform to the ;'token' ABNF.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_extensions_syntax.rs
-      line: 208
+      line: 213
   - label: sec_websocket_extensions_syntax
     section: § 9.1
     snippet: A client requests extensions by including a |Sec-WebSocket-Extensions| header field, which follows the normal rules for HTTP header fields (see [RFC2616], Section 4.2) and the value of the header field is defined by the following ABNF [RFC2616].
@@ -2655,7 +2669,7 @@ sources:
     snippet: Any extension-token used MUST be a registered token (see Section 11.4).
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_extensions_syntax.rs
-      line: 121
+      line: 123
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
       line: 252
   - label: sec_websocket_extensions_syntax (3)
@@ -2663,19 +2677,21 @@ sources:
     snippet: If a value is received by either the client or the server during negotiation that does not conform to the ABNF below, the recipient of such malformed data MUST immediately _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_extensions_syntax.rs
-      line: 324
+      line: 333
+    - file: lint-http-rules/src/violations/sec_websocket_extensions.rs
+      line: 38
   - label: sec_websocket_extensions_syntax (4)
     section: § 9.1
     snippet: Note that this section is using ABNF syntax/rules from [RFC2616], including the "implied *LWS rule".
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_extensions_syntax.rs
-      line: 301
+      line: 310
   - label: Sec-WebSocket-Extensions grammar
     section: § 9.1
     snippet: Sec-WebSocket-Extensions = extension-list extension-list = 1#extension extension = extension-token *( ";" extension-param ) extension-token = registered-token registered-token = token extension-param = token [ "=" (token | quoted-string) ]
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_extensions_syntax.rs
-      line: 110
+      line: 112
   - label: sec_websocket_headers_consistent
     section: § 4.1
     snippet: The ABNF for the value of this header field is 1#token, where the definitions of constructs and rules are as given in [RFC2616].


### PR DESCRIPTION
`violations/sec_websocket_extensions.rs` opens with three entries and `sec_websocket_extensions_syntax` converts whole. Everything else in the field was already borrowed — the `extension-token`, a parameter name, an unquoted value and the value a quoted one unescapes to are one `token` at five positions — and what was left reporting at the rule's own severity is what RFC 2616's notation owns: a value that is nothing but commas, a `;` with no parameter after it, an `=` with no value after it.

None of the three could take an existing id, and the reason is the same each time: §9.1 imports its ABNF from RFC 2616 by name. That `#rule` *allows* null elements where RFC 9110 §5.6.1.1 forbids them, so `list_member_empty` states a MUST NOT this field does not make and `list_member_missing` carries a worked example for a construct it does not use; and `extension-param = token [ "=" (token | quoted-string) ]` is not §5.6.6's `parameters`, which brackets its parameter and requires its value. Same words, different document, different list.

The three rank `error` while the seven borrowed ids stay where they are, and the document is what decides it rather than a judgement: §9.1 says a recipient of a value that does not conform MUST immediately fail the WebSocket connection. A shared entry cannot carry that — `token_empty` answers for eighty other fields — which is the argument for a subject owning its own entries even where one rule is their only reader.

§9.1 and RFC 2616 §2.1 move onto the entries and the rule imports them back.

Floor: 212 of 219 entries cite a sentence.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
