### PR TITLE
A qualification that lists nothing

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1151,6 +1151,14 @@ severity = "warn"
 # Whitespace written where the grammar admits BWS
 severity = "info"
 
+[violations.cache_control_no_cache_argument_empty]
+# Cache-Control no-cache is qualified by no field name
+severity = "info"
+
+[violations.cache_control_private_argument_empty]
+# Cache-Control private is qualified by no field name
+severity = "info"
+
 [violations.challenge_empty]
 # Authentication challenge is empty
 severity = "warn"

--- a/docs/rules/cache_control_directive_valid.md
+++ b/docs/rules/cache_control_directive_valid.md
@@ -24,6 +24,8 @@ This rule complements `cache_control_token_valid` which enforces general token/q
 - [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 - [RFC 9110 §5.6.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4): `quoted-string = DQUOTE *( qdtext / quoted-pair ) DQUOTE` — the two delimiters, the class between them, and the backslash escape
 - [RFC 9111 §1.2.2](https://www.rfc-editor.org/rfc/rfc9111.html#section-1.2.2): `delta-seconds = 1*DIGIT` — the production every field carrying a time in seconds writes its value in, and the clamp that makes an over-long run of digits conforming
+- [RFC 9111 §5.2.2.4](https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.4): no-cache — argument syntax `#field-name`, the qualified form defined as an argument listing one or more field names, and the Note that caches often handle it as an unqualified no-cache
+- [RFC 9111 §5.2.2.7](https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.7): private — argument syntax `#field-name`, the qualified form defined as an argument listing one or more field names, and the Note that caches often handle it as an unqualified private
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/cache_control_directive_valid.rs
+++ b/lint-http-rules/src/rules/cache_control_directive_valid.rs
@@ -4,6 +4,10 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::cache_control::{
+    CACHE_CONTROL_NO_CACHE_ARGUMENT_EMPTY, CACHE_CONTROL_PRIVATE_ARGUMENT_EMPTY, RFC_9111_5_2_2_4,
+    RFC_9111_5_2_2_7,
+};
 use crate::violations::delta_seconds::{DELTA_SECONDS_CHARACTER_FORBIDDEN, RFC_9111_1_2_2};
 use crate::violations::list::{cache_directive_member, LIST_MEMBER_EMPTY, RFC_9110_5_6_1_1};
 use crate::violations::quoted_pair::QUOTED_PAIR_MALFORMED;
@@ -33,8 +37,14 @@ pub struct CacheControlDirectiveValid;
 /// well-formed `token` and not a number breaks nothing about the
 /// `cache-directive` — but § 5.2.2.1 gives that directive's argument the syntax
 /// `delta-seconds`, so the name commits the value to a second production and
-/// the value failed it. What stays unnamed is the sentence with no production
-/// behind it at all: a qualified directive whose argument lists no field.
+/// the value failed it.
+///
+/// The last two are the sentences with no production behind them at all: a
+/// qualified directive whose argument lists no field, written once in
+/// `no-cache`'s subsection and once in `private`'s. They are the
+/// [`cache_control`](crate::violations::cache_control) subject — the layer above
+/// this field's grammar, where a directive's own definition says what its
+/// argument must say.
 static DECLARED: &[&ViolationDef] = &[
     &LIST_MEMBER_EMPTY,
     &TOKEN_EMPTY,
@@ -45,6 +55,8 @@ static DECLARED: &[&ViolationDef] = &[
     &QUOTED_STRING_QUOTE_ESCAPE_MISSING,
     &QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
     &DELTA_SECONDS_CHARACTER_FORBIDDEN,
+    &CACHE_CONTROL_NO_CACHE_ARGUMENT_EMPTY,
+    &CACHE_CONTROL_PRIVATE_ARGUMENT_EMPTY,
 ];
 
 /// The specification references this rule declares, each named so a finding
@@ -68,29 +80,19 @@ const RFC_9111_1_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
 /// One finding from the reading, and the defect it reports as where the
 /// catalogue names that defect.
 ///
-/// The shape `expect_header_valid` settled: a judge that is half converted says
-/// so in its type. The unnamed half here is now one sentence rather than two — a
-/// qualified directive whose argument lists no field at all, which is RFC 9111
-/// saying what a particular directive means by its argument and is a statement
-/// no production carries.
+/// The shape `expect_header_valid` settled — a judge that is half converted
+/// says so in its type — is not this rule's any more: the sentence no
+/// production carries got a subject of its own, one entry per directive that
+/// writes it.
 struct Defect {
-    def: Option<&'static ViolationDef>,
+    def: &'static ViolationDef,
     message: String,
 }
 
 impl Defect {
     /// A defect the catalogue names.
     fn named(def: &'static ViolationDef, message: String) -> Self {
-        Self {
-            def: Some(def),
-            message,
-        }
-    }
-
-    /// A defect no subject has claimed, reported at the rule's severity the way
-    /// every finding here was before the catalogue existed.
-    fn unnamed(message: String) -> Self {
-        Self { def: None, message }
+        Self { def, message }
     }
 }
 
@@ -118,10 +120,7 @@ impl CacheControlDirectiveValid {
                     "Invalid Cache-Control header in {}: {}",
                     side, defect.message
                 );
-                return Some(match defect.def {
-                    Some(def) => ctx.report_with(def, message),
-                    None => self.violation(ctx.severity, message),
-                });
+                return Some(ctx.report_with(defect.def, message));
             }
         }
         None
@@ -151,6 +150,8 @@ severity = "warn"
             RFC_9110_5_6_2,
             RFC_9110_5_6_4,
             RFC_9111_1_2_2,
+            RFC_9111_5_2_2_4,
+            RFC_9111_5_2_2_7,
         ]
     }
 
@@ -342,8 +343,9 @@ fn field_name_list_defect(name: &str, argument: &str) -> Option<Defect> {
     // not the same statement. `#field-name` is a plain `#`, so an argument of
     // nothing is a zero-element list the production generates — what is wrong
     // with `private=""` is that the *qualified* form is defined as listing one
-    // or more field names, which is § 5.2.2.7's sentence and no subject's.
-    // `private=","` is the other one: an element a sender wrote and left blank.
+    // or more field names, which is the directive's own subsection and no
+    // production. `private=","` is the other one: an element a sender wrote and
+    // left blank, which is the list's sender MUST NOT.
     // cite(RFC 9110 § 5.6.1): "#element => [ element ] *( OWS "," OWS [ element ] )"
     let lists_no_field = list.trim().is_empty();
 
@@ -352,7 +354,11 @@ fn field_name_list_defect(name: &str, argument: &str) -> Option<Defect> {
         if field.is_empty() {
             let message = format!("Empty field-name in {} value", name);
             return Some(match lists_no_field {
-                true => Defect::unnamed(message),
+                // Which of the two sentences governs is the directive name, and
+                // the caller has it: each subsection defines its own qualified
+                // form, so a finding here cites the paragraph the sender was
+                // reaching for.
+                true => Defect::named(qualified_form_lists_nothing(name), message),
                 false => Defect::named(&LIST_MEMBER_EMPTY, message),
             });
         }
@@ -364,6 +370,20 @@ fn field_name_list_defect(name: &str, argument: &str) -> Option<Defect> {
         }
     }
     None
+}
+
+/// The entry for a qualified form that lists no field name, chosen by the
+/// directive that was written.
+///
+/// Both subsections state the same requirement for their own directive and the
+/// two entries exist to keep that citation, so the mapping is the whole of the
+/// difference between them. `private` is the fallback rather than a third arm:
+/// only these two names reach here, and the compiler cannot say so.
+fn qualified_form_lists_nothing(name: &str) -> &'static ViolationDef {
+    match name.eq_ignore_ascii_case("no-cache") {
+        true => &CACHE_CONTROL_NO_CACHE_ARGUMENT_EMPTY,
+        false => &CACHE_CONTROL_PRIVATE_ARGUMENT_EMPTY,
+    }
 }
 
 /// Registers this rule into the engine's auto-collected catalogue.
@@ -869,17 +889,26 @@ mod tests {
         );
     }
 
-    /// The one statement left with no production behind it: § 5.2.2.7 defines
-    /// the qualified form as listing *one or more* field names, and no imported
-    /// grammar says a `#field-name` may not be empty — `#` generates it.
-    #[test]
-    fn an_argument_listing_no_field_is_the_rules_own_and_keeps_no_id() {
-        assert_eq!(judge("private=\"\"").violation, "");
+    /// The statement with no production behind it: each directive's subsection
+    /// defines the qualified form as listing *one or more* field names, and no
+    /// imported grammar says a `#field-name` may not be empty — `#` generates
+    /// it. The requirement is written once per directive, so the id says which
+    /// paragraph the finding is against.
+    #[rstest]
+    #[case("private=\"\"", "cache_control_private_argument_empty")]
+    #[case("no-cache=\"\"", "cache_control_no_cache_argument_empty")]
+    #[case("PRIVATE=\"\"", "cache_control_private_argument_empty")]
+    #[case("No-Cache=\" \"", "cache_control_no_cache_argument_empty")]
+    fn an_argument_listing_no_field_names_the_directives_own_sentence(
+        #[case] value: &str,
+        #[case] id: &str,
+    ) {
+        assert_eq!(judge(value).violation, id, "{value}");
     }
 
     /// One line, two statements, and the argument syntax is what separates
     /// them. `#field-name` generates the empty list, so an argument listing
-    /// nothing breaks § 5.2.2.7's definition of the qualified form and not
+    /// nothing breaks the directive's definition of the qualified form and not
     /// § 5.6.1.1's MUST NOT — which forbids an element a sender wrote and left
     /// blank, and is exactly what the comma in the second value is.
     #[test]
@@ -887,7 +916,7 @@ mod tests {
         let empty_list = judge("private=\"\"");
         let empty_element = judge("private=\",\"");
         assert_eq!(empty_list.message, empty_element.message);
-        assert_eq!(empty_list.violation, "");
+        assert_eq!(empty_list.violation, "cache_control_private_argument_empty");
         assert_eq!(empty_element.violation, "list_member_empty");
     }
 

--- a/lint-http-rules/src/violations/cache_control.rs
+++ b/lint-http-rules/src/violations/cache_control.rs
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `Cache-Control` defects — what a *named* directive means by its argument.
+//!
+//! Nothing about this field's grammar is its own. RFC 9111 § 1.2.1 imports
+//! `token`, `quoted-string` and `field-name` from RFC 9110 by reference and
+//! takes the list construct from § 5.6.1, so a directive name holding a `@`, a
+//! member written blank and an unterminated quoted argument all report the ids
+//! any other field written out of those productions reports.
+//!
+//! **What is left is the layer above the grammar: a directive whose definition
+//! says what its argument must say.** `cache-directive = token [ "=" ( token /
+//! quoted-string ) ]` is satisfied by `private=""` — the argument derives, and
+//! the empty interior of a `quoted-string` is a `quoted-string`. What fails is
+//! the sentence in the directive's own subsection, which is where the
+//! qualified form is defined as listing one or more field names.
+//!
+//! **Two entries, one per directive, because the requirement is written once
+//! per directive and every site knows which it read.** The two senders wrote
+//! the same mistake and would apply the same fix, so this is 2 sentences rather
+//! than 2 defects — and the line the catalogue draws is that folding them would
+//! cost a citation both halves can carry: an entry naming § 5.2.2.4 and
+//! § 5.2.2.7 together governs neither finding, where an entry per directive
+//! sends an operator to the paragraph that defines what they wrote.
+//!
+//! **Both are `info`, and the two Notes are the argument.** A cache that cannot
+//! read the qualification handles the directive as if the unqualified form had
+//! arrived — which both sections say is the common implementation anyway — and
+//! the unqualified form of each of these is the *stricter* one: an unqualified
+//! `private` keeps the whole response out of a shared cache, an unqualified
+//! `no-cache` revalidates the whole response. So nothing a recipient does with
+//! the value is wrong, and what the sender loses is the exemption they asked
+//! for. The exchange continues, and continues conservatively.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// The `no-cache` directive: its argument syntax, the qualified form defined as
+/// listing field names, and the Note that caches commonly treat that form as
+/// the unqualified one.
+pub const RFC_9111_5_2_2_4: SpecRef = SpecRef {
+    spec: "RFC 9111",
+    section: Some("5.2.2.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.4",
+    note: "no-cache — argument syntax `#field-name`, the qualified form defined as an argument listing one or more field names, and the Note that caches often handle it as an unqualified no-cache",
+};
+
+/// The `private` directive, written to the same shape: an argument syntax, a
+/// qualified form that lists field names, and the same Note about how the form
+/// is handled in practice.
+pub const RFC_9111_5_2_2_7: SpecRef = SpecRef {
+    spec: "RFC 9111",
+    section: Some("5.2.2.7"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.7",
+    note: "private — argument syntax `#field-name`, the qualified form defined as an argument listing one or more field names, and the Note that caches often handle it as an unqualified private",
+};
+
+defects! {
+    /// `no-cache=""`: the qualified form written with an argument that lists no
+    /// field name at all.
+    ///
+    /// The grammar has nothing to say about it — `cache-directive = token [ "="
+    /// ( token / quoted-string ) ]` derives the empty `quoted-string`, and
+    /// `#field-name` is a plain `#`, which generates a list of none. What the
+    /// value contradicts is the paragraph that defines the form the sender
+    /// reached for: an argument that lists *one or more* field names.
+    ///
+    /// Not the empty *element*: `no-cache=","` is a list with two blanks in it,
+    /// which is [`list_member_empty`](crate::violations::list)'s sender MUST
+    /// NOT and a different mistake. And not `no-cache=` either — a `=` with
+    /// nothing after it is the leniency the two `Cache-Control` rules record
+    /// between them, one level below this entry.
+    ///
+    // cite(RFC 9111 § 5.2.2.4): "The qualified form of the no-cache response directive, with an argument that lists one or more field names"
+    CACHE_CONTROL_NO_CACHE_ARGUMENT_EMPTY = {
+        id: "cache_control_no_cache_argument_empty",
+        title: "Cache-Control no-cache is qualified by no field name",
+        message: "",
+        default_severity: Severity::Info,
+        spec: &[RFC_9111_5_2_2_4],
+    }
+
+    /// `private=""`: the same shape under the other directive that takes a
+    /// `#field-name` argument, and its own section states the requirement in
+    /// its own words.
+    ///
+    /// The sibling entry's reading applies unchanged, which is why the two are
+    /// worded alike and ranked alike: what separates them is the sentence a
+    /// finding names, and a site always knows which directive it read.
+    ///
+    // cite(RFC 9111 § 5.2.2.7): "If a qualified private response directive is present, with an argument that lists one or more field names"
+    CACHE_CONTROL_PRIVATE_ARGUMENT_EMPTY = {
+        id: "cache_control_private_argument_empty",
+        title: "Cache-Control private is qualified by no field name",
+        message: "",
+        default_severity: Severity::Info,
+        spec: &[RFC_9111_5_2_2_7],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The pair is two sentences and one defect, which is the whole reason the
+    /// ids differ and nothing else about them does.
+    #[test]
+    fn the_pair_differs_only_in_the_sentence_it_names() {
+        assert_eq!(
+            CACHE_CONTROL_NO_CACHE_ARGUMENT_EMPTY.default_severity,
+            CACHE_CONTROL_PRIVATE_ARGUMENT_EMPTY.default_severity,
+        );
+        assert_eq!(
+            CACHE_CONTROL_NO_CACHE_ARGUMENT_EMPTY.default_severity,
+            Severity::Info,
+        );
+        assert_eq!(
+            CACHE_CONTROL_NO_CACHE_ARGUMENT_EMPTY.spec,
+            [RFC_9111_5_2_2_4]
+        );
+        assert_eq!(
+            CACHE_CONTROL_PRIVATE_ARGUMENT_EMPTY.spec,
+            [RFC_9111_5_2_2_7]
+        );
+    }
+}

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -37,6 +37,7 @@ pub mod base64;
 pub mod basic_credentials;
 pub mod boundary;
 pub mod bws;
+pub mod cache_control;
 pub mod challenge;
 pub mod charset;
 pub mod comment;
@@ -420,7 +421,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 212;
+        const FLOOR: usize = 214;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -5421,7 +5421,7 @@ sources:
     snippet: A field name labels the corresponding field value as having the semantics defined by that name.
     cited_by:
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 320
+      line: 321
   - label: cache_validation_chain
     section: § 13.1.2
     snippet: The "If-None-Match" header field makes the request method conditional on a recipient cache or origin server either not having any current representation of the target resource, when the field value is "*"
@@ -6809,7 +6809,7 @@ sources:
     - file: lint-http-rules/src/helpers/cache_control.rs
       line: 126
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 347
+      line: 349
   - label: lint-http-rules/src/helpers/comment.rs
     section: § 5.6.4
     snippet: The backslash octet ("\") can be used as a single-octet quoting mechanism within quoted-string and comment constructs.
@@ -9438,7 +9438,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 372
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 269
+      line: 270
     - file: lint-http-rules/src/violations/delta_seconds.rs
       line: 23
   - label: alt_svc_h3_advertisement_valid (2)
@@ -9448,7 +9448,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 346
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 235
+      line: 236
   - label: alt_svc_h3_advertisement_valid (3)
     section: § 1.2.2
     snippet: or the greatest positive integer it can conveniently represent.
@@ -9456,13 +9456,19 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 373
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 270
+      line: 271
   - label: cache_coherence
     section: § 4.2.4
     snippet: A cache MUST NOT generate a stale response unless it is disconnected or doing so is explicitly permitted by the client or origin server
     cited_by:
     - file: lint-http-rules/src/rules/cache_coherence.rs
       line: 183
+  - label: cache_control
+    section: § 5.2.2.4
+    snippet: The qualified form of the no-cache response directive, with an argument that lists one or more field names
+    cited_by:
+    - file: lint-http-rules/src/violations/cache_control.rs
+      line: 77
   - label: cache_control_and_pragma_consistent
     section: § 5.4
     snippet: However, support for Cache-Control is now widespread.  As a result, this specification deprecates Pragma.
@@ -9482,7 +9488,7 @@ sources:
     snippet: The "Cache-Control" header field is used to list directives for caches along the request/response chain.
     cited_by:
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 194
+      line: 195
     - file: lint-http-rules/src/rules/cache_control_token_valid.rs
       line: 145
   - label: max-age argument syntax
@@ -9490,19 +9496,21 @@ sources:
     snippet: delta-seconds (see Section 1.2.2)
     cited_by:
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 255
+      line: 256
   - label: cache_control_directive_valid (2)
     section: § 5.2.2.7
     snippet: If a qualified private response directive is present, with an argument that lists one or more field names
     cited_by:
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 277
+      line: 278
+    - file: lint-http-rules/src/violations/cache_control.rs
+      line: 94
   - label: private argument syntax
     section: § 5.2.2.7
     snippet: This directive uses the quoted-string form of the argument syntax.
     cited_by:
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 319
+      line: 320
   - label: cache_control_present
     section: § 4.2.2
     snippet: Since origin servers do not always provide explicit expiration times, a cache MAY assign a heuristic expiration time when an explicit time is not specified, employing algorithms that use other field values (such as the Last-Modified time) to estimate a plausible expiration time.
@@ -9656,7 +9664,7 @@ sources:
     - file: lint-http-rules/src/helpers/cache_control.rs
       line: 175
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 211
+      line: 212
     - file: lint-http-rules/src/rules/cache_control_token_valid.rs
       line: 162
   - label: lint-http-rules/src/helpers/cache_control.rs (8)


### PR DESCRIPTION
`violations/cache_control.rs` opens with two entries and `cache_control_directive_valid` converts whole. Its last unnamed finding is `private=""` — and `no-cache=""`, which reaches the same line: a directive written in its qualified form with an argument that lists no field name.

Nothing in the grammar objects. `cache-directive = token [ "=" ( token / quoted-string ) ]` derives an empty `quoted-string`, and `#field-name` is a plain `#`, which generates a list of none. What the value contradicts is the paragraph defining the form the sender reached for, and RFC 9111 writes that paragraph once per directive — §5.2.2.4 for `no-cache`, §5.2.2.7 for `private`.

So it is two entries for one defect. The senders wrote the same mistake and would apply the same fix, and the split buys the thing folding would cost: an entry naming both sections governs neither finding, where an entry per directive sends an operator to the paragraph that defines what they wrote. Every site knows which directive it read.

Both are `info`, and the Notes in those same subsections are the argument: a cache that cannot read the qualification handles the directive as if the unqualified form had arrived, which both sections say is the common implementation anyway — and for both of these the unqualified form is the stricter one. Nothing a recipient does with the value is wrong; what the sender loses is the exemption they asked for.

The empty *element* stays where it was: `private=","` is a list with a blank in it, which is §5.6.1.1's sender MUST NOT and a different mistake.

Floor: 214 of 221 entries cite a sentence.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
