### PR TITLE
The nonce a handshake is answered from

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1735,6 +1735,14 @@ severity = "error"
 # Sec-WebSocket-Extensions writes a parameter '=' with no value after it
 severity = "error"
 
+[violations.sec_websocket_key_length_invalid]
+# Sec-WebSocket-Key is not a sixteen-byte nonce
+severity = "warn"
+
+[violations.sec_websocket_key_missing]
+# WebSocket handshake carries no Sec-WebSocket-Key
+severity = "error"
+
 [violations.status_101_ignored]
 # HTTP continues on a connection a 101 handed off
 severity = "warn"

--- a/lint-http-rules/src/helpers/websocket.rs
+++ b/lint-http-rules/src/helpers/websocket.rs
@@ -139,7 +139,7 @@ pub fn opening_handshake_version(
 /// value outside the alphabet, a value the encoding does not generate, and a
 /// perfectly good encoding of the wrong number of octets are three different things
 /// for an operator to go and fix.
-// cite(RFC 6455 § 4.3, label: Sec-WebSocket-Key): "Sec-WebSocket-Key = base64-value-non-empty"
+// cite(RFC 6455 § 4.3, label: Sec-WebSocket-Key grammar): "Sec-WebSocket-Key = base64-value-non-empty"
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SecWebSocketKeyDefect {
     /// An octet that `base64-character` does not derive.

--- a/lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
+++ b/lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
@@ -16,6 +16,9 @@ use crate::violations::base64::{
 use crate::violations::list::{
     LIST_MEMBER_EMPTY, LIST_MEMBER_MISSING, RFC_9110_5_6_1_1, RFC_9110_5_6_1_2,
 };
+use crate::violations::sec_websocket_key::{
+    RFC_6455_4_1, SEC_WEBSOCKET_KEY_LENGTH_INVALID, SEC_WEBSOCKET_KEY_MISSING,
+};
 use crate::violations::token::{
     token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
     TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
@@ -28,17 +31,14 @@ pub struct SecWebsocketHeadersConsistent;
 /// and none it writes.
 ///
 /// **The key**: `Sec-WebSocket-Key = base64-value-non-empty`, and RFC 6455
-/// hands the encoding to RFC 4648 without restating a character of it.
-///
-/// `Sec-WebSocket-Key = base64-value-non-empty`, and RFC 6455 hands the
-/// encoding to RFC 4648 without restating a character of it — so an octet
-/// outside the alphabet, a symbol count no group of twenty-four bits accounts
-/// for, and a final symbol whose discarded bits are not zero are the same three
-/// defects an `Authorization: Basic` value can have. What is left is the
-/// field's own sentence — the nonce is sixteen octets, and the field has to be
-/// there at all — and both of those stay in this rule's words: they belong to a
-/// `sec_websocket_key` subject nothing has written, and a subject with one
-/// reader is written when it is read twice.
+/// hands the encoding to RFC 4648 without restating a character of it — so an
+/// octet outside the alphabet, a symbol count no group of twenty-four bits
+/// accounts for, and a final symbol whose discarded bits are not zero are the
+/// same three defects an `Authorization: Basic` value can have. What is left is
+/// item 7's own two sentences — the field has to be there at all, and what it
+/// carries is a sixteen-byte nonce — which are the
+/// [`sec_websocket_key`](crate::violations::sec_websocket_key) subject and are
+/// declared here beside the encoding's three.
 ///
 /// **The subprotocol list**: `Sec-WebSocket-Protocol-Client = 1#token`, so a
 /// value naming nothing, a stray comma and an octet no `tchar` admits are the
@@ -47,12 +47,15 @@ pub struct SecWebsocketHeadersConsistent;
 /// one word. What stays this rule's own is the uniqueness requirement, which is
 /// about the *set* and which § 5.6.1.1 writes nothing about.
 ///
-/// `Connection` and the version are untouched and say so through their type: an
-/// unnamed [`Defect`] is a finding no subject has claimed.
+/// `Connection`, the version and the subprotocol list's uniqueness requirement
+/// are untouched and say so through their type: an unnamed [`Defect`] is a
+/// finding no subject has claimed.
 static DECLARED: &[&ViolationDef] = &[
     &BASE64_CHARACTER_FORBIDDEN,
     &BASE64_QUANTUM_MALFORMED,
     &BASE64_PAD_BITS_INVALID,
+    &SEC_WEBSOCKET_KEY_MISSING,
+    &SEC_WEBSOCKET_KEY_LENGTH_INVALID,
     &LIST_MEMBER_MISSING,
     &LIST_MEMBER_EMPTY,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
@@ -165,13 +168,14 @@ impl SecWebsocketHeadersConsistent {
     ///
     /// Three of the four verdicts are the encoding's and carry its ids; the
     /// fourth is a well-formed encoding of the wrong number of octets, which is
-    /// this field's own sentence and is left unnamed. The field being absent
-    /// altogether is the same field's sentence and is left unnamed beside it —
-    /// one commit will write both, or neither.
+    /// the field's own sentence and is the `sec_websocket_key` subject's. The
+    /// field being absent altogether is the other sentence of the same numbered
+    /// item, and the two landed together as that entry predicted.
     // cite(RFC 6455 § 4.1): "The request MUST include a header field with the name |Sec-WebSocket-Key|."
     fn key_defect(headers: &hyper::HeaderMap) -> Option<Defect> {
         let Some(raw) = combined_field_value_as_written(headers, "sec-websocket-key") else {
-            return Some(Defect::unnamed(
+            return Some(Defect::named(
+                &SEC_WEBSOCKET_KEY_MISSING,
                 "the request carries no Sec-WebSocket-Key header field".into(),
             ));
         };
@@ -181,10 +185,7 @@ impl SecWebsocketHeadersConsistent {
             shown_in_finding(trim_ows(&raw)),
             defect
         );
-        Some(match key_violation(&defect) {
-            Some(def) => Defect::named(def, message),
-            None => Defect::unnamed(message),
-        })
+        Some(Defect::named(key_violation(&defect), message))
     }
 
     /// The optional `Sec-WebSocket-Protocol`, which is two MUSTs about its members
@@ -264,12 +265,11 @@ impl SecWebsocketHeadersConsistent {
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_6455_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 6455",
-    section: Some("4.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.1",
-    note: "Client Requirements — the numbered list this rule measures: GET, HTTP version at least 1.1, `Upgrade: websocket`, the `Upgrade` connection-option, the `Sec-WebSocket-Key` nonce, `Sec-WebSocket-Version: 13`, and `Sec-WebSocket-Protocol`'s non-empty unique `token` members",
-};
+///
+/// § 4.1 is not written here: its item 7 is what the
+/// [`sec_websocket_key`](crate::violations::sec_websocket_key) entries enforce,
+/// so the reference lives beside them and is imported back — which is also why
+/// the numbered list a reader is sent to is described from the field's side.
 const RFC_6455_4_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 6455",
     section: Some("4.2.1"),

--- a/lint-http-rules/src/violations/base64.rs
+++ b/lint-http-rules/src/violations/base64.rs
@@ -137,27 +137,30 @@ defects! {
     }
 }
 
-/// The defect a [`SecWebSocketKeyDefect`] reports as, where this subject holds
-/// one.
+/// The defect a [`SecWebSocketKeyDefect`] reports as.
 ///
-/// [`SecWebSocketKeyDefect::Length`] is the only variant that answers `None`,
-/// and it is not an encoding defect at all: a base64 spelling of twelve octets
-/// is a perfectly good base64 spelling, and the sixteen is RFC 6455's sentence
-/// about what the field carries. That defect belongs to a `sec_websocket_key`
-/// subject nothing has written, and the rule reporting it keeps its own words
-/// until something does.
+/// Three of the four verdicts are this subject's and the fourth is not an
+/// encoding defect at all: a base64 spelling of twelve octets is a perfectly
+/// good base64 spelling, and the sixteen is RFC 6455's sentence about what the
+/// field carries. That one is
+/// [`sec_websocket_key`](crate::violations::sec_websocket_key)'s, which is why
+/// this mapping crosses subjects rather than answering `None` — **a reader
+/// whose verdicts belong to two subjects is still one mapping**, the shape
+/// `word_defect` has for the alternation it splits.
 ///
 /// The mapping lives here rather than in a file named after the helper for the
 /// reason every mapping in this catalogue is shelved that way — the first thing
 /// this reader measures is the encoding, and a
 /// subject file holding nothing but a mapping fn would carry no `// cite` and
 /// fail the citation ratchet on the spot.
-pub fn sec_websocket_key_defect(defect: &SecWebSocketKeyDefect) -> Option<&'static ViolationDef> {
+pub fn sec_websocket_key_defect(defect: &SecWebSocketKeyDefect) -> &'static ViolationDef {
     match defect {
-        SecWebSocketKeyDefect::Alphabet(_) => Some(&BASE64_CHARACTER_FORBIDDEN),
-        SecWebSocketKeyDefect::Shape => Some(&BASE64_QUANTUM_MALFORMED),
-        SecWebSocketKeyDefect::PadBits => Some(&BASE64_PAD_BITS_INVALID),
-        SecWebSocketKeyDefect::Length(_) => None,
+        SecWebSocketKeyDefect::Alphabet(_) => &BASE64_CHARACTER_FORBIDDEN,
+        SecWebSocketKeyDefect::Shape => &BASE64_QUANTUM_MALFORMED,
+        SecWebSocketKeyDefect::PadBits => &BASE64_PAD_BITS_INVALID,
+        SecWebSocketKeyDefect::Length(_) => {
+            &crate::violations::sec_websocket_key::SEC_WEBSOCKET_KEY_LENGTH_INVALID
+        }
     }
 }
 
@@ -166,34 +169,25 @@ mod tests {
     use super::*;
     use crate::helpers::websocket::sec_websocket_key_defect as read_key;
 
-    /// The mapping, written against the reader: four verdicts, three ids and
-    /// one deliberate `None`. The values are the ones RFC 6455's own examples
-    /// and NOTE reach.
+    /// The mapping, written against the reader: four verdicts, four ids, and
+    /// the fourth belonging to the field rather than to the encoding. The
+    /// values are the ones RFC 6455's own examples and NOTE reach.
     #[test]
-    fn the_three_encoding_verdicts_are_three_ids_and_the_length_is_not_one() {
+    fn the_three_encoding_verdicts_are_three_ids_and_the_length_is_another_subjects() {
         let id = |value: &str| {
             let defect = read_key(value).expect("a defect");
-            sec_websocket_key_defect(&defect).map(|def| def.id)
+            sec_websocket_key_defect(&defect).id
         };
 
         // `!` is not one of the sixty-four, and `=` inside the value is a pad
         // character where no padding goes.
-        assert_eq!(
-            id("dGhlIHNhbXBsZSBub25jZQ!="),
-            Some("base64_character_forbidden")
-        );
-        assert_eq!(
-            id("dGhlIHNhbXBsZ=Sbm9uY2U="),
-            Some("base64_quantum_malformed")
-        );
+        assert_eq!(id("dGhlIHNhbXBsZSBub25jZQ!="), "base64_character_forbidden");
+        assert_eq!(id("dGhlIHNhbXBsZ=Sbm9uY2U="), "base64_quantum_malformed");
         // § 4.1's own NOTE prints this spelling of the octets 0x01..0x10.
-        assert_eq!(
-            id("AQIDBAUGBwgJCgsMDQ4PEC=="),
-            Some("base64_pad_bits_invalid")
-        );
+        assert_eq!(id("AQIDBAUGBwgJCgsMDQ4PEC=="), "base64_pad_bits_invalid");
         // A well-formed encoding of the wrong number of octets is not the
-        // encoding's defect, so this subject does not answer for it.
-        assert_eq!(id("dGhlIHNhbXBsZQ=="), None);
+        // encoding's defect, and the id it answers with says whose it is.
+        assert_eq!(id("dGhlIHNhbXBsZQ=="), "sec_websocket_key_length_invalid");
         // And the value § 4.1 prints as the field's example is no defect at all.
         assert!(read_key("dGhlIHNhbXBsZSBub25jZQ==").is_none());
     }

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -64,6 +64,7 @@ pub mod quoted_string;
 pub mod qvalue;
 pub mod request_target;
 pub mod sec_websocket_extensions;
+pub mod sec_websocket_key;
 pub mod status;
 pub mod strict_transport_security;
 pub mod te;
@@ -421,7 +422,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 214;
+        const FLOOR: usize = 216;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/sec_websocket_key.rs
+++ b/lint-http-rules/src/violations/sec_websocket_key.rs
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `Sec-WebSocket-Key` defects — what the field carries, rather than how it is
+//! spelled.
+//!
+//! `Sec-WebSocket-Key = base64-value-non-empty` and RFC 6455 hands the encoding
+//! to RFC 4648 without restating a character of it, so an octet outside the
+//! alphabet, a symbol count no group of twenty-four bits accounts for and a
+//! final symbol carrying bits a conforming encoder zeroes are all
+//! [`base64`](crate::violations::base64)'s — the same three defects an
+//! `Authorization: Basic` value can have.
+//!
+//! **What is left is item 7 of § 4.1's list, and it is two sentences about a
+//! nonce**: that the field is there at all, and that what it carries is a
+//! randomly selected sixteen-byte value. Neither is an encoding question — a
+//! base64 spelling of twelve octets is a perfectly good base64 spelling — which
+//! is why the encoding subject's mapping had one verdict it could not answer
+//! and this subject is what answers it.
+//!
+//! **The two entries rank apart, on whether the handshake can complete.** A
+//! request with no key at all cannot be answered: § 4.2.2 derives
+//! `Sec-WebSocket-Accept` from the key's octets, so a server has nothing to
+//! compute from and § 4.2.1 tells it to stop and answer with an error status. A
+//! key of the wrong length is answered normally — the accept value is the SHA-1
+//! of the field *as a string*, whatever length it decodes to — and what is lost
+//! is the guarantee the nonce exists for: that this handshake cannot be
+//! replayed from a cached response. **Ask whether the exchange can continue**,
+//! which is the same question [`status`](crate::violations::status) is ranked
+//! by, and here it separates the pair.
+//!
+//! Not here: whether the nonce was *randomly* selected, or reused across
+//! connections. Both are properties of how a value was chosen and a capture of
+//! one handshake holds no evidence of either.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// Client Requirements, item 7: the field, the nonce it carries, and the
+/// sixteen bytes that nonce is. The two entries below split one numbered item
+/// into its two sentences.
+pub const RFC_6455_4_1: SpecRef = SpecRef {
+    spec: "RFC 6455",
+    section: Some("4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.1",
+    note: "Client Requirements — the numbered list this rule measures: GET, HTTP version at least 1.1, `Upgrade: websocket`, the `Upgrade` connection-option, the `Sec-WebSocket-Key` nonce, `Sec-WebSocket-Version: 13`, and `Sec-WebSocket-Protocol`'s non-empty unique `token` members",
+};
+
+defects! {
+    /// An opening handshake with no `Sec-WebSocket-Key` field on it at all.
+    ///
+    /// `error`, and the server's side of the same document is why: the accept
+    /// value a `101` owes is derived from this field's octets, so a request
+    /// without one asks for a handshake no server can complete. What a server
+    /// does instead is stop and answer with an error status.
+    ///
+    /// Over HTTP/2 and HTTP/3 the field is not sent and not processed — RFC
+    /// 8441 replaces the nonce with the extended CONNECT — so a rule reporting
+    /// this entry has to know which version carried the request.
+    ///
+    // cite(RFC 6455 § 4.1): "The request MUST include a header field with the name |Sec-WebSocket-Key|."
+    SEC_WEBSOCKET_KEY_MISSING = {
+        id: "sec_websocket_key_missing",
+        title: "WebSocket handshake carries no Sec-WebSocket-Key",
+        message: "",
+        default_severity: Severity::Error,
+        spec: &[RFC_6455_4_1],
+    }
+
+    /// A field whose value is a well-formed base64 encoding of some number of
+    /// octets other than sixteen.
+    ///
+    /// **Not an encoding defect**, which is the whole reason this entry exists
+    /// beside [`base64`](crate::violations::base64)'s three: every symbol is in
+    /// the alphabet, the quantum count is whole and the padding is where it
+    /// belongs. What the value fails is the sentence saying what the field
+    /// carries — a nonce of sixteen bytes — and that sentence is this
+    /// document's.
+    ///
+    /// `_invalid` and not `_malformed`: the value derives from
+    /// `base64-value-non-empty` exactly as written, and what refuses it is a
+    /// requirement past the grammar, which is the line
+    /// `docs/development.md` draws between the two words.
+    ///
+    /// `warn`, where the absent field is an `error`. The handshake still
+    /// completes: § 4.2.2 hashes the field as a string rather than the octets
+    /// it decodes to, so a server answers a twelve-octet key with a perfectly
+    /// valid accept value. What is lost is what the length is *for* — a nonce
+    /// wide enough that a `101` cannot be replayed out of a cache.
+    ///
+    // cite(RFC 6455 § 4.1): "The value of this header field MUST be a nonce consisting of a randomly selected 16-byte value that has been base64-encoded (see Section 4 of [RFC4648])."
+    SEC_WEBSOCKET_KEY_LENGTH_INVALID = {
+        id: "sec_websocket_key_length_invalid",
+        title: "Sec-WebSocket-Key is not a sixteen-byte nonce",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_6455_4_1],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One numbered item, two sentences, two entries — and the rank is what
+    /// they disagree about: a server can answer one of these and not the other.
+    #[test]
+    fn the_absent_field_outranks_the_wrong_length() {
+        assert!(
+            SEC_WEBSOCKET_KEY_LENGTH_INVALID.default_severity
+                < SEC_WEBSOCKET_KEY_MISSING.default_severity
+        );
+        assert_eq!(SEC_WEBSOCKET_KEY_MISSING.default_severity, Severity::Error);
+    }
+
+    /// Both are item 7's, which is the one place the field's own requirements
+    /// are written; the encoding's sentences live with the encoding.
+    #[test]
+    fn both_entries_name_the_field_s_own_item() {
+        assert_eq!(SEC_WEBSOCKET_KEY_MISSING.spec, [RFC_6455_4_1]);
+        assert_eq!(SEC_WEBSOCKET_KEY_LENGTH_INVALID.spec, [RFC_6455_4_1]);
+    }
+}

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -2557,7 +2557,7 @@ sources:
     - file: lint-http-proxy/src/proxy/websocket/mod.rs
       line: 38
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 99
+      line: 102
   - label: lint-http-proxy/src/proxy/websocket/mod.rs (2)
     section: § 4.1
     snippet: The request MUST contain an |Upgrade| header field whose value MUST include the "websocket" keyword.
@@ -2622,7 +2622,7 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 314
-  - label: Sec-WebSocket-Key
+  - label: Sec-WebSocket-Key grammar
     section: § 4.3
     snippet: Sec-WebSocket-Key = base64-value-non-empty
     cited_by:
@@ -2697,31 +2697,33 @@ sources:
     snippet: The ABNF for the value of this header field is 1#token, where the definitions of constructs and rules are as given in [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 203
+      line: 204
   - label: sec_websocket_headers_consistent (2)
     section: § 4.1
     snippet: The elements that comprise this value MUST be non-empty strings with characters in the range U+0021 to U+007E not including separator characters as defined in [RFC2616] and MUST all be unique strings.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 202
+      line: 203
   - label: sec_websocket_headers_consistent (3)
     section: § 4.1
     snippet: The request MUST include a header field with the name |Sec-WebSocket-Key|.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 171
+      line: 174
+    - file: lint-http-rules/src/violations/sec_websocket_key.rs
+      line: 63
   - label: sec_websocket_headers_consistent (4)
     section: § 4.1
     snippet: The request MUST include a header field with the name |Sec-WebSocket-Version|.  The value of this header field MUST be 13.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 123
+      line: 126
   - label: sec_websocket_headers_consistent (5)
     section: § 4.2.1
     snippet: A |Connection| header field that includes the token "Upgrade", treated as an ASCII case-insensitive value.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 100
+      line: 103
   - label: sec_websocket_headers_consistent (6)
     section: § 4.2.1
     snippet: An HTTP/1.1 or higher GET request
@@ -2741,13 +2743,13 @@ sources:
     snippet: Sec-WebSocket-Protocol-Client = 1#token
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 204
+      line: 205
   - label: Sec-WebSocket-Version-Server
     section: § 4.3
     snippet: Sec-WebSocket-Version-Server = 1#version
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 131
+      line: 134
     - file: lint-http-rules/src/rules/sec_websocket_version_advertised.rs
       line: 39
   - label: sec_websocket_headers_consistent (8)
@@ -2755,7 +2757,7 @@ sources:
     snippet: If the server doesn't support the requested version, it MUST respond with a |Sec-WebSocket-Version| header field (or multiple |Sec-WebSocket-Version| header fields) containing all versions it is willing to use.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 151
+      line: 154
     - file: lint-http-rules/src/rules/sec_websocket_version_advertised.rs
       line: 40
   - label: sec_websocket_headers_consistent (9)
@@ -2763,7 +2765,13 @@ sources:
     snippet: a client can initially request the version of the WebSocket Protocol that it prefers (which doesn't necessarily have to be the latest supported by the client)
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 150
+      line: 153
+  - label: sec_websocket_key
+    section: § 4.1
+    snippet: The value of this header field MUST be a nonce consisting of a randomly selected 16-byte value that has been base64-encoded (see Section 4 of [RFC4648]).
+    cited_by:
+    - file: lint-http-rules/src/violations/sec_websocket_key.rs
+      line: 93
   - label: sec_websocket_version_advertised
     section: § 11.3.5
     snippet: In such a case, the header field includes the protocol version(s) supported by the server.
@@ -6639,7 +6647,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 324
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 212
+      line: 213
   - label: lint-http-rules/src/helpers/auth.rs
     section: § 11.1
     snippet: It uses a case-insensitive token to identify the authentication scheme
@@ -7603,7 +7611,7 @@ sources:
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
       line: 197
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 205
+      line: 206
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 506
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs


### PR DESCRIPTION
`violations/sec_websocket_key.rs` opens with two entries and `sec_websocket_headers_consistent`'s key reading converts whole. The field's spelling was already borrowed — RFC 6455 hands the encoding to RFC 4648 without restating a character of it, so an octet outside the alphabet, a broken quantum and a final symbol carrying bits an encoder zeroes are the same three defects an `Authorization: Basic` value has. What was left is item 7's own two sentences: the field has to be there, and what it carries is a sixteen-byte nonce.

A base64 spelling of twelve octets is a perfectly good base64 spelling, which is why the encoding subject's mapping had a verdict it could not answer. It answers now by naming another subject's entry, and drops its `Option`: a reader whose verdicts belong to two subjects is still one mapping.

The pair ranks apart on whether the handshake can complete. With no key at all there is nothing to derive `Sec-WebSocket-Accept` from and a server is told to stop and answer with an error status. A key of the wrong length is answered normally — the accept value is the SHA-1 of the field as a string, whatever it decodes to — and what is lost is what the length is for.

The ABNF fragment's label in the websocket helper gains the word `grammar`, matching its three siblings: a subject file is labelled by its stem, and `sec_websocket_key` and `Sec-WebSocket-Key` differ only in punctuation, so the citations file would have folded two fragments into one.

Floor: 216 of 223 entries cite a sentence.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
