### PR TITLE
The version a handshake asks for

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1747,8 +1747,16 @@ severity = "error"
 # Sec-WebSocket-Version is written with no value
 severity = "error"
 
+[violations.sec_websocket_version_invalid]
+# WebSocket handshake asks for a version other than 13
+severity = "warn"
+
 [violations.sec_websocket_version_malformed]
 # Sec-WebSocket-Version derives from no version production
+severity = "error"
+
+[violations.sec_websocket_version_missing]
+# WebSocket handshake carries no Sec-WebSocket-Version
 severity = "error"
 
 [violations.status_101_ignored]

--- a/lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
+++ b/lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
@@ -21,7 +21,7 @@ use crate::violations::sec_websocket_key::{
 };
 use crate::violations::sec_websocket_version::{
     version_defect as version_violation, RFC_6455_4_3, SEC_WEBSOCKET_VERSION_EMPTY,
-    SEC_WEBSOCKET_VERSION_MALFORMED,
+    SEC_WEBSOCKET_VERSION_INVALID, SEC_WEBSOCKET_VERSION_MALFORMED, SEC_WEBSOCKET_VERSION_MISSING,
 };
 use crate::violations::token::{
     token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
@@ -62,6 +62,8 @@ static DECLARED: &[&ViolationDef] = &[
     &SEC_WEBSOCKET_KEY_LENGTH_INVALID,
     &SEC_WEBSOCKET_VERSION_EMPTY,
     &SEC_WEBSOCKET_VERSION_MALFORMED,
+    &SEC_WEBSOCKET_VERSION_MISSING,
+    &SEC_WEBSOCKET_VERSION_INVALID,
     &LIST_MEMBER_MISSING,
     &LIST_MEMBER_EMPTY,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
@@ -139,7 +141,8 @@ impl SecWebsocketHeadersConsistent {
         // message clean.
         // cite(RFC 6455 § 4.3, label: Sec-WebSocket-Version-Server): "Sec-WebSocket-Version-Server = 1#version"
         let Some(raw) = combined_field_value_as_written(headers, "sec-websocket-version") else {
-            return Some(Defect::unnamed(
+            return Some(Defect::named(
+                &SEC_WEBSOCKET_VERSION_MISSING,
                 "the request carries no Sec-WebSocket-Version header field".into(),
             ));
         };
@@ -160,18 +163,23 @@ impl SecWebsocketHeadersConsistent {
         if value == "13" {
             return None;
         }
-        // Not "invalid", because § 4.4 prints a request exactly like this one as its
-        // illustration of version advertisement -- `Sec-WebSocket-Version: 25`, answered
-        // with a 400 listing what the server will speak. What the value settles is
-        // which protocol this handshake is for, and this document defines one of them.
+        // The catalogue's `_invalid` is what this is: a value that derives from
+        // the production and a requirement past the grammar refusing it. § 4.4
+        // prints a request exactly like this one -- `Sec-WebSocket-Version: 25`,
+        // answered with a 400 listing what the server will speak -- and that is
+        // how a server *answers* it, not a licence for the sender. Which is also
+        // why the entry ranks below the two that derive from nothing.
         // cite(RFC 6455 § 4.4): "a client can initially request the version of the WebSocket Protocol that it prefers (which doesn't necessarily have to be the latest supported by the client)"
         // cite(RFC 6455 § 4.4): "If the server doesn't support the requested version, it MUST respond with a |Sec-WebSocket-Version| header field (or multiple |Sec-WebSocket-Version| header fields) containing all versions it is willing to use."
-        Some(Defect::unnamed(format!(
-            "its Sec-WebSocket-Version is `{}`, so it is not a handshake for the version this \
-             document defines; RFC 6455 § 4.4 makes that a version advertisement, and the \
-             answer it asks a server for is a 400 carrying the versions the server will speak",
-            shown_in_finding(value)
-        )))
+        Some(Defect::named(
+            &SEC_WEBSOCKET_VERSION_INVALID,
+            format!(
+                "its Sec-WebSocket-Version is `{}`, so it is not a handshake for the version this \
+                 document defines; RFC 6455 § 4.4 makes that a version advertisement, and the \
+                 answer it asks a server for is a 400 carrying the versions the server will speak",
+                shown_in_finding(value)
+            ),
+        ))
     }
 
     /// The `Sec-WebSocket-Key` half.

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -423,7 +423,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 218;
+        const FLOOR: usize = 220;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/sec_websocket_version.rs
+++ b/lint-http-rules/src/violations/sec_websocket_version.rs
@@ -31,14 +31,19 @@
 //! reply that would let a client retry — is written for a version the server
 //! *understood* and does not speak. Neither of these is that.
 //!
-//! Not here: a request whose version is a perfectly good number other than 13.
-//! That value derives from the production and what refuses it is § 4.1's item 9,
-//! which is the field's requirement rather than its grammar — a separate entry,
-//! and one that has to be read beside § 4.4 before it is written.
+//! **The other two entries are the field's requirement rather than its grammar**,
+//! and they are one numbered item: § 4.1 item 9 asks a request for the field and
+//! for the value `13`. A request with no field at all is not a handshake this
+//! document can answer; a request with a good number that is not 13 is one it
+//! answers by refusing, which is where the two part company in rank.
 
 use crate::helpers::websocket::VersionDefect;
 use crate::lint::Severity;
 use crate::rules::SpecRef;
+// Item 9 is one numbered item of the same list item 7 is in, so the reference is
+// written once — in the subject that reached it first — and the two subjects
+// name the same `SpecRef` rather than two equal ones.
+use crate::violations::sec_websocket_key::RFC_6455_4_1;
 use crate::violations::{defects, ViolationDef};
 
 /// The collected ABNF: the `version` production, the comment bounding it, and
@@ -91,6 +96,54 @@ defects! {
         default_severity: Severity::Error,
         spec: &[RFC_6455_4_3],
     }
+
+    /// An opening handshake with no `Sec-WebSocket-Version` field on it at all.
+    ///
+    /// The first half of item 9, and `error` for the reason the grammar's two
+    /// are: a server has no version to check and § 4.2.1 has it stop and answer
+    /// with an error status. There is nothing to advertise back either — § 4.4's
+    /// reply lists the versions a server will speak *in answer to* one it was
+    /// asked for.
+    ///
+    // cite(RFC 6455 § 4.1): "The request MUST include a header field with the name |Sec-WebSocket-Version|.  The value of this header field MUST be 13."
+    SEC_WEBSOCKET_VERSION_MISSING = {
+        id: "sec_websocket_version_missing",
+        title: "WebSocket handshake carries no Sec-WebSocket-Version",
+        message: "",
+        default_severity: Severity::Error,
+        spec: &[RFC_6455_4_1],
+    }
+
+    /// A request whose version derives from the production and is not 13.
+    ///
+    /// **`_invalid` is the vocabulary's word for exactly this**: the value is
+    /// grammatical and a requirement past the grammar refuses it. The rule
+    /// reporting it had declined the word on the grounds that § 4.4 prints a
+    /// request like this one — `Sec-WebSocket-Version: 25`, answered with a 400
+    /// listing what the server will speak — but that section describes how a
+    /// server *answers* a version it does not understand, and item 9 is what
+    /// says which version a request may carry. Both are true, and only one of
+    /// them is addressed to the sender.
+    ///
+    /// `warn`, alone in this subject, and § 4.4 is why: the exchange has a
+    /// defined outcome that leaves the connection an ordinary HTTP one and the
+    /// client able to ask again. A version nobody can *read* has no such reply —
+    /// the advertisement is written for a version a server understood and does
+    /// not speak.
+    ///
+    /// The NOTE beside item 9 is worth knowing before raising this: the draft
+    /// values 9 through 12 were reserved in the registry and never used, so a
+    /// capture carrying one is a client built against a draft rather than a
+    /// client speaking a version that exists.
+    ///
+    // cite(RFC 6455 § 4.1): "The request MUST include a header field with the name |Sec-WebSocket-Version|.  The value of this header field MUST be 13."
+    SEC_WEBSOCKET_VERSION_INVALID = {
+        id: "sec_websocket_version_invalid",
+        title: "WebSocket handshake asks for a version other than 13",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_6455_4_1],
+    }
 }
 
 /// The entry a [`VersionDefect`] reports as.
@@ -134,7 +187,8 @@ mod tests {
     }
 
     /// A version nobody can read is a handshake nobody can negotiate, whichever
-    /// side wrote it — so the pair ranks together and ranks at the top.
+    /// side wrote it — so those rank at the top, and the one value the document
+    /// answers by refusing ranks below them.
     #[test]
     fn a_version_that_cannot_be_read_ends_the_negotiation() {
         assert_eq!(
@@ -145,5 +199,21 @@ mod tests {
             SEC_WEBSOCKET_VERSION_MALFORMED.default_severity,
             Severity::Error
         );
+        assert_eq!(
+            SEC_WEBSOCKET_VERSION_MISSING.default_severity,
+            Severity::Error
+        );
+        assert!(
+            SEC_WEBSOCKET_VERSION_INVALID.default_severity
+                < SEC_WEBSOCKET_VERSION_MALFORMED.default_severity
+        );
+    }
+
+    /// Which sentence each half names: the grammar for the two that fail the
+    /// production, item 9 for the two that fail what the field is for.
+    #[test]
+    fn the_grammar_and_the_requirement_are_two_sections() {
+        assert_eq!(SEC_WEBSOCKET_VERSION_MALFORMED.spec, [RFC_6455_4_3]);
+        assert_eq!(SEC_WEBSOCKET_VERSION_INVALID.spec, [RFC_6455_4_1]);
     }
 }

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -2557,7 +2557,7 @@ sources:
     - file: lint-http-proxy/src/proxy/websocket/mod.rs
       line: 38
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 108
+      line: 110
   - label: lint-http-proxy/src/proxy/websocket/mod.rs (2)
     section: § 4.1
     snippet: The request MUST contain an |Upgrade| header field whose value MUST include the "websocket" keyword.
@@ -2641,9 +2641,9 @@ sources:
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 47
     - file: lint-http-rules/src/violations/sec_websocket_version.rs
-      line: 62
+      line: 67
     - file: lint-http-rules/src/violations/sec_websocket_version.rs
-      line: 86
+      line: 91
   - label: extension repetition
     section: § 9.1
     snippet: extension = extension-token *( ";" extension-param )
@@ -2701,19 +2701,19 @@ sources:
     snippet: The ABNF for the value of this header field is 1#token, where the definitions of constructs and rules are as given in [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 218
+      line: 226
   - label: sec_websocket_headers_consistent (2)
     section: § 4.1
     snippet: The elements that comprise this value MUST be non-empty strings with characters in the range U+0021 to U+007E not including separator characters as defined in [RFC2616] and MUST all be unique strings.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 217
+      line: 225
   - label: sec_websocket_headers_consistent (3)
     section: § 4.1
     snippet: The request MUST include a header field with the name |Sec-WebSocket-Key|.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 188
+      line: 196
     - file: lint-http-rules/src/violations/sec_websocket_key.rs
       line: 63
   - label: sec_websocket_headers_consistent (4)
@@ -2721,25 +2721,29 @@ sources:
     snippet: The request MUST include a header field with the name |Sec-WebSocket-Version|.  The value of this header field MUST be 13.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 132
+      line: 134
+    - file: lint-http-rules/src/violations/sec_websocket_version.rs
+      line: 108
+    - file: lint-http-rules/src/violations/sec_websocket_version.rs
+      line: 139
   - label: sec_websocket_headers_consistent (5)
     section: § 4.2.1
     snippet: A |Connection| header field that includes the token "Upgrade", treated as an ASCII case-insensitive value.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 109
+      line: 111
   - label: sec_websocket_headers_consistent (6)
     section: § 4.2.1
     snippet: An HTTP/1.1 or higher GET request
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 416
+      line: 424
   - label: sec_websocket_headers_consistent (7)
     section: § 4.2.1
     snippet: the server MUST stop processing the client's handshake and return an HTTP response with an appropriate error code (such as 400 Bad Request)
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 417
+      line: 425
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
       line: 65
   - label: Sec-WebSocket-Protocol
@@ -2747,13 +2751,13 @@ sources:
     snippet: Sec-WebSocket-Protocol-Client = 1#token
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 219
+      line: 227
   - label: Sec-WebSocket-Version-Server
     section: § 4.3
     snippet: Sec-WebSocket-Version-Server = 1#version
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 140
+      line: 142
     - file: lint-http-rules/src/rules/sec_websocket_version_advertised.rs
       line: 82
   - label: sec_websocket_headers_consistent (8)
@@ -2761,7 +2765,7 @@ sources:
     snippet: If the server doesn't support the requested version, it MUST respond with a |Sec-WebSocket-Version| header field (or multiple |Sec-WebSocket-Version| header fields) containing all versions it is willing to use.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 168
+      line: 173
     - file: lint-http-rules/src/rules/sec_websocket_version_advertised.rs
       line: 83
   - label: sec_websocket_headers_consistent (9)
@@ -2769,7 +2773,7 @@ sources:
     snippet: a client can initially request the version of the WebSocket Protocol that it prefers (which doesn't necessarily have to be the latest supported by the client)
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 167
+      line: 172
   - label: sec_websocket_key
     section: § 4.1
     snippet: The value of this header field MUST be a nonce consisting of a randomly selected 16-byte value that has been base64-encoded (see Section 4 of [RFC4648]).
@@ -6651,7 +6655,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 324
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 227
+      line: 235
   - label: lint-http-rules/src/helpers/auth.rs
     section: § 11.1
     snippet: It uses a case-insensitive token to identify the authentication scheme
@@ -7615,7 +7619,7 @@ sources:
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
       line: 197
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 220
+      line: 228
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 506
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs


### PR DESCRIPTION
Item 9 of RFC 6455 §4.1 joins the `sec_websocket_version` subject as two entries, and `sec_websocket_headers_consistent`'s version reading converts whole. The grammar's two entries landed with the production; these are what the field is *for*: a request has to carry it, and the value has to be 13.

The second overturns a refusal written into the rule. It had declined the word "invalid" because §4.4 prints a request exactly like this one — `Sec-WebSocket-Version: 25`, answered with a 400 listing what the server will speak — but that section says how a server *answers* a version it does not understand, and item 9 says which version a request may carry. Both are true and only one of them is addressed to the sender. `_invalid` is the catalogue's word for a value that is grammatical and refused past the grammar, which is this exactly.

It is also the only `warn` in the subject, and §4.4 is why: the exchange has a defined outcome that leaves the connection ordinary HTTP and the client able to ask again. A version nobody can read has no such reply — the advertisement is written for a version a server understood and does not speak.

The reference for §4.1 is not written twice. Item 7 and item 9 are two entries of one numbered list, so the version subject imports the const the key subject already holds rather than defining an equal one beside it.

Floor: 220 of 227 entries cite a sentence.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
