### PR TITLE
A name a client asked for twice

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1743,6 +1743,10 @@ severity = "warn"
 # WebSocket handshake carries no Sec-WebSocket-Key
 severity = "error"
 
+[violations.sec_websocket_protocol_duplicated]
+# Sec-WebSocket-Protocol names one subprotocol twice
+severity = "warn"
+
 [violations.sec_websocket_version_empty]
 # Sec-WebSocket-Version is written with no value
 severity = "error"

--- a/lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
+++ b/lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
@@ -19,6 +19,7 @@ use crate::violations::list::{
 use crate::violations::sec_websocket_key::{
     RFC_6455_4_1, SEC_WEBSOCKET_KEY_LENGTH_INVALID, SEC_WEBSOCKET_KEY_MISSING,
 };
+use crate::violations::sec_websocket_protocol::SEC_WEBSOCKET_PROTOCOL_DUPLICATED;
 use crate::violations::sec_websocket_version::{
     version_defect as version_violation, RFC_6455_4_3, SEC_WEBSOCKET_VERSION_EMPTY,
     SEC_WEBSOCKET_VERSION_INVALID, SEC_WEBSOCKET_VERSION_MALFORMED, SEC_WEBSOCKET_VERSION_MISSING,
@@ -48,12 +49,13 @@ pub struct SecWebsocketHeadersConsistent;
 /// value naming nothing, a stray comma and an octet no `tchar` admits are the
 /// list's and the token's — and the alphabet § 4.1 spells out in words (U+0021
 /// to U+007E less the separators) is `token`, which the ABNF beside it says in
-/// one word. What stays this rule's own is the uniqueness requirement, which is
-/// about the *set* and which § 5.6.1.1 writes nothing about.
+/// one word. The uniqueness requirement is about the *set* rather than the
+/// members and § 5.6.1.1 writes nothing about it, so it is the
+/// [`sec_websocket_protocol`](crate::violations::sec_websocket_protocol)
+/// subject's — the field's own entry beside the productions it is spelled in.
 ///
-/// `Connection`, the version and the subprotocol list's uniqueness requirement
-/// are untouched and say so through their type: an unnamed [`Defect`] is a
-/// finding no subject has claimed.
+/// `Connection` is untouched and says so through its type: an unnamed
+/// [`Defect`] is a finding no subject has claimed.
 static DECLARED: &[&ViolationDef] = &[
     &BASE64_CHARACTER_FORBIDDEN,
     &BASE64_QUANTUM_MALFORMED,
@@ -64,6 +66,7 @@ static DECLARED: &[&ViolationDef] = &[
     &SEC_WEBSOCKET_VERSION_MALFORMED,
     &SEC_WEBSOCKET_VERSION_MISSING,
     &SEC_WEBSOCKET_VERSION_INVALID,
+    &SEC_WEBSOCKET_PROTOCOL_DUPLICATED,
     &LIST_MEMBER_MISSING,
     &LIST_MEMBER_EMPTY,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
@@ -273,11 +276,14 @@ impl SecWebsocketHeadersConsistent {
         // of one name are two strings, so the comparison is of what was written.
         for (i, member) in members.iter().enumerate() {
             if members[..i].contains(member) {
-                return Some(Defect::unnamed(format!(
-                    "its Sec-WebSocket-Protocol names the subprotocol `{}` more than once, and \
-                     the elements of this list are required to be unique",
-                    shown_in_finding(member)
-                )));
+                return Some(Defect::named(
+                    &SEC_WEBSOCKET_PROTOCOL_DUPLICATED,
+                    format!(
+                        "its Sec-WebSocket-Protocol names the subprotocol `{}` more than once, \
+                         and the elements of this list are required to be unique",
+                        shown_in_finding(member)
+                    ),
+                ));
             }
         }
         None

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -65,6 +65,7 @@ pub mod qvalue;
 pub mod request_target;
 pub mod sec_websocket_extensions;
 pub mod sec_websocket_key;
+pub mod sec_websocket_protocol;
 pub mod sec_websocket_version;
 pub mod status;
 pub mod strict_transport_security;
@@ -423,7 +424,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 220;
+        const FLOOR: usize = 221;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/sec_websocket_protocol.rs
+++ b/lint-http-rules/src/violations/sec_websocket_protocol.rs
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `Sec-WebSocket-Protocol` defects — what a subprotocol list says beyond its
+//! grammar.
+//!
+//! The spelling is borrowed and § 4.1 says so twice over: the alphabet the
+//! sentence spells out — U+0021 to U+007E less the separators — is `tchar`, and
+//! the ABNF beside it writes `1#token` in one word. So an octet no `token`
+//! admits, a member written blank and a value naming nothing are the
+//! [`token`](crate::violations::token) and [`list`](crate::violations::list)
+//! subjects', on both sides of the exchange.
+//!
+//! **What is left is what the list is, rather than how it is written.** § 4.1
+//! item 10 asks the client's names to be *unique strings*, and § 5.6.1.1 says
+//! nothing about a set: a list may repeat a member and still be a list. That is
+//! this subject's first entry, and the comparison behind it is of what was
+//! written — this document folds case where it means to, saying so in as many
+//! words for the two fields where it does, and saying nothing of the kind here.
+//!
+//! **The response's half of the field is the same subject and is not written
+//! yet.** § 4.3 gives the server `Sec-WebSocket-Protocol-Server = token` against
+//! the client's `1#token`, and § 4.2.2 adds two sentences no production carries:
+//! that the empty string is not a legal value, and that the name has to be one
+//! the client offered. The second is `_unsolicited`'s shape exactly — a value
+//! whose evidence is in the other message — and both are `websocket_handshake_
+//! valid`'s to declare when they land.
+
+use crate::lint::Severity;
+use crate::violations::defects;
+use crate::violations::sec_websocket_key::RFC_6455_4_1;
+
+defects! {
+    /// The same subprotocol name written twice in one request's list.
+    ///
+    /// Nothing about the grammar objects — `1#token` counts members and does
+    /// not compare them — so the requirement is item 10's own, and it is about
+    /// the *set* the list stands for: a client's names are ordered by
+    /// preference, and a name preferred twice states nothing a server can act
+    /// on that the first mention did not.
+    ///
+    /// `warn`. The handshake completes: a server picks one name it is willing
+    /// to speak, and a repeat leaves that choice exactly where it was. What is
+    /// wrong is the value rather than the outcome.
+    ///
+    /// The comparison is of the octets as written. This document folds case
+    /// where it means to — `Connection`'s token and `Upgrade`'s keyword are
+    /// each *treated as an ASCII case-insensitive value* in as many words — and
+    /// says nothing of the kind for these names, so `chat` and `Chat` are two
+    /// strings and two subprotocols.
+    ///
+    // cite(RFC 6455 § 4.1): "The elements that comprise this value MUST be non-empty strings with characters in the range U+0021 to U+007E not including separator characters as defined in [RFC2616] and MUST all be unique strings."
+    SEC_WEBSOCKET_PROTOCOL_DUPLICATED = {
+        id: "sec_websocket_protocol_duplicated",
+        title: "Sec-WebSocket-Protocol names one subprotocol twice",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_6455_4_1],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The one entry this subject has so far, and the rank that separates it
+    /// from the handshake's fatal halves: a repeated preference is a value a
+    /// server reads straight past.
+    #[test]
+    fn a_repeated_name_leaves_the_handshake_working() {
+        assert_eq!(
+            SEC_WEBSOCKET_PROTOCOL_DUPLICATED.default_severity,
+            Severity::Warn
+        );
+        assert_eq!(SEC_WEBSOCKET_PROTOCOL_DUPLICATED.spec, [RFC_6455_4_1]);
+    }
+}

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -2557,7 +2557,7 @@ sources:
     - file: lint-http-proxy/src/proxy/websocket/mod.rs
       line: 38
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 110
+      line: 113
   - label: lint-http-proxy/src/proxy/websocket/mod.rs (2)
     section: § 4.1
     snippet: The request MUST contain an |Upgrade| header field whose value MUST include the "websocket" keyword.
@@ -2701,19 +2701,21 @@ sources:
     snippet: The ABNF for the value of this header field is 1#token, where the definitions of constructs and rules are as given in [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 226
+      line: 229
   - label: sec_websocket_headers_consistent (2)
     section: § 4.1
     snippet: The elements that comprise this value MUST be non-empty strings with characters in the range U+0021 to U+007E not including separator characters as defined in [RFC2616] and MUST all be unique strings.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 225
+      line: 228
+    - file: lint-http-rules/src/violations/sec_websocket_protocol.rs
+      line: 53
   - label: sec_websocket_headers_consistent (3)
     section: § 4.1
     snippet: The request MUST include a header field with the name |Sec-WebSocket-Key|.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 196
+      line: 199
     - file: lint-http-rules/src/violations/sec_websocket_key.rs
       line: 63
   - label: sec_websocket_headers_consistent (4)
@@ -2721,7 +2723,7 @@ sources:
     snippet: The request MUST include a header field with the name |Sec-WebSocket-Version|.  The value of this header field MUST be 13.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 134
+      line: 137
     - file: lint-http-rules/src/violations/sec_websocket_version.rs
       line: 108
     - file: lint-http-rules/src/violations/sec_websocket_version.rs
@@ -2731,19 +2733,19 @@ sources:
     snippet: A |Connection| header field that includes the token "Upgrade", treated as an ASCII case-insensitive value.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 111
+      line: 114
   - label: sec_websocket_headers_consistent (6)
     section: § 4.2.1
     snippet: An HTTP/1.1 or higher GET request
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 424
+      line: 430
   - label: sec_websocket_headers_consistent (7)
     section: § 4.2.1
     snippet: the server MUST stop processing the client's handshake and return an HTTP response with an appropriate error code (such as 400 Bad Request)
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 425
+      line: 431
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
       line: 65
   - label: Sec-WebSocket-Protocol
@@ -2751,13 +2753,13 @@ sources:
     snippet: Sec-WebSocket-Protocol-Client = 1#token
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 227
+      line: 230
   - label: Sec-WebSocket-Version-Server
     section: § 4.3
     snippet: Sec-WebSocket-Version-Server = 1#version
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 142
+      line: 145
     - file: lint-http-rules/src/rules/sec_websocket_version_advertised.rs
       line: 82
   - label: sec_websocket_headers_consistent (8)
@@ -2765,7 +2767,7 @@ sources:
     snippet: If the server doesn't support the requested version, it MUST respond with a |Sec-WebSocket-Version| header field (or multiple |Sec-WebSocket-Version| header fields) containing all versions it is willing to use.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 173
+      line: 176
     - file: lint-http-rules/src/rules/sec_websocket_version_advertised.rs
       line: 83
   - label: sec_websocket_headers_consistent (9)
@@ -2773,7 +2775,7 @@ sources:
     snippet: a client can initially request the version of the WebSocket Protocol that it prefers (which doesn't necessarily have to be the latest supported by the client)
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 172
+      line: 175
   - label: sec_websocket_key
     section: § 4.1
     snippet: The value of this header field MUST be a nonce consisting of a randomly selected 16-byte value that has been base64-encoded (see Section 4 of [RFC4648]).
@@ -6655,7 +6657,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 324
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 235
+      line: 238
   - label: lint-http-rules/src/helpers/auth.rs
     section: § 11.1
     snippet: It uses a case-insensitive token to identify the authentication scheme
@@ -7619,7 +7621,7 @@ sources:
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
       line: 197
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 228
+      line: 231
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 506
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs


### PR DESCRIPTION
`violations/sec_websocket_protocol.rs` opens with one entry: the same subprotocol written twice in a request's list. The spelling was already borrowed and §4.1 says so twice over — the alphabet the sentence spells out, U+0021 to U+007E less the separators, is `tchar`, and the ABNF beside it writes `1#token` in one word — so the octets and the empty members were the token's and the list's.

Uniqueness is neither. §5.6.1.1 counts members and never compares them, so *MUST all be unique strings* is the field's own requirement about the set the list stands for, and it is the field's entry rather than the rule's however few rules read it.

`warn`: a server picks a name it is willing to speak and a repeat leaves that choice exactly where it was. The comparison stays over the octets as written — this document folds case where it means to, saying so in as many words for `Connection` and `Upgrade` and saying nothing of the kind here.

The response's half of the field is the same subject and is written down as next: §4.2.2 says the empty string is not a legal value and that the name has to be one the client offered, which is `_unsolicited`'s shape exactly.

Floor: 221 of 228 entries cite a sentence.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
