### PR TITLE
A subprotocol the client never named

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1747,6 +1747,14 @@ severity = "error"
 # Sec-WebSocket-Protocol names one subprotocol twice
 severity = "warn"
 
+[violations.sec_websocket_protocol_empty]
+# Sec-WebSocket-Protocol is written with no subprotocol in it
+severity = "error"
+
+[violations.sec_websocket_protocol_unsolicited]
+# Sec-WebSocket-Protocol names a subprotocol the request did not offer
+severity = "error"
+
 [violations.sec_websocket_version_conflicting]
 # Sec-WebSocket-Version advertises the version the request asked for
 severity = "warn"

--- a/docs/rules/websocket_handshake_valid.md
+++ b/docs/rules/websocket_handshake_valid.md
@@ -33,6 +33,7 @@ Two neighbours own the sentences this rule does not. The obligation to send an `
 - [RFC 6455 §9.1](https://www.rfc-editor.org/rfc/rfc6455.html#section-9.1): Negotiating Extensions — the server's list is the extensions in use, each extension's own document defines what a valid answer to its parameters is, and an `extension-token` is a registered name
 - [RFC 8441 §5](https://www.rfc-editor.org/rfc/rfc8441.html#section-5): Updates RFC 6455: over HTTP/2 the handshake is an extended CONNECT, `Connection` and `Upgrade` MUST NOT be included, and `Sec-WebSocket-Accept` is not processed — the sentences behind this rule's version gate
 - [RFC 9220 §3](https://www.rfc-editor.org/rfc/rfc9220.html#section-3): Carries RFC 8441's mechanism to HTTP/3 with identical semantics
+- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
+++ b/lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
@@ -227,7 +227,11 @@ impl SecWebsocketHeadersConsistent {
     /// exact; the definition it resolves to today is cited beside it.
     // cite(RFC 6455 § 4.1): "The elements that comprise this value MUST be non-empty strings with characters in the range U+0021 to U+007E not including separator characters as defined in [RFC2616] and MUST all be unique strings."
     // cite(RFC 6455 § 4.1): "The ABNF for the value of this header field is 1#token, where the definitions of constructs and rules are as given in [RFC2616]."
-    // cite(RFC 6455 § 4.3, label: Sec-WebSocket-Protocol): "Sec-WebSocket-Protocol-Client = 1#token"
+    // The label is the production's full name and not the field's: a label of
+    // `Sec-WebSocket-Protocol` and the `sec_websocket_protocol` subject's file
+    // stem differ only in punctuation and case, which is one fragment identity
+    // for two groups of sentences.
+    // cite(RFC 6455 § 4.3, label: Sec-WebSocket-Protocol-Client): "Sec-WebSocket-Protocol-Client = 1#token"
     // cite(RFC 9110 § 5.6.2): "token = 1*tchar tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA"
     fn subprotocol_defect(headers: &hyper::HeaderMap) -> Option<Defect> {
         let raw = combined_field_value_as_written(headers, "sec-websocket-protocol")?;

--- a/lint-http-rules/src/rules/websocket_handshake_valid.rs
+++ b/lint-http-rules/src/rules/websocket_handshake_valid.rs
@@ -11,6 +11,14 @@ use crate::helpers::websocket::{
 };
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::sec_websocket_protocol::{
+    RFC_6455_4_2_2, SEC_WEBSOCKET_PROTOCOL_EMPTY, SEC_WEBSOCKET_PROTOCOL_UNSOLICITED,
+};
+use crate::violations::token::{
+    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
+    TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+};
+use crate::violations::ViolationDef;
 
 /// The server's half of a WebSocket opening handshake, measured against the
 /// request it answers.
@@ -37,6 +45,53 @@ use crate::rules::{Rule, RuleMeta};
 /// The history parameter is unused: both halves of a transaction arrive together,
 /// and nothing here spans two of them.
 pub struct WebsocketHandshakeValid;
+
+/// The defects this rule declares, and the two directions they are read in.
+///
+/// The subprotocol is where the server's grammar and the client's differ —
+/// `Sec-WebSocket-Protocol-Server = token` against `1#token` — so the response's
+/// emptiness is § 4.2.2's own sentence rather than the list's floor, and a name
+/// the request never offered is `_unsolicited`, whose evidence sits in the other
+/// message this rule holds. What is left of the field is the alphabet it is
+/// spelled in, and that is [`token`](crate::violations::token)'s on both sides:
+/// the comma that says a server answered with a list is a delimiter § 5.6.2
+/// names, and it keeps its own message beside the shared id.
+///
+/// Everything else this rule reads is still unnamed and says so through
+/// [`Defect`], which is a finding no subject has claimed.
+static DECLARED: &[&ViolationDef] = &[
+    &SEC_WEBSOCKET_PROTOCOL_EMPTY,
+    &SEC_WEBSOCKET_PROTOCOL_UNSOLICITED,
+    &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+    &TOKEN_CHARACTER_FORBIDDEN,
+];
+
+/// One finding from the reading, and the defect it reports as where the
+/// catalogue names that defect.
+///
+/// The shape `expect_header_valid` settled and the rule measuring the other half
+/// of this handshake reuses: a judge that is half converted says so in its type
+/// rather than being split in two.
+struct Defect {
+    def: Option<&'static ViolationDef>,
+    message: String,
+}
+
+impl Defect {
+    /// A defect the catalogue names.
+    fn named(def: &'static ViolationDef, message: String) -> Self {
+        Self {
+            def: Some(def),
+            message,
+        }
+    }
+
+    /// A defect no subject has claimed yet, reported at the rule's severity the
+    /// way every finding here was before the catalogue existed.
+    fn unnamed(message: String) -> Self {
+        Self { def: None, message }
+    }
+}
 
 impl WebsocketHandshakeValid {
     /// The one finding here that is about the request, and it is about the
@@ -280,6 +335,12 @@ impl WebsocketHandshakeValid {
     /// as not a legal value, the production is one `token`, and the name has to be
     /// one the client offered.
     ///
+    /// The first and the third are the field's own entries, because no production
+    /// carries either — the emptiness the grammar refuses is a `token`'s floor,
+    /// and what § 4.2.2 adds is that this field's empty string is not its absence.
+    /// The alphabet in between is `token`'s, on this side of the exchange as on
+    /// the other.
+    ///
     /// The last comparison is of what was written. This document folds case where
     /// it means to — the two fields above are each *"treated as an ASCII
     /// case-insensitive value"* in so many words — and says nothing of the kind
@@ -290,41 +351,47 @@ impl WebsocketHandshakeValid {
     /// the null value rather than a defect, so the whole check is behind the
     /// field's presence.
     // cite(RFC 6455 § 4.1): "If the response includes a |Sec-WebSocket-Protocol| header field and this header field indicates the use of a subprotocol that was not present in the client's handshake (the server has indicated a subprotocol not requested by the client), the client MUST _Fail the WebSocket Connection_."
-    // cite(RFC 6455 § 4.2.2): "The value chosen MUST be derived from the client's handshake, specifically by selecting one of the values from the |Sec-WebSocket-Protocol| field that the server is willing to use for this connection (if any)."
     // cite(RFC 6455 § 4.2.2): "if the server does not wish to agree to one of the suggested subprotocols, it MUST NOT send back a |Sec-WebSocket-Protocol| header field in its response"
-    // cite(RFC 6455 § 4.2.2): "The empty string is not the same as the null value for these purposes and is not a legal value for this field."
     // cite(RFC 6455 § 4.3, label: Sec-WebSocket-Protocol-Server): "Sec-WebSocket-Protocol-Server = token"
     fn subprotocol_defect(
         req_headers: &hyper::HeaderMap,
         resp_headers: &hyper::HeaderMap,
-    ) -> Option<String> {
+    ) -> Option<Defect> {
         let raw = combined_field_value_as_written(resp_headers, "sec-websocket-protocol")?;
         let value = trim_ows(&raw);
         if value.is_empty() {
-            return Some(
+            return Some(Defect::named(
+                &SEC_WEBSOCKET_PROTOCOL_EMPTY,
                 "its Sec-WebSocket-Protocol is empty, and the empty string is named as not a \
                  legal value for this field — a server agreeing to no subprotocol sends no field \
                  at all"
                     .into(),
-            );
+            ));
         }
-        // A comma is not a `tchar`, so the scan below would report it as one more
-        // octet the production does not admit. It earns its own sentence: what the
-        // server got wrong is not a character, it is that it answered with a list
-        // where the grammar for its direction writes one name.
+        // A comma is not a `tchar`, so the entry is the same one the scan below
+        // reports and the message is not: what the server got wrong is not a
+        // character it chose, it is that it answered with a list where the grammar
+        // for its direction writes one name. The delimiter is what says so, which
+        // is why the reading survives the id being shared.
         if value.contains(',') {
-            return Some(format!(
-                "its Sec-WebSocket-Protocol is `{}`, and the server's field is one subprotocol \
-                 name where the client's is a list of them",
-                shown_in_finding(value)
+            return Some(Defect::named(
+                &TOKEN_CHARACTER_FORBIDDEN,
+                format!(
+                    "its Sec-WebSocket-Protocol is `{}`, and the server's field is one subprotocol \
+                     name where the client's is a list of them",
+                    shown_in_finding(value)
+                ),
             ));
         }
         if let Some(c) = crate::helpers::token::find_invalid_token_char(value) {
-            return Some(format!(
-                "its Sec-WebSocket-Protocol is `{}`, which holds {} and so derives from no \
-                 `token`",
-                shown_in_finding(value),
-                describe_octet(c as u8)
+            return Some(Defect::named(
+                token_character(c),
+                format!(
+                    "its Sec-WebSocket-Protocol is `{}`, which holds {} and so derives from no \
+                     `token`",
+                    shown_in_finding(value),
+                    describe_octet(c as u8)
+                ),
             ));
         }
         let offered = combined_field_value_as_written(req_headers, "sec-websocket-protocol")
@@ -335,10 +402,13 @@ impl WebsocketHandshakeValid {
         if list_members(&offered).any(|m| m == value) {
             return None;
         }
-        Some(format!(
-            "its Sec-WebSocket-Protocol names the subprotocol `{}`, which the request it answers \
-             did not offer",
-            shown_in_finding(value)
+        Some(Defect::named(
+            &SEC_WEBSOCKET_PROTOCOL_UNSOLICITED,
+            format!(
+                "its Sec-WebSocket-Protocol names the subprotocol `{}`, which the request it \
+                 answers did not offer",
+                shown_in_finding(value)
+            ),
         ))
     }
 }
@@ -361,6 +431,13 @@ fn extension_token(member: &str) -> &str {
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
+///
+/// § 4.2.2 is not written here and neither is RFC 9110 § 5.6.2: the first is
+/// what the two subprotocol entries in
+/// [`sec_websocket_protocol`](crate::violations::sec_websocket_protocol)
+/// enforce and the second is what
+/// [`token`](crate::violations::token)'s pair does, so both references live
+/// beside the entries that cite them and are imported back.
 const RFC_6455_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 6455",
     section: Some("4.1"),
@@ -372,12 +449,6 @@ const RFC_6455_4_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("4.2.1"),
     url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.2.1",
     note: "Reading the Client's Opening Handshake — the description a handshake has to match, and the requirement to refuse one that does not, which is what makes a 101 over a malformed key the server's defect",
-};
-const RFC_6455_4_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 6455",
-    section: Some("4.2.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.2.2",
-    note: "Sending the Server's Opening Handshake — what a server sends if it accepts, the five things it sends instead if it does not, and how `Sec-WebSocket-Accept`, `/subprotocol/` and `/extensions/` are derived from the request",
 };
 const RFC_6455_4_3: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 6455",
@@ -432,7 +503,12 @@ severity = "warn"
             RFC_6455_9_1,
             RFC_8441_5,
             RFC_9220_3,
+            RFC_9110_5_6_2,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -519,21 +595,25 @@ impl Rule for WebsocketHandshakeValid {
             // admissibility ahead of the questions about its fields. One message carries
             // one finding, so the first defect is the one reported.
             let defect = [
-                Self::refusable_handshake(&req.headers),
-                Self::upgrade_defect(&resp.headers),
-                Self::connection_defect(&resp.headers),
-                Self::accept_defect(&req.headers, &resp.headers),
-                Self::extensions_defect(&req.headers, &resp.headers),
+                Self::refusable_handshake(&req.headers).map(Defect::unnamed),
+                Self::upgrade_defect(&resp.headers).map(Defect::unnamed),
+                Self::connection_defect(&resp.headers).map(Defect::unnamed),
+                Self::accept_defect(&req.headers, &resp.headers).map(Defect::unnamed),
+                Self::extensions_defect(&req.headers, &resp.headers).map(Defect::unnamed),
                 Self::subprotocol_defect(&req.headers, &resp.headers),
             ]
             .into_iter()
             .flatten()
             .next()?;
 
-            Some(self.violation(
-                ctx.severity,
-                format!("This 101 completes a WebSocket opening handshake, but {defect}"),
-            ))
+            let message = format!(
+                "This 101 completes a WebSocket opening handshake, but {}",
+                defect.message
+            );
+            match defect.def {
+                Some(def) => Some(ctx.report_with(def, message)),
+                None => Some(self.violation(ctx.severity, message)),
+            }
         };
         Vec::from_iter(finding())
     }
@@ -881,17 +961,39 @@ mod tests {
         assert!(run(&tx).unwrap().message.contains(&accept));
     }
 
-    /// The server's subprotocol field is one `token` the client offered.
+    /// The server's subprotocol field is one `token` the client offered, and
+    /// each way of failing that is reported under the entry that owns it: the
+    /// field's own two sentences, and the alphabet's — which the comma reaches
+    /// by a reading of its own and the same id.
     #[rstest]
     #[case("chat", None)]
     #[case("superchat", None)]
-    #[case("mqtt", Some("did not offer"))]
-    #[case("Chat", Some("did not offer"))]
-    #[case("", Some("not a legal value"))]
-    #[case("   ", Some("not a legal value"))]
-    #[case("chat, superchat", Some("one subprotocol name"))]
-    #[case("cha t", Some("derives from no `token`"))]
-    fn the_servers_subprotocol(#[case] value: &str, #[case] expected: Option<&str>) {
+    #[case(
+        "mqtt",
+        Some(("did not offer", "sec_websocket_protocol_unsolicited"))
+    )]
+    #[case(
+        "Chat",
+        Some(("did not offer", "sec_websocket_protocol_unsolicited"))
+    )]
+    #[case("", Some(("not a legal value", "sec_websocket_protocol_empty")))]
+    #[case("   ", Some(("not a legal value", "sec_websocket_protocol_empty")))]
+    #[case(
+        "chat, superchat",
+        Some(("one subprotocol name", "token_character_forbidden"))
+    )]
+    #[case(
+        "cha t",
+        Some((
+            "derives from no `token`",
+            "token_whitespace_or_control_forbidden"
+        ))
+    )]
+    #[case(
+        "cha:t",
+        Some(("derives from no `token`", "token_character_forbidden"))
+    )]
+    fn the_servers_subprotocol(#[case] value: &str, #[case] expected: Option<(&str, &str)>) {
         let mut req = handshake_request();
         req.push(("sec-websocket-protocol", "chat, superchat"));
         let mut resp = handshake_response();
@@ -899,7 +1001,11 @@ mod tests {
         let tx = make_ws_tx(req, 101, resp);
         match expected {
             None => assert!(run(&tx).is_none()),
-            Some(text) => assert!(run(&tx).unwrap().message.contains(text), "{value}"),
+            Some((text, id)) => {
+                let found = run(&tx).unwrap();
+                assert!(found.message.contains(text), "{value}");
+                assert_eq!(found.violation, id, "{value}");
+            }
         }
     }
 
@@ -914,7 +1020,33 @@ mod tests {
         let mut resp = handshake_response();
         resp.push(("sec-websocket-protocol", "chat"));
         let tx = make_ws_tx(handshake_request(), 101, resp);
-        assert!(run(&tx).unwrap().message.contains("did not offer"));
+        let found = run(&tx).unwrap();
+        assert!(found.message.contains("did not offer"));
+        assert_eq!(found.violation, "sec_websocket_protocol_unsolicited");
+    }
+
+    /// The rank a subprotocol finding carries is its entry's and no longer the
+    /// rule's: the fixture configures this rule at `warn`, and both halves of
+    /// what a server may write wrong come out at the `error` their defs
+    /// default to — while everything still unnamed here keeps the rule's.
+    #[rstest]
+    fn a_named_defect_takes_its_entrys_rank_and_an_unnamed_one_the_rules() {
+        let mut resp = handshake_response();
+        resp.push(("sec-websocket-protocol", "mqtt"));
+        let mut req = handshake_request();
+        req.push(("sec-websocket-protocol", "chat"));
+        let tx = make_ws_tx(req, 101, resp);
+        assert_eq!(run(&tx).unwrap().severity, crate::lint::Severity::Error);
+
+        // The `Upgrade` reading, which no subject has claimed.
+        let tx = make_ws_tx(
+            handshake_request(),
+            101,
+            vec![("connection", "Upgrade"), ("sec-websocket-accept", ACCEPT)],
+        );
+        let found = run(&tx).unwrap();
+        assert_eq!(found.severity, crate::lint::Severity::Warn);
+        assert!(found.violation.is_empty());
     }
 
     /// Extensions are compared on the name half of each member; the parameters

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -424,7 +424,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 223;
+        const FLOOR: usize = 225;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/sec_websocket_protocol.rs
+++ b/lint-http-rules/src/violations/sec_websocket_protocol.rs
@@ -19,17 +19,33 @@
 //! written — this document folds case where it means to, saying so in as many
 //! words for the two fields where it does, and saying nothing of the kind here.
 //!
-//! **The response's half of the field is the same subject and is not written
-//! yet.** § 4.3 gives the server `Sec-WebSocket-Protocol-Server = token` against
-//! the client's `1#token`, and § 4.2.2 adds two sentences no production carries:
-//! that the empty string is not a legal value, and that the name has to be one
-//! the client offered. The second is `_unsolicited`'s shape exactly — a value
-//! whose evidence is in the other message — and both are `websocket_handshake_
-//! valid`'s to declare when they land.
+//! **The response's half of the field is the same subject, and it is two more
+//! entries.** § 4.3 gives the server `Sec-WebSocket-Protocol-Server = token`
+//! against the client's `1#token`, so the direction that carries a list is the
+//! one whose emptiness the list owns; what § 4.2.2 adds are two sentences no
+//! production carries, that the empty string is not a legal value and that the
+//! name has to be one the client offered. Both are the field's own and both are
+//! declared by `websocket_handshake_valid`, which is the rule that holds the
+//! request beside the response and so the only one able to ask the second.
 
 use crate::lint::Severity;
+use crate::rules::SpecRef;
 use crate::violations::defects;
 use crate::violations::sec_websocket_key::RFC_6455_4_1;
+
+/// The section a server's half of the handshake is written from, and the one
+/// that says the two things about this field its grammar does not.
+///
+/// `websocket_handshake_valid` imports it back rather than keeping the equal
+/// copy it had: two definitions of one section would pass
+/// `every_violation_spec_is_declared_by_its_rule` today and drift apart on the
+/// first edit to either.
+pub const RFC_6455_4_2_2: SpecRef = SpecRef {
+    spec: "RFC 6455",
+    section: Some("4.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.2.2",
+    note: "Sending the Server's Opening Handshake — what a server sends if it accepts, the five things it sends instead if it does not, and how `Sec-WebSocket-Accept`, `/subprotocol/` and `/extensions/` are derived from the request",
+};
 
 defects! {
     /// The same subprotocol name written twice in one request's list.
@@ -58,15 +74,79 @@ defects! {
         default_severity: Severity::Warn,
         spec: &[RFC_6455_4_1],
     }
+
+    /// The server's field written with nothing in it.
+    ///
+    /// **The response's emptiness is the field's where the request's is the
+    /// list's**, and one sentence is the whole of the difference. A client
+    /// writes `1#token`, so an element with nothing in it and a value naming no
+    /// element at all are arithmetic on a production and belong to
+    /// [`list`](crate::violations::list). A server writes one `token`, which
+    /// has a floor of its own — but § 4.2.2 does not leave it at the floor: it
+    /// says in as many words that the empty string *is not the same as the null
+    /// value* here and is not legal. That distinction is what
+    /// [`token_empty`](crate::violations::token) cannot carry, since a token
+    /// with no characters in it is the same defect wherever it is written and
+    /// this one is only a defect in a field whose absence means something.
+    ///
+    /// `error`. Absence is how a server says it agreed to no subprotocol, and
+    /// the sentence exists to stop a reader taking this for that: the two sides
+    /// come out of the handshake without agreeing on whether a subprotocol is
+    /// in use, and a client reading the field at all finds it naming nothing it
+    /// offered.
+    ///
+    // cite(RFC 6455 § 4.2.2): "The empty string is not the same as the null value for these purposes and is not a legal value for this field."
+    SEC_WEBSOCKET_PROTOCOL_EMPTY = {
+        id: "sec_websocket_protocol_empty",
+        title: "Sec-WebSocket-Protocol is written with no subprotocol in it",
+        message: "",
+        default_severity: Severity::Error,
+        spec: &[RFC_6455_4_2_2],
+    }
+
+    /// A subprotocol the request never offered: a name outside the client's
+    /// list, or any name at all where the client sent no list.
+    ///
+    /// `_unsolicited` is the ending whose evidence is in the *other* message,
+    /// and this is its plainest case. Nothing is wrong with the value as
+    /// written — it is a `token`, and it may well be a registered subprotocol —
+    /// and what condemns it is a field in the request it answers. § 4.2.2 says
+    /// where the value comes from in as many words, *by selecting one of the
+    /// values* the client sent, so a name that was not among them was derived
+    /// from something other than the handshake.
+    ///
+    /// A request that offered none is the same defect and not a milder one: the
+    /// set to select from is empty, so every name is outside it, and the same
+    /// section tells a server unwilling to agree to send no field at all.
+    ///
+    /// `error`, and the client's own list is why: it is handed one instruction
+    /// for this exact case and it is to fail the connection. The handshake
+    /// completes on the wire and the connection it opens does not survive being
+    /// read.
+    ///
+    /// The comparison is of the octets as written, the same choice
+    /// [`SEC_WEBSOCKET_PROTOCOL_DUPLICATED`] records and for the same reason:
+    /// this document folds case at the two fields where it says so, and says
+    /// nothing of the kind about a subprotocol name.
+    ///
+    // cite(RFC 6455 § 4.2.2): "The value chosen MUST be derived from the client's handshake, specifically by selecting one of the values from the |Sec-WebSocket-Protocol| field that the server is willing to use for this connection (if any)."
+    SEC_WEBSOCKET_PROTOCOL_UNSOLICITED = {
+        id: "sec_websocket_protocol_unsolicited",
+        title: "Sec-WebSocket-Protocol names a subprotocol the request did not offer",
+        message: "",
+        default_severity: Severity::Error,
+        spec: &[RFC_6455_4_2_2],
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// The one entry this subject has so far, and the rank that separates it
-    /// from the handshake's fatal halves: a repeated preference is a value a
-    /// server reads straight past.
+    /// The rank that separates the request's entry from the response's two: a
+    /// repeated preference is a value a server reads straight past, and both
+    /// halves of what a server may write wrong are a connection the client is
+    /// told to fail.
     #[test]
     fn a_repeated_name_leaves_the_handshake_working() {
         assert_eq!(
@@ -74,5 +154,21 @@ mod tests {
             Severity::Warn
         );
         assert_eq!(SEC_WEBSOCKET_PROTOCOL_DUPLICATED.spec, [RFC_6455_4_1]);
+        for def in [
+            &SEC_WEBSOCKET_PROTOCOL_EMPTY,
+            &SEC_WEBSOCKET_PROTOCOL_UNSOLICITED,
+        ] {
+            assert_eq!(def.default_severity, Severity::Error, "{}", def.id);
+            assert_eq!(def.spec, [RFC_6455_4_2_2], "{}", def.id);
+        }
+    }
+
+    /// The two sections this subject cites are one field read from both ends,
+    /// and nothing here may collapse them: § 4.1 states what a client writes
+    /// and § 4.2.2 what a server may answer with, so an entry taking the wrong
+    /// one would cite a sentence addressed to the other sender.
+    #[test]
+    fn the_two_directions_cite_different_sections() {
+        assert_ne!(RFC_6455_4_1.section, RFC_6455_4_2_2.section);
     }
 }

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -2505,7 +2505,7 @@ sources:
     - file: lint-http-proxy/src/proxy/websocket/mod.rs
       line: 73
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 250
+      line: 305
   - label: lint-http-proxy/src/proxy/websocket/frame.rs
     section: § 5.2
     snippet: '%x3-7 are reserved for further non-control frames'
@@ -2677,7 +2677,7 @@ sources:
     - file: lint-http-rules/src/rules/sec_websocket_extensions_syntax.rs
       line: 123
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 252
+      line: 307
   - label: sec_websocket_extensions_syntax (3)
     section: § 9.1
     snippet: If a value is received by either the client or the server during negotiation that does not conform to the ABNF below, the recipient of such malformed data MUST immediately _Fail the WebSocket Connection_.
@@ -2711,7 +2711,7 @@ sources:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
       line: 228
     - file: lint-http-rules/src/violations/sec_websocket_protocol.rs
-      line: 53
+      line: 69
   - label: sec_websocket_headers_consistent (3)
     section: § 4.1
     snippet: The request MUST include a header field with the name |Sec-WebSocket-Key|.
@@ -2741,21 +2741,21 @@ sources:
     snippet: An HTTP/1.1 or higher GET request
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 430
+      line: 434
   - label: sec_websocket_headers_consistent (7)
     section: § 4.2.1
     snippet: the server MUST stop processing the client's handshake and return an HTTP response with an appropriate error code (such as 400 Bad Request)
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 431
+      line: 435
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 65
-  - label: Sec-WebSocket-Protocol
+      line: 120
+  - label: Sec-WebSocket-Protocol-Client
     section: § 4.3
     snippet: Sec-WebSocket-Protocol-Client = 1#token
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 230
+      line: 234
   - label: Sec-WebSocket-Version-Server
     section: § 4.3
     snippet: Sec-WebSocket-Version-Server = 1#version
@@ -2784,6 +2784,18 @@ sources:
     cited_by:
     - file: lint-http-rules/src/violations/sec_websocket_key.rs
       line: 93
+  - label: sec_websocket_protocol
+    section: § 4.2.2
+    snippet: The empty string is not the same as the null value for these purposes and is not a legal value for this field.
+    cited_by:
+    - file: lint-http-rules/src/violations/sec_websocket_protocol.rs
+      line: 98
+  - label: sec_websocket_protocol (2)
+    section: § 4.2.2
+    snippet: The value chosen MUST be derived from the client's handshake, specifically by selecting one of the values from the |Sec-WebSocket-Protocol| field that the server is willing to use for this connection (if any).
+    cited_by:
+    - file: lint-http-rules/src/violations/sec_websocket_protocol.rs
+      line: 132
   - label: sec_websocket_version_advertised
     section: § 11.3.5
     snippet: In such a case, the header field includes the protocol version(s) supported by the server.
@@ -2951,163 +2963,151 @@ sources:
     snippet: If the response includes a |Sec-WebSocket-Extensions| header field and this header field indicates the use of an extension that was not present in the client's handshake (the server has indicated an extension not requested by the client), the client MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 248
+      line: 303
   - label: websocket_handshake_valid (2)
     section: § 4.1
     snippet: If the response includes a |Sec-WebSocket-Protocol| header field and this header field indicates the use of a subprotocol that was not present in the client's handshake (the server has indicated a subprotocol not requested by the client), the client MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 292
+      line: 353
   - label: websocket_handshake_valid (3)
     section: § 4.1
     snippet: If the response lacks a |Connection| header field or the |Connection| header field doesn't contain a token that is an ASCII case-insensitive match for the value "Upgrade", the client MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 160
+      line: 215
   - label: websocket_handshake_valid (4)
     section: § 4.1
     snippet: If the response lacks a |Sec-WebSocket-Accept| header field or the |Sec-WebSocket-Accept| contains a value other than the base64-encoded SHA-1 of the concatenation of the |Sec-WebSocket-Key| (as a string, not base64-decoded) with the string "258EAFA5-E914-47DA-95CA-C5AB0DC85B11" but ignoring any leading and trailing whitespace, the client MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 195
+      line: 250
   - label: websocket_handshake_valid (5)
     section: § 4.1
     snippet: If the response lacks an |Upgrade| header field or the |Upgrade| header field contains a value that is not an ASCII case-insensitive match for the value "websocket", the client MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 125
+      line: 180
   - label: websocket_handshake_valid (6)
     section: § 4.1
     snippet: If the status code received from the server is not 101, the client handles the response per HTTP [RFC2616] procedures.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 501
+      line: 577
   - label: websocket_handshake_valid (7)
     section: § 4.1
     snippet: In particular, the client might perform authentication if it receives a 401 status code; the server might redirect the client using a 3xx status code (but clients are not required to follow them), etc.  Otherwise, proceed as follows.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 502
+      line: 578
   - label: websocket_handshake_valid (8)
     section: § 4.2.1
     snippet: A |Sec-WebSocket-Key| header field with a base64-encoded (see Section 4 of [RFC4648]) value that, when decoded, is 16 bytes in length.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 67
+      line: 122
   - label: websocket_handshake_valid (9)
     section: § 4.2.1
     snippet: A |Sec-WebSocket-Version| header field, with a value of 13.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 68
+      line: 123
   - label: websocket_handshake_valid (10)
     section: § 4.2.1
     snippet: including but not limited to any violations of the ABNF grammar specified for the components of the handshake
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 66
+      line: 121
   - label: websocket_handshake_valid (11)
     section: § 4.2.2
     snippet: A Status-Line with a 101 response code as per RFC 2616 [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 508
+      line: 584
   - label: websocket_handshake_valid (12)
     section: § 4.2.2
     snippet: A |Connection| header field with value "Upgrade".
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 161
+      line: 216
   - label: websocket_handshake_valid (13)
     section: § 4.2.2
     snippet: A |Sec-WebSocket-Accept| header field.  The value of this header field is constructed by concatenating /key/, defined above in step 4 in Section 4.2.2, with the string "258EAFA5-E914-47DA-95CA-C5AB0DC85B11", taking the SHA-1 hash of this concatenated value to obtain a 20-byte value and base64-encoding (see Section 4 of [RFC4648]) this 20-byte hash.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 196
+      line: 251
   - label: websocket_handshake_valid (14)
     section: § 4.2.2
     snippet: An |Upgrade| header field with value "websocket" as per RFC 2616 [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 126
+      line: 181
   - label: websocket_handshake_valid (15)
     section: § 4.2.2
     snippet: Extensions not listed by the client MUST NOT be listed.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 249
+      line: 304
   - label: websocket_handshake_valid (16)
     section: § 4.2.2
     snippet: If the requested service is not available, the server MUST send an appropriate HTTP error code (such as 404 Not Found) and abort the WebSocket handshake.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 507
+      line: 583
   - label: websocket_handshake_valid (17)
     section: § 4.2.2
     snippet: If the server chooses to accept the incoming connection, it MUST reply with a valid HTTP response indicating the following.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 503
+      line: 579
   - label: websocket_handshake_valid (18)
     section: § 4.2.2
     snippet: If the server does not wish to accept this connection, it MUST return an appropriate HTTP error code (e.g., 403 Forbidden) and abort the WebSocket handshake described in this section.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 506
+      line: 582
   - label: websocket_handshake_valid (19)
     section: § 4.2.2
     snippet: If this version does not match a version understood by the server, the server MUST abort the WebSocket handshake described in this section and instead send an appropriate HTTP error code (such as 426 Upgrade Required) and a |Sec-WebSocket-Version| header field indicating the version(s) the server is capable of understanding.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 69
+      line: 124
   - label: websocket_handshake_valid (20)
-    section: § 4.2.2
-    snippet: The empty string is not the same as the null value for these purposes and is not a legal value for this field.
-    cited_by:
-    - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 295
-  - label: websocket_handshake_valid (21)
     section: § 4.2.2
     snippet: The server MAY redirect the client using a 3xx status code [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 505
-  - label: websocket_handshake_valid (22)
+      line: 581
+  - label: websocket_handshake_valid (21)
     section: § 4.2.2
     snippet: The server can perform additional client authentication, for example, by returning a 401 status code with the corresponding |WWW-Authenticate| header field as described in [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 504
-  - label: websocket_handshake_valid (23)
-    section: § 4.2.2
-    snippet: The value chosen MUST be derived from the client's handshake, specifically by selecting one of the values from the |Sec-WebSocket-Protocol| field that the server is willing to use for this connection (if any).
-    cited_by:
-    - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 293
-  - label: websocket_handshake_valid (24)
+      line: 580
+  - label: websocket_handshake_valid (22)
     section: § 4.2.2
     snippet: if the server does not wish to agree to one of the suggested subprotocols, it MUST NOT send back a |Sec-WebSocket-Protocol| header field in its response
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 294
+      line: 354
   - label: Sec-WebSocket-Protocol-Server
     section: § 4.3
     snippet: Sec-WebSocket-Protocol-Server = token
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 296
+      line: 355
   - label: extension
     section: § 4.3
     snippet: extension = extension-token *( ";" extension-param )
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 353
-  - label: websocket_handshake_valid (25)
+      line: 423
+  - label: websocket_handshake_valid (23)
     section: § 9.1
     snippet: any extension parameters, and what constitutes a valid response by a server to a requested set of parameters by a client, will be defined by each such extension.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 251
+      line: 306
 - label: RFC 6585
   url: https://www.rfc-editor.org/rfc/rfc6585.html
   fragments:
@@ -6661,7 +6661,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 324
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 238
+      line: 242
   - label: lint-http-rules/src/helpers/auth.rs
     section: § 11.1
     snippet: It uses a case-insensitive token to identify the authentication scheme
@@ -7625,7 +7625,7 @@ sources:
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
       line: 197
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 231
+      line: 235
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 506
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs


### PR DESCRIPTION
`websocket_handshake_valid` declares its first entries: the response's half of `Sec-WebSocket-Protocol`, which is two sentences no production carries. The empty string is one of them, and it is the field's rather than the list's — a client writes `1#token`, so a blank member is arithmetic on a production, while §4.2.2 says in as many words that a server's empty string *is not the same as the null value*, and no `token` floor can hold that distinction: absence is how a server says it agreed to nothing.

The other is `_unsolicited` at its plainest. Nothing is wrong with the value as written and what condemns it is a field in the request it answers: §4.2.2 says the name is *selected* from the client's list, so a name outside it — or any name where the client sent none — was derived from something other than the handshake. Both are `error`, because the client's own list hands it one instruction for this case and it is to fail the connection.

The alphabet in between stays `token`'s on this side as on the other. The comma that says a server answered with a list keeps its own message under `token_character_forbidden`: the delimiter is what says a list was meant, and the reading survives the id being shared.

§4.2.2's definition moves onto the subject and the rule imports it back. A label of `Sec-WebSocket-Protocol` and the subject's file stem differ only in punctuation and case, which is one fragment identity for two groups of sentences, so the label becomes `Sec-WebSocket-Protocol-Client` — the production it quotes.

Floor: 225 of 232 entries cite a sentence.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
