### PR TITLE
An extension nobody asked for

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1735,6 +1735,10 @@ severity = "error"
 # Sec-WebSocket-Extensions writes a parameter '=' with no value after it
 severity = "error"
 
+[violations.sec_websocket_extensions_unsolicited]
+# Sec-WebSocket-Extensions names an extension the request did not offer
+severity = "error"
+
 [violations.sec_websocket_key_length_invalid]
 # Sec-WebSocket-Key is not a sixteen-byte nonce
 severity = "warn"

--- a/lint-http-rules/src/rules/websocket_handshake_valid.rs
+++ b/lint-http-rules/src/rules/websocket_handshake_valid.rs
@@ -11,6 +11,7 @@ use crate::helpers::websocket::{
 };
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::sec_websocket_extensions::SEC_WEBSOCKET_EXTENSIONS_UNSOLICITED;
 use crate::violations::sec_websocket_protocol::{
     RFC_6455_4_2_2, SEC_WEBSOCKET_PROTOCOL_EMPTY, SEC_WEBSOCKET_PROTOCOL_UNSOLICITED,
 };
@@ -57,9 +58,16 @@ pub struct WebsocketHandshakeValid;
 /// the comma that says a server answered with a list is a delimiter § 5.6.2
 /// names, and it keeps its own message beside the shared id.
 ///
+/// The extensions half is the same shape once more: the field's grammar is
+/// `sec_websocket_extensions_syntax`' in both directions, and what is left here
+/// is a name the request never offered — which no reading of one message can
+/// see, and which is why the entry sits in a subject otherwise spelled entirely
+/// out of § 9.1's ABNF.
+///
 /// Everything else this rule reads is still unnamed and says so through
 /// [`Defect`], which is a finding no subject has claimed.
 static DECLARED: &[&ViolationDef] = &[
+    &SEC_WEBSOCKET_EXTENSIONS_UNSOLICITED,
     &SEC_WEBSOCKET_PROTOCOL_EMPTY,
     &SEC_WEBSOCKET_PROTOCOL_UNSOLICITED,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
@@ -301,14 +309,13 @@ impl WebsocketHandshakeValid {
     /// both directions and each field section on its own — including the RFC
     /// 2616 notation § 9.1 imports, under which a null list element conforms.
     // cite(RFC 6455 § 4.1): "If the response includes a |Sec-WebSocket-Extensions| header field and this header field indicates the use of an extension that was not present in the client's handshake (the server has indicated an extension not requested by the client), the client MUST _Fail the WebSocket Connection_."
-    // cite(RFC 6455 § 4.2.2): "Extensions not listed by the client MUST NOT be listed."
     // cite(RFC 6455 § 9.1): "The extensions listed by the server in response represent the extensions actually in use for the connection."
     // cite(RFC 6455 § 9.1): "any extension parameters, and what constitutes a valid response by a server to a requested set of parameters by a client, will be defined by each such extension."
     // cite(RFC 6455 § 9.1): "Any extension-token used MUST be a registered token (see Section 11.4)."
     fn extensions_defect(
         req_headers: &hyper::HeaderMap,
         resp_headers: &hyper::HeaderMap,
-    ) -> Option<String> {
+    ) -> Option<Defect> {
         let raw = combined_field_value_as_written(resp_headers, "sec-websocket-extensions")?;
         let offered_raw = combined_field_value_as_written(req_headers, "sec-websocket-extensions")
             .unwrap_or_default();
@@ -316,10 +323,13 @@ impl WebsocketHandshakeValid {
         for member in list_members(&raw) {
             let name = extension_token(member);
             if !offered.contains(&name) {
-                return Some(format!(
-                    "its Sec-WebSocket-Extensions names the extension `{}`, which the request it \
-                     answers did not offer",
-                    shown_in_finding(name)
+                return Some(Defect::named(
+                    &SEC_WEBSOCKET_EXTENSIONS_UNSOLICITED,
+                    format!(
+                        "its Sec-WebSocket-Extensions names the extension `{}`, which the request \
+                         it answers did not offer",
+                        shown_in_finding(name)
+                    ),
                 ));
             }
         }
@@ -599,7 +609,7 @@ impl Rule for WebsocketHandshakeValid {
                 Self::upgrade_defect(&resp.headers).map(Defect::unnamed),
                 Self::connection_defect(&resp.headers).map(Defect::unnamed),
                 Self::accept_defect(&req.headers, &resp.headers).map(Defect::unnamed),
-                Self::extensions_defect(&req.headers, &resp.headers).map(Defect::unnamed),
+                Self::extensions_defect(&req.headers, &resp.headers),
                 Self::subprotocol_defect(&req.headers, &resp.headers),
             ]
             .into_iter()
@@ -1067,7 +1077,11 @@ mod tests {
         let tx = make_ws_tx(req, 101, resp);
         match expected {
             None => assert!(run(&tx).is_none()),
-            Some(text) => assert!(run(&tx).unwrap().message.contains(text), "{value}"),
+            Some(text) => {
+                let found = run(&tx).unwrap();
+                assert!(found.message.contains(text), "{value}");
+                assert_eq!(found.violation, "sec_websocket_extensions_unsolicited");
+            }
         }
     }
 

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -424,7 +424,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 225;
+        const FLOOR: usize = 226;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/sec_websocket_extensions.rs
+++ b/lint-http-rules/src/violations/sec_websocket_extensions.rs
@@ -21,12 +21,20 @@
 //! borrowing either would put a citation on a finding whose grammar the cited
 //! sentence does not govern.
 //!
-//! **Every entry here is an `error`, and one sentence is why.** § 9.1 does not
-//! leave the consequence of a malformed value to a recipient's judgement: *the
-//! recipient of such malformed data MUST immediately _Fail the WebSocket
-//! Connection_*. So the question [`status`](crate::violations::status) ranks by
-//! — whether the exchange can continue — is answered by the document itself,
-//! and answered the same way for all three.
+//! **The fourth entry is about neither the grammar nor its notation**, and it
+//! is the one that needs two messages to see: an extension a server lists that
+//! the client never offered derives from the ABNF exactly, and what condemns it
+//! is § 4.2.2's prohibition on listing it. Negotiation is an exchange, so a
+//! subject spelled out of one message's productions cannot be all of it.
+//!
+//! **Every entry here is an `error`, and § 9.1 is why for three of them.** It
+//! does not leave the consequence of a malformed value to a recipient's
+//! judgement: *the recipient of such malformed data MUST immediately _Fail the
+//! WebSocket Connection_*. So the question
+//! [`status`](crate::violations::status) ranks by — whether the exchange can
+//! continue — is answered by the document itself. The fourth lands at the same
+//! rank by a sentence of its own, § 4.1's instruction to a client that reads an
+//! extension it did not ask for, which is to fail the connection.
 //!
 //! **The borrowed ids stay at their own rank, and that is not an
 //! inconsistency to fix.** `token_empty` answers for eighty other fields and
@@ -40,6 +48,9 @@
 use crate::lint::Severity;
 use crate::rules::SpecRef;
 use crate::violations::defects;
+// One definition of the server's section for both subjects a server chooses
+// from, kept where the first entry to cite it landed rather than copied here.
+use crate::violations::sec_websocket_protocol::RFC_6455_4_2_2;
 
 /// Negotiating Extensions: the grammar, the MUST that makes a non-conforming
 /// value a failure of the connection, and the note that the notation is RFC
@@ -147,6 +158,38 @@ defects! {
         default_severity: Severity::Error,
         spec: &[RFC_6455_9_1],
     }
+
+    /// An extension in a response the request never offered — a name outside
+    /// the client's list, or any name at all where the client sent no list.
+    ///
+    /// **The one entry here that is about neither the grammar nor its
+    /// notation.** Everything else this subject owns is a value that fails to
+    /// derive from § 9.1's ABNF; this one derives perfectly and is still wrong,
+    /// because negotiation has two messages in it and only one of them is being
+    /// read when a value is measured against a production. § 4.2.2 states it as
+    /// a prohibition on the sender, and § 9.1 says what the field means when it
+    /// is obeyed: the server's list *is* the extensions in use, so a name the
+    /// client never offered claims a connection is running something neither
+    /// side agreed to.
+    ///
+    /// `error`, with the rest of the subject, and by a different sentence: not
+    /// § 9.1's failure on malformed data, which this value is not, but the
+    /// instruction § 4.1 hands the client for this exact case, which is to fail
+    /// the connection.
+    ///
+    /// The comparison is over the `extension-token` half of each member, and it
+    /// is of the octets as written: a name is registered rather than spelled
+    /// afresh by either side, and this document folds case at the two fields
+    /// where it says so and nowhere near this one.
+    ///
+    // cite(RFC 6455 § 4.2.2): "Extensions not listed by the client MUST NOT be listed."
+    SEC_WEBSOCKET_EXTENSIONS_UNSOLICITED = {
+        id: "sec_websocket_extensions_unsolicited",
+        title: "Sec-WebSocket-Extensions names an extension the request did not offer",
+        message: "",
+        default_severity: Severity::Error,
+        spec: &[RFC_6455_4_2_2],
+    }
 }
 
 #[cfg(test)]
@@ -155,16 +198,27 @@ mod tests {
 
     /// The rank is the document's rather than the subject's judgement: a value
     /// that does not conform to § 9.1's ABNF is a connection a recipient MUST
-    /// fail, so nothing here can be the milder half of anything.
+    /// fail, and an extension the client never offered is one § 4.1 tells it to
+    /// fail for, so nothing here can be the milder half of anything.
     #[test]
     fn a_value_this_field_cannot_read_ends_the_connection() {
         for def in [
             &SEC_WEBSOCKET_EXTENSIONS_EMPTY,
             &SEC_WEBSOCKET_EXTENSIONS_PARAMETER_MISSING,
             &SEC_WEBSOCKET_EXTENSIONS_PARAMETER_VALUE_EMPTY,
+            &SEC_WEBSOCKET_EXTENSIONS_UNSOLICITED,
         ] {
             assert_eq!(def.default_severity, Severity::Error, "{}", def.id);
         }
+    }
+
+    /// The one entry here that no production could have produced, and the
+    /// section it cites says so: § 9.1 is where this field is written and
+    /// § 4.2.2 is where a server is told what it may write there.
+    #[test]
+    fn the_entry_needing_two_messages_cites_the_section_addressed_to_the_server() {
+        assert_eq!(SEC_WEBSOCKET_EXTENSIONS_UNSOLICITED.spec, [RFC_6455_4_2_2]);
+        assert_ne!(RFC_6455_4_2_2.section, RFC_6455_9_1.section);
     }
 
     /// The list floor is the 1997 notation's and the two parameter absences are

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1117,7 +1117,7 @@ sources:
     - file: lint-http-rules/src/rules/sec_websocket_version_advertised.rs
       line: 87
     - file: lint-http-rules/src/violations/sec_websocket_extensions.rs
-      line: 93
+      line: 104
     - file: lint-http-rules/src/violations/sec_websocket_version.rs
       line: 173
   - label: sec_websocket_extensions_syntax (3)
@@ -2505,7 +2505,7 @@ sources:
     - file: lint-http-proxy/src/proxy/websocket/mod.rs
       line: 73
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 305
+      line: 312
   - label: lint-http-proxy/src/proxy/websocket/frame.rs
     section: § 5.2
     snippet: '%x3-7 are reserved for further non-control frames'
@@ -2646,18 +2646,24 @@ sources:
       line: 78
     - file: lint-http-rules/src/violations/sec_websocket_version.rs
       line: 102
+  - label: sec_websocket_extensions
+    section: § 4.2.2
+    snippet: Extensions not listed by the client MUST NOT be listed.
+    cited_by:
+    - file: lint-http-rules/src/violations/sec_websocket_extensions.rs
+      line: 185
   - label: extension repetition
     section: § 9.1
     snippet: extension = extension-token *( ";" extension-param )
     cited_by:
     - file: lint-http-rules/src/violations/sec_websocket_extensions.rs
-      line: 114
+      line: 125
   - label: extension-param alternation
     section: § 9.1
     snippet: extension-param = token [ "=" (token | quoted-string) ]
     cited_by:
     - file: lint-http-rules/src/violations/sec_websocket_extensions.rs
-      line: 142
+      line: 153
   - label: quoted-string parameter note
     section: § 9.1
     snippet: ;When using the quoted-string syntax variant, the value ;after quoted-string unescaping MUST conform to the ;'token' ABNF.
@@ -2677,7 +2683,7 @@ sources:
     - file: lint-http-rules/src/rules/sec_websocket_extensions_syntax.rs
       line: 123
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 307
+      line: 314
   - label: sec_websocket_extensions_syntax (3)
     section: § 9.1
     snippet: If a value is received by either the client or the server during negotiation that does not conform to the ABNF below, the recipient of such malformed data MUST immediately _Fail the WebSocket Connection_.
@@ -2685,7 +2691,7 @@ sources:
     - file: lint-http-rules/src/rules/sec_websocket_extensions_syntax.rs
       line: 333
     - file: lint-http-rules/src/violations/sec_websocket_extensions.rs
-      line: 38
+      line: 46
   - label: sec_websocket_extensions_syntax (4)
     section: § 9.1
     snippet: Note that this section is using ABNF syntax/rules from [RFC2616], including the "implied *LWS rule".
@@ -2749,7 +2755,7 @@ sources:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
       line: 435
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 120
+      line: 128
   - label: Sec-WebSocket-Protocol-Client
     section: § 4.3
     snippet: Sec-WebSocket-Protocol-Client = 1#token
@@ -2963,151 +2969,145 @@ sources:
     snippet: If the response includes a |Sec-WebSocket-Extensions| header field and this header field indicates the use of an extension that was not present in the client's handshake (the server has indicated an extension not requested by the client), the client MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 303
+      line: 311
   - label: websocket_handshake_valid (2)
     section: § 4.1
     snippet: If the response includes a |Sec-WebSocket-Protocol| header field and this header field indicates the use of a subprotocol that was not present in the client's handshake (the server has indicated a subprotocol not requested by the client), the client MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 353
+      line: 363
   - label: websocket_handshake_valid (3)
     section: § 4.1
     snippet: If the response lacks a |Connection| header field or the |Connection| header field doesn't contain a token that is an ASCII case-insensitive match for the value "Upgrade", the client MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 215
+      line: 223
   - label: websocket_handshake_valid (4)
     section: § 4.1
     snippet: If the response lacks a |Sec-WebSocket-Accept| header field or the |Sec-WebSocket-Accept| contains a value other than the base64-encoded SHA-1 of the concatenation of the |Sec-WebSocket-Key| (as a string, not base64-decoded) with the string "258EAFA5-E914-47DA-95CA-C5AB0DC85B11" but ignoring any leading and trailing whitespace, the client MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 250
+      line: 258
   - label: websocket_handshake_valid (5)
     section: § 4.1
     snippet: If the response lacks an |Upgrade| header field or the |Upgrade| header field contains a value that is not an ASCII case-insensitive match for the value "websocket", the client MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 180
+      line: 188
   - label: websocket_handshake_valid (6)
     section: § 4.1
     snippet: If the status code received from the server is not 101, the client handles the response per HTTP [RFC2616] procedures.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 577
+      line: 587
   - label: websocket_handshake_valid (7)
     section: § 4.1
     snippet: In particular, the client might perform authentication if it receives a 401 status code; the server might redirect the client using a 3xx status code (but clients are not required to follow them), etc.  Otherwise, proceed as follows.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 578
+      line: 588
   - label: websocket_handshake_valid (8)
     section: § 4.2.1
     snippet: A |Sec-WebSocket-Key| header field with a base64-encoded (see Section 4 of [RFC4648]) value that, when decoded, is 16 bytes in length.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 122
+      line: 130
   - label: websocket_handshake_valid (9)
     section: § 4.2.1
     snippet: A |Sec-WebSocket-Version| header field, with a value of 13.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 123
+      line: 131
   - label: websocket_handshake_valid (10)
     section: § 4.2.1
     snippet: including but not limited to any violations of the ABNF grammar specified for the components of the handshake
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 121
+      line: 129
   - label: websocket_handshake_valid (11)
     section: § 4.2.2
     snippet: A Status-Line with a 101 response code as per RFC 2616 [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 584
+      line: 594
   - label: websocket_handshake_valid (12)
     section: § 4.2.2
     snippet: A |Connection| header field with value "Upgrade".
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 216
+      line: 224
   - label: websocket_handshake_valid (13)
     section: § 4.2.2
     snippet: A |Sec-WebSocket-Accept| header field.  The value of this header field is constructed by concatenating /key/, defined above in step 4 in Section 4.2.2, with the string "258EAFA5-E914-47DA-95CA-C5AB0DC85B11", taking the SHA-1 hash of this concatenated value to obtain a 20-byte value and base64-encoding (see Section 4 of [RFC4648]) this 20-byte hash.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 251
+      line: 259
   - label: websocket_handshake_valid (14)
     section: § 4.2.2
     snippet: An |Upgrade| header field with value "websocket" as per RFC 2616 [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 181
+      line: 189
   - label: websocket_handshake_valid (15)
-    section: § 4.2.2
-    snippet: Extensions not listed by the client MUST NOT be listed.
-    cited_by:
-    - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 304
-  - label: websocket_handshake_valid (16)
     section: § 4.2.2
     snippet: If the requested service is not available, the server MUST send an appropriate HTTP error code (such as 404 Not Found) and abort the WebSocket handshake.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 583
-  - label: websocket_handshake_valid (17)
+      line: 593
+  - label: websocket_handshake_valid (16)
     section: § 4.2.2
     snippet: If the server chooses to accept the incoming connection, it MUST reply with a valid HTTP response indicating the following.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 579
-  - label: websocket_handshake_valid (18)
+      line: 589
+  - label: websocket_handshake_valid (17)
     section: § 4.2.2
     snippet: If the server does not wish to accept this connection, it MUST return an appropriate HTTP error code (e.g., 403 Forbidden) and abort the WebSocket handshake described in this section.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 582
-  - label: websocket_handshake_valid (19)
+      line: 592
+  - label: websocket_handshake_valid (18)
     section: § 4.2.2
     snippet: If this version does not match a version understood by the server, the server MUST abort the WebSocket handshake described in this section and instead send an appropriate HTTP error code (such as 426 Upgrade Required) and a |Sec-WebSocket-Version| header field indicating the version(s) the server is capable of understanding.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 124
-  - label: websocket_handshake_valid (20)
+      line: 132
+  - label: websocket_handshake_valid (19)
     section: § 4.2.2
     snippet: The server MAY redirect the client using a 3xx status code [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 581
-  - label: websocket_handshake_valid (21)
+      line: 591
+  - label: websocket_handshake_valid (20)
     section: § 4.2.2
     snippet: The server can perform additional client authentication, for example, by returning a 401 status code with the corresponding |WWW-Authenticate| header field as described in [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 580
-  - label: websocket_handshake_valid (22)
+      line: 590
+  - label: websocket_handshake_valid (21)
     section: § 4.2.2
     snippet: if the server does not wish to agree to one of the suggested subprotocols, it MUST NOT send back a |Sec-WebSocket-Protocol| header field in its response
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 354
+      line: 364
   - label: Sec-WebSocket-Protocol-Server
     section: § 4.3
     snippet: Sec-WebSocket-Protocol-Server = token
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 355
+      line: 365
   - label: extension
     section: § 4.3
     snippet: extension = extension-token *( ";" extension-param )
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 423
-  - label: websocket_handshake_valid (23)
+      line: 433
+  - label: websocket_handshake_valid (22)
     section: § 9.1
     snippet: any extension parameters, and what constitutes a valid response by a server to a requested set of parameters by a client, will be defined by each such extension.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 306
+      line: 313
 - label: RFC 6585
   url: https://www.rfc-editor.org/rfc/rfc6585.html
   fragments:


### PR DESCRIPTION
`websocket_handshake_valid`'s extensions reading converts: an extension a server lists that the client never offered, which is the same shape as the subprotocol beside it and lands in a subject that had nothing like it.

Every other entry of `sec_websocket_extensions` is a value that fails to derive from §9.1's ABNF. This one derives exactly and is still wrong, because negotiation has two messages in it and a subject spelled out of one message's productions cannot be all of it. §4.2.2 states it as a prohibition on the sender, and §9.1 says what the field means when it is obeyed: the server's list *is* the extensions in use, so a name the client never sent claims a connection is running something neither side agreed to.

`error`, with the rest of the subject and by a different sentence — not §9.1's failure on malformed data, which this value is not, but the instruction §4.1 hands a client that reads an extension it did not ask for.

§4.2.2 is imported from the subprotocol subject rather than defined a second time: one section, one reference, for both of the things a server chooses from.

Floor: 226 of 233 entries cite a sentence.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
