### PR TITLE
The field a server cannot template

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1723,6 +1723,14 @@ severity = "error"
 # A request-target carries whitespace
 severity = "error"
 
+[violations.sec_websocket_accept_conflicting]
+# Sec-WebSocket-Accept is not the value the request's key derives
+severity = "error"
+
+[violations.sec_websocket_accept_missing]
+# A WebSocket handshake response carries no Sec-WebSocket-Accept
+severity = "error"
+
 [violations.sec_websocket_extensions_empty]
 # Sec-WebSocket-Extensions names no extension
 severity = "error"

--- a/lint-http-rules/src/rules/websocket_handshake_valid.rs
+++ b/lint-http-rules/src/rules/websocket_handshake_valid.rs
@@ -11,6 +11,9 @@ use crate::helpers::websocket::{
 };
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::sec_websocket_accept::{
+    SEC_WEBSOCKET_ACCEPT_CONFLICTING, SEC_WEBSOCKET_ACCEPT_MISSING,
+};
 use crate::violations::sec_websocket_extensions::SEC_WEBSOCKET_EXTENSIONS_UNSOLICITED;
 use crate::violations::sec_websocket_protocol::{
     RFC_6455_4_2_2, SEC_WEBSOCKET_PROTOCOL_EMPTY, SEC_WEBSOCKET_PROTOCOL_UNSOLICITED,
@@ -64,9 +67,17 @@ pub struct WebsocketHandshakeValid;
 /// see, and which is why the entry sits in a subject otherwise spelled entirely
 /// out of § 9.1's ABNF.
 ///
-/// Everything else this rule reads is still unnamed and says so through
-/// [`Defect`], which is a finding no subject has claimed.
+/// `Sec-WebSocket-Accept` is the subject this rule brought into the catalogue,
+/// because it is the only rule that can read it: the value is derived from a
+/// field of the *request*, so nothing holding one message alone can say whether
+/// it is right.
+///
+/// What is left unnamed is the response's `Upgrade` and `Connection`, and the
+/// `101` that completed a handshake a server was required to refuse. All three
+/// say so through [`Defect`], which is a finding no subject has claimed.
 static DECLARED: &[&ViolationDef] = &[
+    &SEC_WEBSOCKET_ACCEPT_CONFLICTING,
+    &SEC_WEBSOCKET_ACCEPT_MISSING,
     &SEC_WEBSOCKET_EXTENSIONS_UNSOLICITED,
     &SEC_WEBSOCKET_PROTOCOL_EMPTY,
     &SEC_WEBSOCKET_PROTOCOL_UNSOLICITED,
@@ -260,12 +271,15 @@ impl WebsocketHandshakeValid {
     fn accept_defect(
         req_headers: &hyper::HeaderMap,
         resp_headers: &hyper::HeaderMap,
-    ) -> Option<String> {
+    ) -> Option<Defect> {
         let key = combined_field_value_as_written(req_headers, "sec-websocket-key")?;
         let expected = compute_accept(&key)?;
         let Some(raw) = combined_field_value_as_written(resp_headers, "sec-websocket-accept")
         else {
-            return Some("it carries no Sec-WebSocket-Accept header field".into());
+            return Some(Defect::named(
+                &SEC_WEBSOCKET_ACCEPT_MISSING,
+                "it carries no Sec-WebSocket-Accept header field".into(),
+            ));
         };
         // The clause of the sentence above that reads "but ignoring any leading and
         // trailing whitespace" — and `OWS` is what whitespace means on a value read
@@ -276,10 +290,13 @@ impl WebsocketHandshakeValid {
         if value == expected {
             return None;
         }
-        Some(format!(
-            "its Sec-WebSocket-Accept is `{}`, where the value derived from the request's \
-             Sec-WebSocket-Key is `{expected}`",
-            shown_in_finding(value)
+        Some(Defect::named(
+            &SEC_WEBSOCKET_ACCEPT_CONFLICTING,
+            format!(
+                "its Sec-WebSocket-Accept is `{}`, where the value derived from the request's \
+                 Sec-WebSocket-Key is `{expected}`",
+                shown_in_finding(value)
+            ),
         ))
     }
 
@@ -608,7 +625,7 @@ impl Rule for WebsocketHandshakeValid {
                 Self::refusable_handshake(&req.headers).map(Defect::unnamed),
                 Self::upgrade_defect(&resp.headers).map(Defect::unnamed),
                 Self::connection_defect(&resp.headers).map(Defect::unnamed),
-                Self::accept_defect(&req.headers, &resp.headers).map(Defect::unnamed),
+                Self::accept_defect(&req.headers, &resp.headers),
                 Self::extensions_defect(&req.headers, &resp.headers),
                 Self::subprotocol_defect(&req.headers, &resp.headers),
             ]
@@ -868,10 +885,11 @@ mod tests {
             101,
             vec![("upgrade", "websocket"), ("connection", "Upgrade")],
         );
-        assert!(run(&tx)
-            .unwrap()
+        let found = run(&tx).unwrap();
+        assert!(found
             .message
             .contains("carries no Sec-WebSocket-Accept header field"));
+        assert_eq!(found.violation, "sec_websocket_accept_missing");
 
         let tx = make_ws_tx(
             handshake_request(),
@@ -884,6 +902,7 @@ mod tests {
         );
         let v = run(&tx).unwrap();
         assert!(v.message.contains(ACCEPT), "{}", v.message);
+        assert_eq!(v.violation, "sec_websocket_accept_conflicting");
     }
 
     /// The whitespace this comparison ignores is `OWS`. An octet that merely looks

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -63,6 +63,7 @@ pub mod quoted_pair;
 pub mod quoted_string;
 pub mod qvalue;
 pub mod request_target;
+pub mod sec_websocket_accept;
 pub mod sec_websocket_extensions;
 pub mod sec_websocket_key;
 pub mod sec_websocket_protocol;
@@ -424,7 +425,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 226;
+        const FLOOR: usize = 228;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/sec_websocket_accept.rs
+++ b/lint-http-rules/src/violations/sec_websocket_accept.rs
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `Sec-WebSocket-Accept` defects — the one field that proves a server read the
+//! request.
+//!
+//! Every other field of a `101` a server could write from a template. This one
+//! it cannot: the value is the request's `Sec-WebSocket-Key` concatenated with a
+//! fixed GUID, hashed, and base64-encoded, so a server that answers with
+//! anything else either did not read the key or is not the server the client
+//! opened a handshake with. That is the whole of the field, and it is two
+//! entries — the field is absent, or the value is not the one the key derives.
+//!
+//! **Nothing here is a grammar entry, and the absence is deliberate.** § 4.3
+//! writes `Sec-WebSocket-Accept = base64-value-non-empty`, and a subject that
+//! measured a value against it would report every non-conforming value twice:
+//! the derived value is canonical base64 of twenty octets, so a value the
+//! grammar rejects is a value the comparison rejects, and the comparison's
+//! message can name what the server should have written where the production
+//! could only say it did not derive. **A production nothing can fail on its own
+//! earns no entry** — the [`base64`](crate::violations::base64) ids stay with
+//! the request's key, which is a value nothing else in the exchange constrains.
+//!
+//! **Both entries are `error`**, and the question
+//! [`status`](crate::violations::status) ranks by is answered by § 4.1 rather
+//! than by this subject: a client that finds either of them is told to _Fail the
+//! WebSocket Connection_, and by then the HTTP conversation is over — the `101`
+//! has handed the connection to a protocol whose first message the client will
+//! never send.
+
+use crate::lint::Severity;
+use crate::violations::defects;
+use crate::violations::sec_websocket_protocol::RFC_6455_4_2_2;
+
+defects! {
+    /// A `101` completing a WebSocket handshake with no `Sec-WebSocket-Accept`
+    /// on it at all.
+    ///
+    /// Kept apart from the value that does not derive, the way this catalogue
+    /// keeps every absence apart from every wrong value: a server that wrote no
+    /// field never ran the derivation, and one that wrote the wrong value ran it
+    /// over something other than the key it was sent. The fixes are not the
+    /// same, and neither is what an operator learns from the finding.
+    ///
+    /// Not to be confused with [`upgrade_101_missing`](crate::violations::upgrade),
+    /// which every `101` owes whatever it switched to. This field is owed by the
+    /// handshake this document defines, and a `101` that is not one of those
+    /// owes nothing here.
+    ///
+    // cite(RFC 6455 § 4.2.2): "A |Sec-WebSocket-Accept| header field.  The value of this header field is constructed by concatenating /key/, defined above in step 4 in Section 4.2.2, with the string "258EAFA5-E914-47DA-95CA-C5AB0DC85B11", taking the SHA-1 hash of this concatenated value to obtain a 20-byte value and base64-encoding (see Section 4 of [RFC4648]) this 20-byte hash."
+    SEC_WEBSOCKET_ACCEPT_MISSING = {
+        id: "sec_websocket_accept_missing",
+        title: "A WebSocket handshake response carries no Sec-WebSocket-Accept",
+        message: "",
+        default_severity: Severity::Error,
+        spec: &[RFC_6455_4_2_2],
+    }
+
+    /// A value that is not the one the request's `Sec-WebSocket-Key` derives.
+    ///
+    /// `_conflicting` and not `_invalid`: nothing about the value can be
+    /// measured on its own. It is a perfectly good base64 string as often as
+    /// not, and what is wrong is that it disagrees with a field in the other
+    /// message — the two things this document requires to agree are the key the
+    /// client sent and the hash the server echoed, and a finding here is the
+    /// disagreement rather than either value's own defect.
+    ///
+    /// **A second field line is this entry too**, and the reason is worth
+    /// keeping: the field is not list-based, so two lines do not make two
+    /// members — the value is the join, comma and all, and the join derives from
+    /// no key. The finding is worded from what the message says rather than from
+    /// what one of its lines says.
+    ///
+    /// The derivation is the sentence, so the message names the value the server
+    /// should have written. This is the entry whose finding an operator can act
+    /// on without reading the specification at all.
+    ///
+    // cite(RFC 6455 § 4.2.2): "A |Sec-WebSocket-Accept| header field.  The value of this header field is constructed by concatenating /key/, defined above in step 4 in Section 4.2.2, with the string "258EAFA5-E914-47DA-95CA-C5AB0DC85B11", taking the SHA-1 hash of this concatenated value to obtain a 20-byte value and base64-encoding (see Section 4 of [RFC4648]) this 20-byte hash."
+    SEC_WEBSOCKET_ACCEPT_CONFLICTING = {
+        id: "sec_websocket_accept_conflicting",
+        title: "Sec-WebSocket-Accept is not the value the request's key derives",
+        message: "",
+        default_severity: Severity::Error,
+        spec: &[RFC_6455_4_2_2],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One field, one sentence, two ways of failing it — and the rank is the
+    /// same for both because the client's instruction is: the connection has
+    /// already left HTTP, so neither can be repaired by a later message.
+    #[test]
+    fn the_absent_field_and_the_wrong_value_are_two_ids_of_one_rank() {
+        assert_eq!(
+            SEC_WEBSOCKET_ACCEPT_MISSING.id,
+            "sec_websocket_accept_missing"
+        );
+        assert_eq!(
+            SEC_WEBSOCKET_ACCEPT_CONFLICTING.id,
+            "sec_websocket_accept_conflicting"
+        );
+        for def in [
+            &SEC_WEBSOCKET_ACCEPT_MISSING,
+            &SEC_WEBSOCKET_ACCEPT_CONFLICTING,
+        ] {
+            assert_eq!(def.default_severity, Severity::Error, "{}", def.id);
+            assert_eq!(def.spec, [RFC_6455_4_2_2], "{}", def.id);
+        }
+    }
+}

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -2505,7 +2505,7 @@ sources:
     - file: lint-http-proxy/src/proxy/websocket/mod.rs
       line: 73
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 312
+      line: 329
   - label: lint-http-proxy/src/proxy/websocket/frame.rs
     section: § 5.2
     snippet: '%x3-7 are reserved for further non-control frames'
@@ -2683,7 +2683,7 @@ sources:
     - file: lint-http-rules/src/rules/sec_websocket_extensions_syntax.rs
       line: 123
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 314
+      line: 331
   - label: sec_websocket_extensions_syntax (3)
     section: § 9.1
     snippet: If a value is received by either the client or the server during negotiation that does not conform to the ABNF below, the recipient of such malformed data MUST immediately _Fail the WebSocket Connection_.
@@ -2755,7 +2755,7 @@ sources:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
       line: 435
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 128
+      line: 139
   - label: Sec-WebSocket-Protocol-Client
     section: § 4.3
     snippet: Sec-WebSocket-Protocol-Client = 1#token
@@ -2969,145 +2969,149 @@ sources:
     snippet: If the response includes a |Sec-WebSocket-Extensions| header field and this header field indicates the use of an extension that was not present in the client's handshake (the server has indicated an extension not requested by the client), the client MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 311
+      line: 328
   - label: websocket_handshake_valid (2)
     section: § 4.1
     snippet: If the response includes a |Sec-WebSocket-Protocol| header field and this header field indicates the use of a subprotocol that was not present in the client's handshake (the server has indicated a subprotocol not requested by the client), the client MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 363
+      line: 380
   - label: websocket_handshake_valid (3)
     section: § 4.1
     snippet: If the response lacks a |Connection| header field or the |Connection| header field doesn't contain a token that is an ASCII case-insensitive match for the value "Upgrade", the client MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 223
+      line: 234
   - label: websocket_handshake_valid (4)
     section: § 4.1
     snippet: If the response lacks a |Sec-WebSocket-Accept| header field or the |Sec-WebSocket-Accept| contains a value other than the base64-encoded SHA-1 of the concatenation of the |Sec-WebSocket-Key| (as a string, not base64-decoded) with the string "258EAFA5-E914-47DA-95CA-C5AB0DC85B11" but ignoring any leading and trailing whitespace, the client MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 258
+      line: 269
   - label: websocket_handshake_valid (5)
     section: § 4.1
     snippet: If the response lacks an |Upgrade| header field or the |Upgrade| header field contains a value that is not an ASCII case-insensitive match for the value "websocket", the client MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 188
+      line: 199
   - label: websocket_handshake_valid (6)
     section: § 4.1
     snippet: If the status code received from the server is not 101, the client handles the response per HTTP [RFC2616] procedures.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 587
+      line: 604
   - label: websocket_handshake_valid (7)
     section: § 4.1
     snippet: In particular, the client might perform authentication if it receives a 401 status code; the server might redirect the client using a 3xx status code (but clients are not required to follow them), etc.  Otherwise, proceed as follows.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 588
+      line: 605
   - label: websocket_handshake_valid (8)
     section: § 4.2.1
     snippet: A |Sec-WebSocket-Key| header field with a base64-encoded (see Section 4 of [RFC4648]) value that, when decoded, is 16 bytes in length.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 130
+      line: 141
   - label: websocket_handshake_valid (9)
     section: § 4.2.1
     snippet: A |Sec-WebSocket-Version| header field, with a value of 13.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 131
+      line: 142
   - label: websocket_handshake_valid (10)
     section: § 4.2.1
     snippet: including but not limited to any violations of the ABNF grammar specified for the components of the handshake
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 129
+      line: 140
   - label: websocket_handshake_valid (11)
     section: § 4.2.2
     snippet: A Status-Line with a 101 response code as per RFC 2616 [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 594
+      line: 611
   - label: websocket_handshake_valid (12)
     section: § 4.2.2
     snippet: A |Connection| header field with value "Upgrade".
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 224
+      line: 235
   - label: websocket_handshake_valid (13)
     section: § 4.2.2
     snippet: A |Sec-WebSocket-Accept| header field.  The value of this header field is constructed by concatenating /key/, defined above in step 4 in Section 4.2.2, with the string "258EAFA5-E914-47DA-95CA-C5AB0DC85B11", taking the SHA-1 hash of this concatenated value to obtain a 20-byte value and base64-encoding (see Section 4 of [RFC4648]) this 20-byte hash.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 259
+      line: 270
+    - file: lint-http-rules/src/violations/sec_websocket_accept.rs
+      line: 51
+    - file: lint-http-rules/src/violations/sec_websocket_accept.rs
+      line: 79
   - label: websocket_handshake_valid (14)
     section: § 4.2.2
     snippet: An |Upgrade| header field with value "websocket" as per RFC 2616 [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 189
+      line: 200
   - label: websocket_handshake_valid (15)
     section: § 4.2.2
     snippet: If the requested service is not available, the server MUST send an appropriate HTTP error code (such as 404 Not Found) and abort the WebSocket handshake.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 593
+      line: 610
   - label: websocket_handshake_valid (16)
     section: § 4.2.2
     snippet: If the server chooses to accept the incoming connection, it MUST reply with a valid HTTP response indicating the following.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 589
+      line: 606
   - label: websocket_handshake_valid (17)
     section: § 4.2.2
     snippet: If the server does not wish to accept this connection, it MUST return an appropriate HTTP error code (e.g., 403 Forbidden) and abort the WebSocket handshake described in this section.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 592
+      line: 609
   - label: websocket_handshake_valid (18)
     section: § 4.2.2
     snippet: If this version does not match a version understood by the server, the server MUST abort the WebSocket handshake described in this section and instead send an appropriate HTTP error code (such as 426 Upgrade Required) and a |Sec-WebSocket-Version| header field indicating the version(s) the server is capable of understanding.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 132
+      line: 143
   - label: websocket_handshake_valid (19)
     section: § 4.2.2
     snippet: The server MAY redirect the client using a 3xx status code [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 591
+      line: 608
   - label: websocket_handshake_valid (20)
     section: § 4.2.2
     snippet: The server can perform additional client authentication, for example, by returning a 401 status code with the corresponding |WWW-Authenticate| header field as described in [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 590
+      line: 607
   - label: websocket_handshake_valid (21)
     section: § 4.2.2
     snippet: if the server does not wish to agree to one of the suggested subprotocols, it MUST NOT send back a |Sec-WebSocket-Protocol| header field in its response
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 364
+      line: 381
   - label: Sec-WebSocket-Protocol-Server
     section: § 4.3
     snippet: Sec-WebSocket-Protocol-Server = token
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 365
+      line: 382
   - label: extension
     section: § 4.3
     snippet: extension = extension-token *( ";" extension-param )
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 433
+      line: 450
   - label: websocket_handshake_valid (22)
     section: § 9.1
     snippet: any extension parameters, and what constitutes a valid response by a server to a requested set of parameters by a client, will be defined by each such extension.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 313
+      line: 330
 - label: RFC 6585
   url: https://www.rfc-editor.org/rfc/rfc6585.html
   fragments:


### PR DESCRIPTION
`violations/sec_websocket_accept.rs`, and the rule that reads it is the only rule that could: the value is the request's `Sec-WebSocket-Key` concatenated with a fixed GUID, hashed and base64-encoded, so nothing holding one message alone can say whether a server got it right. Two entries — the field is absent, or the value is not the one the key derives.

The wrong value is `_conflicting` and not `_invalid`, because nothing about it can be measured on its own: it is a perfectly good base64 string as often as not, and what is wrong is that it disagrees with a field in the other message. A second field line is the same entry, since this field is not list-based and the value is the join, comma and all.

No grammar entry, and the absence is the point. §4.3 writes `Sec-WebSocket-Accept = base64-value-non-empty`, and the derived value is canonical base64 of twenty octets — so every value the production rejects the comparison rejects too, and the comparison can name what the server should have written where the production could only say it did not derive. A production nothing can fail on its own earns no entry.

Both `error`: §4.1 hands the client one instruction for either, and by then the `101` has handed the connection to a protocol whose first message it will never send.

Floor: 228 of 235 entries cite a sentence.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
