### PR TITLE
The name that keeps a field from travelling

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1935,6 +1935,10 @@ severity = "warn"
 # A 426 response carries no Upgrade field
 severity = "warn"
 
+[violations.upgrade_connection_option_missing]
+# Upgrade is sent with no upgrade connection-option in Connection
+severity = "warn"
+
 [violations.uri_character_forbidden]
 # Value holds a character no URI is written with
 severity = "warn"

--- a/lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
+++ b/lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
@@ -7,8 +7,20 @@ use crate::helpers::headers::combined_field_value_as_written;
 use crate::helpers::shown::shown_in_finding;
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::upgrade::{RFC_9110_7_8, UPGRADE_CONNECTION_OPTION_MISSING};
+use crate::violations::ViolationDef;
 
 pub struct UpgradeAndConnectionConsistent;
+
+/// One entry, and it is `Upgrade`'s rather than `Connection`'s.
+///
+/// The missing name is on `Connection`, and the sentence requiring it is in the
+/// section defining `Upgrade` — as `TE`'s is in `TE`'s and `Keep-Alive`'s is in
+/// a 1997 document. A shared entry would have to cite § 7.6.1's general wording
+/// for findings whose evidence is a field-specific MUST, which is the shape the
+/// registry family already refused: **an identical defect under a different
+/// sentence is a different entry.**
+static DECLARED: &[&ViolationDef] = &[&UPGRADE_CONNECTION_OPTION_MISSING];
 
 impl UpgradeAndConnectionConsistent {
     /// One field section, measured against the sentence that pairs the two fields.
@@ -40,9 +52,12 @@ impl UpgradeAndConnectionConsistent {
     /// quotation needs to be evidence of anything.
     ///
     /// cite(RFC 9110 § 7.6.1): "When a field aside from Connection is used to supply control information for or about the current connection, the sender MUST list the corresponding field name within the Connection header field."
-    /// cite(RFC 9110 § 7.8): "A sender of Upgrade MUST also send an "Upgrade" connection option in the Connection header field (Section 7.6.1) to inform intermediaries not to forward this field."
     /// cite(RFC 9110 § A, label: Upgrade grammar, sender-expanded): "Upgrade = [ protocol *( OWS "," OWS protocol ) ]"
-    fn defect(headers: &hyper::HeaderMap, version: &str, direction: &str) -> Option<String> {
+    fn defect(
+        headers: &hyper::HeaderMap,
+        version: &str,
+        direction: &str,
+    ) -> Option<(&'static ViolationDef, String)> {
         // The major digit decides whether this version has a `Connection` field to
         // carry the option; `http_version` owns the production that reads it. The MUST
         // is unconditional in its own sentence and its condition is one section away:
@@ -96,11 +111,14 @@ impl UpgradeAndConnectionConsistent {
             Some(value) => format!("its Connection field names `{}`", shown_in_finding(value)),
             None => "the message carries no Connection field".to_string(),
         };
-        Some(format!(
-            "{direction} carries an Upgrade header field without an 'upgrade' connection option \
-             in Connection ({names}); Upgrade applies to the immediate connection only, the \
-             option is what stops an intermediary from forwarding it, and a recipient that \
-             receives it forwarded is told to ignore it (RFC 9110 §7.8)"
+        Some((
+            &UPGRADE_CONNECTION_OPTION_MISSING,
+            format!(
+                "{direction} carries an Upgrade header field without an 'upgrade' connection \
+                 option in Connection ({names}); Upgrade applies to the immediate connection \
+                 only, the option is what stops an intermediary from forwarding it, and a \
+                 recipient that receives it forwarded is told to ignore it (RFC 9110 §7.8)"
+            ),
         ))
     }
 }
@@ -108,14 +126,10 @@ impl UpgradeAndConnectionConsistent {
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_9110_7_8: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("7.8"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8",
-    note: "Upgrade — the sender's obligation to name the field as a connection-option \
-           beside it, and the `#protocol` grammar that makes the field's presence the \
-           thing the obligation turns on",
-};
+///
+/// § 7.8 is not written here: it is the sentence the entry this rule reports
+/// enforces, so the reference lives beside that entry in
+/// [`upgrade`](crate::violations::upgrade) and is imported back.
 const RFC_9110_7_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
     section: Some("7.6.1"),
@@ -158,6 +172,10 @@ severity = "warn"
         &[RFC_9110_7_8, RFC_9110_7_6_1, RFC_9113_8_2_2, RFC_9114_4_2]
     }
 
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
+    }
+
     fn examples(&self) -> &'static [crate::rules::Example] {
         use crate::rules::{Compliance, Example};
         &[
@@ -198,7 +216,7 @@ impl Rule for UpgradeAndConnectionConsistent {
             // the request may have arrived over HTTP/3 while the response came back from
             // the origin over HTTP/1.1, and the sender the sentence is about is the one
             // that wrote the section being read.
-            let message = Self::defect(&tx.request.headers, &tx.request.version, "Request")
+            let (def, message) = Self::defect(&tx.request.headers, &tx.request.version, "Request")
                 .or_else(|| {
                     let resp = tx.response.as_ref()?;
                     Self::defect(&resp.headers, &resp.version, "Response")
@@ -206,7 +224,7 @@ impl Rule for UpgradeAndConnectionConsistent {
 
             // Read last: every gate above ends the rule, so only a message about to be
             // reported pays for the map probes and the hash over the rule id.
-            Some(self.violation(ctx.severity, message))
+            Some(ctx.report_with(def, message))
         };
         Vec::from_iter(finding())
     }
@@ -313,6 +331,20 @@ mod tests {
             "{}",
             violation.message
         );
+    }
+
+    /// One entry for both shapes of the absence — the option is what is missing
+    /// either way, and the message is where the two part company. The rank is the
+    /// entry's now, and it is the one this rule had chosen for itself.
+    #[rstest]
+    #[case(vec![("upgrade", "websocket")])]
+    #[case(vec![("connection", "keep-alive"), ("upgrade", "websocket")])]
+    fn both_shapes_of_the_absence_report_one_entry(#[case] header_pairs: Vec<(&str, &str)>) {
+        let mut tx = make_test_transaction();
+        tx.request.headers = make_headers_from_pairs(header_pairs.as_slice());
+        let violation = run(&tx).expect("a field without its option");
+        assert_eq!(violation.violation, "upgrade_connection_option_missing");
+        assert_eq!(violation.severity, crate::lint::Severity::Warn);
     }
 
     /// The version gate, over the fixture the rule *does* report. Only the version

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -425,7 +425,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 228;
+        const FLOOR: usize = 229;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/upgrade.rs
+++ b/lint-http-rules/src/violations/upgrade.rs
@@ -26,7 +26,17 @@
 //! upgrade mechanism, that it may not switch to something nobody offered —
 //! belongs to [`status`](crate::violations::status).
 //!
-//! **Four entries: the same two defects under each of the two status codes**,
+//! **The fifth entry is not a status code's**, and it is the only one here that
+//! is about a *different* field: a sender that writes `Upgrade` owes the field's
+//! name as a `connection-option` on `Connection`, because that option is the
+//! whole of what makes the field hop-by-hop. It sits in this subject for the
+//! reason the registry family settled — the sentence is written once per field,
+//! § 7.8 for this one and § 10.1.4 for `TE`, so the shape being identical does
+//! not make the requirement shared, and [`te`](crate::violations::te) already
+//! carries its own.
+//!
+//! **Four of the five are the same two defects under each of the two status
+//! codes**,
 //! and the ids say which because the conditions and the sentences both differ.
 //! An entry naming § 15.2.2 and § 15.5.22 together would give up the citation
 //! its findings can carry — 2 sites out of 2 know which status they read — and
@@ -67,7 +77,56 @@ pub const RFC_9110_15_5_22: SpecRef = SpecRef {
     note: "426 Upgrade Required — the server refuses the request under the current protocol, and MUST send an `Upgrade` field to indicate the required protocol(s). RFC 9110 §7.8 states the same MUST from the field's side.",
 };
 
+/// The field's own section, and the sentence that pairs it with `Connection`.
+/// § 7.6.1 states the same obligation for every connection-specific field; this
+/// is where it is written for this one, which is why the entry below can name a
+/// field at all.
+pub const RFC_9110_7_8: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.8"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8",
+    note: "Upgrade — the sender's obligation to name the field as a connection-option \
+           beside it, and the `#protocol` grammar that makes the field's presence the \
+           thing the obligation turns on",
+};
+
 defects! {
+    /// A message carrying `Upgrade` and no `upgrade` connection-option in
+    /// `Connection`. The field applies to the immediate connection; the option
+    /// is what stops an intermediary from relaying it, and § 7.6.1 tells the
+    /// recipient of a relayed one to ignore it — so the upgrade this message
+    /// asks for is lost in both directions rather than merely mis-declared.
+    ///
+    /// **One entry where this catalogue usually writes two.** A `Connection`
+    /// that names other options and a message with no `Connection` at all are
+    /// two shapes and they are one absence: what is missing is the *option*, and
+    /// it is equally missing whichever way the container turned out. **Split
+    /// when the thing that is absent differs, not when what surrounds it does**
+    /// — which is exactly what separates the two pairs above, where a field that
+    /// was never written and a field written blank are two different absences of
+    /// a protocol name. The site keeps both shapes in its message.
+    ///
+    /// **Asked only of the versions that have a `Connection` field**, which is
+    /// the reading of whichever rule reports it and not this entry's: over
+    /// HTTP/2 and HTTP/3 the option cannot be sent at all, so an entry demanding
+    /// it would ask a sender to make its own message malformed.
+    ///
+    /// `warn` rather than `error` despite the MUST, and
+    /// [`te_connection_option_missing`](crate::violations::te) is the sibling
+    /// that ranked it first: nothing about this message is unreadable, and the
+    /// defect is a guard that was not set rather than a statement that is wrong.
+    /// What it risks is a *later* hop being misled, which no recipient of this
+    /// message can detect.
+    ///
+    // cite(RFC 9110 § 7.8): "A sender of Upgrade MUST also send an "Upgrade" connection option in the Connection header field (Section 7.6.1) to inform intermediaries not to forward this field."
+    UPGRADE_CONNECTION_OPTION_MISSING = {
+        id: "upgrade_connection_option_missing",
+        title: "Upgrade is sent with no upgrade connection-option in Connection",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_9110_7_8],
+    }
+
     /// A `101` response with no `Upgrade` field on it at all. The connection
     /// has changed protocol and the message that changed it does not say to
     /// what.

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -6559,7 +6559,7 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 49
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
-      line: 61
+      line: 76
   - label: lint-http-proxy/src/proxy/hop_by_hop.rs (8)
     section: § 7.6.1
     snippet: Intermediaries MUST parse a received Connection header field before a message is forwarded and, for each connection-option in this field, remove any header or trailer field(s) from the message with the same name as the connection-option, and then remove the Connection header field itself (or replace it with the intermediary's own control options for the forwarded message).
@@ -8207,7 +8207,7 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 214
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
-      line: 60
+      line: 75
   - label: range_and_content_range_consistent
     section: § 14.1.2
     snippet: If the representation data has a content coding applied, each byte range is calculated with respect to the encoded sequence of bytes, not the sequence of underlying bytes that would be obtained after decoding.
@@ -8969,9 +8969,9 @@ sources:
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
       line: 137
     - file: lint-http-rules/src/violations/upgrade.rs
-      line: 120
+      line: 179
     - file: lint-http-rules/src/violations/upgrade.rs
-      line: 140
+      line: 199
   - label: status_426_upgrade_valid (3)
     section: § 7.8
     snippet: A server MAY send an Upgrade header field in any other response to advertise that it implements support for upgrading to the listed protocols, in order of descending preference, when appropriate for a future request.
@@ -9211,7 +9211,7 @@ sources:
     - file: lint-http-rules/src/rules/trailer_fields_valid.rs
       line: 260
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
-      line: 42
+      line: 54
   - label: trailer_header_valid
     section: § 6.5.2
     snippet: The "Trailer" header field (Section 6.6.2) can be sent to indicate fields likely to be sent in the trailer section, which allows recipients to prepare for their receipt before processing the content.
@@ -9241,27 +9241,27 @@ sources:
     snippet: The server MUST generate an Upgrade header field in the response that indicates which protocol(s) will be in effect after this response.
     cited_by:
     - file: lint-http-rules/src/violations/upgrade.rs
-      line: 75
+      line: 134
     - file: lint-http-rules/src/violations/upgrade.rs
-      line: 94
+      line: 153
+  - label: upgrade (2)
+    section: § 7.8
+    snippet: A sender of Upgrade MUST also send an "Upgrade" connection option in the Connection header field (Section 7.6.1) to inform intermediaries not to forward this field.
+    cited_by:
+    - file: lint-http-rules/src/violations/upgrade.rs
+      line: 121
   - label: upgrade_and_connection_consistent
     section: § 7.6.1
     snippet: In contrast, a connection-specific field received without a corresponding connection option usually indicates that the field has been improperly forwarded by an intermediary and ought to be ignored by the recipient.
     cited_by:
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
-      line: 94
-  - label: upgrade_and_connection_consistent (2)
-    section: § 7.8
-    snippet: A sender of Upgrade MUST also send an "Upgrade" connection option in the Connection header field (Section 7.6.1) to inform intermediaries not to forward this field.
-    cited_by:
-    - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
-      line: 43
+      line: 109
   - label: Upgrade grammar, sender-expanded
     section: § A
     snippet: Upgrade = [ protocol *( OWS "," OWS protocol ) ]
     cited_by:
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
-      line: 44
+      line: 55
     - file: lint-http-rules/src/rules/upgrade_header_syntax.rs
       line: 200
   - label: upgrade_header_syntax
@@ -10630,7 +10630,7 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 48
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
-      line: 63
+      line: 78
   - label: no_body_for_1xx_204_304
     section: § 8.2.2
     snippet: An endpoint MUST NOT generate an HTTP/2 message containing connection-specific header fields.
@@ -10644,7 +10644,7 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 215
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
-      line: 62
+      line: 77
     - file: lint-http-rules/src/violations/field.rs
       line: 164
   - label: no_connection_specific_fields
@@ -11037,7 +11037,7 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 217
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
-      line: 64
+      line: 79
     - file: lint-http-rules/src/violations/field.rs
       line: 166
 - label: RFC 9218


### PR DESCRIPTION
`upgrade_and_connection_consistent` converts whole: an `Upgrade` sent with no `upgrade` connection-option in `Connection`. The option is the only thing that makes the field hop-by-hop — without it an intermediary relays a field meant for one connection, and §7.6.1 tells whoever receives it forwarded to ignore it, so the upgrade is lost in both directions.

A `connection` subject was written for it and then deleted. The shape is identical for `Upgrade`, `TE` and `Keep-Alive`, but the *sentence* is not: §7.8 states it for this field, §10.1.4 for `TE`, and a 1997 document for `Keep-Alive`. A shared entry would have to cite §7.6.1's general wording for findings whose evidence is a field-specific MUST — the shape the registry family already refused, and the one `te_connection_option_missing` settled first. An identical defect under a different sentence is a different entry.

One entry, where this catalogue usually writes two. A `Connection` naming other options and a message with no `Connection` at all are two shapes of one absence: what is missing is the option, and it is equally missing whichever way the container turned out. Split when the thing that is absent differs, not when what surrounds it does — which is exactly what separates the two status-code pairs in this subject, where a field never written and a field written blank are two different absences of a protocol name.

`warn`, the rank the sibling entry chose: nothing here is unreadable, and what is risked is a later hop being misled, which no recipient of this message can see.

Floor: 229 of 236 entries cite a sentence.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
