### PR TITLE
One option, three rules, one id

### DIFF
--- a/docs/rules/sec_websocket_headers_consistent.md
+++ b/docs/rules/sec_websocket_headers_consistent.md
@@ -34,6 +34,7 @@ Only HTTP/1.x messages are measured. Over HTTP/2 and HTTP/3 the opening handshak
 - [RFC 9110 §5.6.1.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1): The list construct — `1#element => element *( OWS "," OWS element )`, and the sender's MUST NOT against an empty element
 - [RFC 9110 §5.6.1.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.2): The values a `1#element` production does not generate — the empty value among them — beside the recipient's instruction to ignore empty elements
 - [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
+- [RFC 9110 §7.8](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8): Upgrade — the sender's obligation to name the field as a connection-option beside it, and the `#protocol` grammar that makes the field's presence the thing the obligation turns on
 
 ## Configuration
 

--- a/docs/rules/websocket_handshake_valid.md
+++ b/docs/rules/websocket_handshake_valid.md
@@ -34,6 +34,7 @@ Two neighbours own the sentences this rule does not. The obligation to send an `
 - [RFC 8441 §5](https://www.rfc-editor.org/rfc/rfc8441.html#section-5): Updates RFC 6455: over HTTP/2 the handshake is an extended CONNECT, `Connection` and `Upgrade` MUST NOT be included, and `Sec-WebSocket-Accept` is not processed — the sentences behind this rule's version gate
 - [RFC 9220 §3](https://www.rfc-editor.org/rfc/rfc9220.html#section-3): Carries RFC 8441's mechanism to HTTP/3 with identical semantics
 - [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
+- [RFC 9110 §7.8](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8): Upgrade — the sender's obligation to name the field as a connection-option beside it, and the `#protocol` grammar that makes the field's presence the thing the obligation turns on
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
+++ b/lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
@@ -28,6 +28,7 @@ use crate::violations::token::{
     token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
     TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
 };
+use crate::violations::upgrade::{RFC_9110_7_8, UPGRADE_CONNECTION_OPTION_MISSING};
 use crate::violations::ViolationDef;
 
 pub struct SecWebsocketHeadersConsistent;
@@ -54,8 +55,12 @@ pub struct SecWebsocketHeadersConsistent;
 /// [`sec_websocket_protocol`](crate::violations::sec_websocket_protocol)
 /// subject's — the field's own entry beside the productions it is spelled in.
 ///
-/// `Connection` is untouched and says so through its type: an unnamed
-/// [`Defect`] is a finding no subject has claimed.
+/// **`Connection` is the one entry here that RFC 6455 did not have to write.**
+/// The option that keeps `Upgrade` from being forwarded is owed by any sender of
+/// that field, and § 7.8 is where HTTP says so; § 4.1's *MUST include the
+/// "Upgrade" token* is the same requirement restated for this handshake, so the
+/// finding takes [`upgrade`](crate::violations::upgrade)'s entry rather than
+/// spelling a second id for one protocol's copy of it.
 static DECLARED: &[&ViolationDef] = &[
     &BASE64_CHARACTER_FORBIDDEN,
     &BASE64_QUANTUM_MALFORMED,
@@ -67,37 +72,30 @@ static DECLARED: &[&ViolationDef] = &[
     &SEC_WEBSOCKET_VERSION_MISSING,
     &SEC_WEBSOCKET_VERSION_INVALID,
     &SEC_WEBSOCKET_PROTOCOL_DUPLICATED,
+    &UPGRADE_CONNECTION_OPTION_MISSING,
     &LIST_MEMBER_MISSING,
     &LIST_MEMBER_EMPTY,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
     &TOKEN_CHARACTER_FORBIDDEN,
 ];
 
-/// One finding from the reading, and the defect it reports as where the
-/// catalogue names that defect.
+/// One finding from the reading, and the entry it reports as.
 ///
-/// The shape `expect_header_valid` settled and `warning_header_syntax` reused: a
-/// judge that is half converted says so in its type rather than being split in
-/// two. Here the unnamed half is everything this rule reads that is not an
-/// encoding.
+/// The shape `expect_header_valid` settled, carried here while three of the four
+/// judges were still unnamed — **and the `Option` around `def` is gone now that
+/// the fourth has landed**, which is what a rule does when its last arm is
+/// named. What is left unnamed in this rule is not a judge at all: the HTTP
+/// version the handshake was sent over is read before any field is, and it
+/// reports through the pre-catalogue path.
 struct Defect {
-    def: Option<&'static ViolationDef>,
+    def: &'static ViolationDef,
     message: String,
 }
 
 impl Defect {
     /// A defect the catalogue names.
     fn named(def: &'static ViolationDef, message: String) -> Self {
-        Self {
-            def: Some(def),
-            message,
-        }
-    }
-
-    /// A defect no subject has claimed yet, reported at the rule's severity the
-    /// way every finding here was before the catalogue existed.
-    fn unnamed(message: String) -> Self {
-        Self { def: None, message }
+        Self { def, message }
     }
 }
 
@@ -110,22 +108,34 @@ impl SecWebsocketHeadersConsistent {
     /// that a `connection-option` is a field name and therefore compared without
     /// case. The lines are joined before it looks, because `Connection` is one list
     /// however many lines carry it.
+    ///
+    /// **This document restates a requirement HTTP already makes**, and the entry is
+    /// the one HTTP's sentence owns: a sender of `Upgrade` owes the option whatever
+    /// protocol it is upgrading to, so a handshake missing it is not a different
+    /// defect from `Upgrade: h2c` missing it. The two sentences below are what this
+    /// rule reads — the second is the same requirement written from the server's
+    /// side of the same handshake — and `upgrade_and_connection_consistent` reports
+    /// the same entry from the general sentence.
     // cite(RFC 6455 § 4.1): "The request MUST contain a |Connection| header field whose value MUST include the "Upgrade" token."
     // cite(RFC 6455 § 4.2.1): "A |Connection| header field that includes the token "Upgrade", treated as an ASCII case-insensitive value."
-    fn connection_defect(headers: &hyper::HeaderMap) -> Option<String> {
+    fn connection_defect(headers: &hyper::HeaderMap) -> Option<Defect> {
         let Some(value) = combined_field_value_as_written(headers, "connection") else {
-            return Some(
+            return Some(Defect::named(
+                &UPGRADE_CONNECTION_OPTION_MISSING,
                 "the request carries no Connection header field, so it names no connection-option \
                  at all"
                     .into(),
-            );
+            ));
         };
         if is_nominated_by_connection("upgrade", Some(&value)) {
             return None;
         }
-        Some(format!(
-            "its Connection header field is `{}`, which does not include the Upgrade token",
-            shown_in_finding(&value)
+        Some(Defect::named(
+            &UPGRADE_CONNECTION_OPTION_MISSING,
+            format!(
+                "its Connection header field is `{}`, which does not include the Upgrade token",
+                shown_in_finding(&value)
+            ),
         ))
     }
 
@@ -356,6 +366,7 @@ severity = "warn"
             RFC_9110_5_6_1_1,
             RFC_9110_5_6_1_2,
             RFC_9110_5_6_2,
+            RFC_9110_7_8,
         ]
     }
 
@@ -446,7 +457,7 @@ impl Rule for SecWebsocketHeadersConsistent {
             // taking the document's order rather than a convenient one means the finding
             // an operator sees first is the one the list reaches first.
             let defect = [
-                Self::connection_defect(&req.headers).map(Defect::unnamed),
+                Self::connection_defect(&req.headers),
                 Self::key_defect(&req.headers),
                 Self::version_defect(&req.headers),
                 Self::subprotocol_defect(&req.headers),
@@ -455,14 +466,13 @@ impl Rule for SecWebsocketHeadersConsistent {
             .flatten()
             .next()?;
 
-            let message = format!(
-                "This request asks to be upgraded to the WebSocket Protocol, but {}",
-                defect.message
-            );
-            match defect.def {
-                Some(def) => Some(ctx.report_with(def, message)),
-                None => violation(message),
-            }
+            Some(ctx.report_with(
+                defect.def,
+                format!(
+                    "This request asks to be upgraded to the WebSocket Protocol, but {}",
+                    defect.message
+                ),
+            ))
         };
         Vec::from_iter(finding())
     }
@@ -567,6 +577,9 @@ mod tests {
         ]);
         let v = run(&tx).expect("a Connection naming no Upgrade option is a finding");
         assert!(v.message.contains("Upgrade token"));
+        // HTTP's entry, not this document's: the option is owed by any sender of
+        // `Upgrade`, and § 4.1 restates that for one protocol.
+        assert_eq!(v.violation, "upgrade_connection_option_missing");
     }
 
     #[test]

--- a/lint-http-rules/src/rules/websocket_handshake_valid.rs
+++ b/lint-http-rules/src/rules/websocket_handshake_valid.rs
@@ -22,6 +22,7 @@ use crate::violations::token::{
     token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
     TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
 };
+use crate::violations::upgrade::{RFC_9110_7_8, UPGRADE_CONNECTION_OPTION_MISSING};
 use crate::violations::ViolationDef;
 
 /// The server's half of a WebSocket opening handshake, measured against the
@@ -72,9 +73,15 @@ pub struct WebsocketHandshakeValid;
 /// field of the *request*, so nothing holding one message alone can say whether
 /// it is right.
 ///
-/// What is left unnamed is the response's `Upgrade` and `Connection`, and the
-/// `101` that completed a handshake a server was required to refuse. All three
-/// say so through [`Defect`], which is a finding no subject has claimed.
+/// The response's `Connection` takes [`upgrade`](crate::violations::upgrade)'s
+/// entry, because the option a sender of `Upgrade` owes is HTTP's requirement
+/// and § 4.1 only restates it for this handshake — the same reading the rule
+/// measuring the request made, so one id now answers for both halves of the
+/// exchange and for every other protocol an `Upgrade` may name.
+///
+/// What is left unnamed is the response's `Upgrade` value and the `101` that
+/// completed a handshake a server was required to refuse. Both say so through
+/// [`Defect`], which is a finding no subject has claimed.
 static DECLARED: &[&ViolationDef] = &[
     &SEC_WEBSOCKET_ACCEPT_CONFLICTING,
     &SEC_WEBSOCKET_ACCEPT_MISSING,
@@ -83,6 +90,7 @@ static DECLARED: &[&ViolationDef] = &[
     &SEC_WEBSOCKET_PROTOCOL_UNSOLICITED,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
     &TOKEN_CHARACTER_FORBIDDEN,
+    &UPGRADE_CONNECTION_OPTION_MISSING,
 ];
 
 /// One finding from the reading, and the defect it reports as where the
@@ -231,21 +239,31 @@ impl WebsocketHandshakeValid {
     /// case; the sentence here asks for exactly that fold in its own words. The
     /// lines are joined before it looks, because `Connection` is one list however
     /// many of them carry it.
+    /// **The entry is HTTP's and not this document's**, the same reading the rule
+    /// measuring the request took: a sender of `Upgrade` owes the option whatever
+    /// it is upgrading to, § 7.8 is where that is written, and the two sentences
+    /// below restate it for one protocol and one direction. A `101` is a message
+    /// carrying `Upgrade`, so the general sentence reaches it without any help
+    /// from this one.
     // cite(RFC 6455 § 4.1): "If the response lacks a |Connection| header field or the |Connection| header field doesn't contain a token that is an ASCII case-insensitive match for the value "Upgrade", the client MUST _Fail the WebSocket Connection_."
     // cite(RFC 6455 § 4.2.2): "A |Connection| header field with value "Upgrade"."
-    fn connection_defect(resp_headers: &hyper::HeaderMap) -> Option<String> {
+    fn connection_defect(resp_headers: &hyper::HeaderMap) -> Option<Defect> {
         let Some(value) = combined_field_value_as_written(resp_headers, "connection") else {
-            return Some(
+            return Some(Defect::named(
+                &UPGRADE_CONNECTION_OPTION_MISSING,
                 "it carries no Connection header field, so it names no connection-option at all"
                     .into(),
-            );
+            ));
         };
         if is_nominated_by_connection("upgrade", Some(&value)) {
             return None;
         }
-        Some(format!(
-            "its Connection header field is `{}`, which does not include the Upgrade token",
-            shown_in_finding(&value)
+        Some(Defect::named(
+            &UPGRADE_CONNECTION_OPTION_MISSING,
+            format!(
+                "its Connection header field is `{}`, which does not include the Upgrade token",
+                shown_in_finding(&value)
+            ),
         ))
     }
 
@@ -531,6 +549,7 @@ severity = "warn"
             RFC_8441_5,
             RFC_9220_3,
             RFC_9110_5_6_2,
+            RFC_9110_7_8,
         ]
     }
 
@@ -624,7 +643,7 @@ impl Rule for WebsocketHandshakeValid {
             let defect = [
                 Self::refusable_handshake(&req.headers).map(Defect::unnamed),
                 Self::upgrade_defect(&resp.headers).map(Defect::unnamed),
-                Self::connection_defect(&resp.headers).map(Defect::unnamed),
+                Self::connection_defect(&resp.headers),
                 Self::accept_defect(&req.headers, &resp.headers),
                 Self::extensions_defect(&req.headers, &resp.headers),
                 Self::subprotocol_defect(&req.headers, &resp.headers),
@@ -839,6 +858,10 @@ mod tests {
         }
     }
 
+    /// Both shapes of the missing option report one entry, and it is the one HTTP
+    /// owns — the same id `upgrade_and_connection_consistent` reports about the
+    /// same message from the general sentence, and the same one the request's half
+    /// of this handshake reports about the other message.
     #[rstest]
     fn the_response_connection_is_required() {
         let tx = make_ws_tx(
@@ -846,10 +869,23 @@ mod tests {
             101,
             vec![("upgrade", "websocket"), ("sec-websocket-accept", ACCEPT)],
         );
-        assert!(run(&tx)
-            .unwrap()
-            .message
-            .contains("carries no Connection header field"));
+        let found = run(&tx).unwrap();
+        assert!(found.message.contains("carries no Connection header field"));
+        assert_eq!(found.violation, "upgrade_connection_option_missing");
+
+        let tx = make_ws_tx(
+            handshake_request(),
+            101,
+            vec![
+                ("upgrade", "websocket"),
+                ("connection", "keep-alive"),
+                ("sec-websocket-accept", ACCEPT),
+            ],
+        );
+        assert_eq!(
+            run(&tx).unwrap().violation,
+            "upgrade_connection_option_missing"
+        );
     }
 
     /// A `Connection` value holding an `obs-text` octet is a value, and the finding

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -2505,7 +2505,7 @@ sources:
     - file: lint-http-proxy/src/proxy/websocket/mod.rs
       line: 73
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 329
+      line: 347
   - label: lint-http-proxy/src/proxy/websocket/frame.rs
     section: § 5.2
     snippet: '%x3-7 are reserved for further non-control frames'
@@ -2559,7 +2559,7 @@ sources:
     - file: lint-http-proxy/src/proxy/websocket/mod.rs
       line: 38
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 113
+      line: 119
   - label: lint-http-proxy/src/proxy/websocket/mod.rs (2)
     section: § 4.1
     snippet: The request MUST contain an |Upgrade| header field whose value MUST include the "websocket" keyword.
@@ -2683,7 +2683,7 @@ sources:
     - file: lint-http-rules/src/rules/sec_websocket_extensions_syntax.rs
       line: 123
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 331
+      line: 349
   - label: sec_websocket_extensions_syntax (3)
     section: § 9.1
     snippet: If a value is received by either the client or the server during negotiation that does not conform to the ABNF below, the recipient of such malformed data MUST immediately _Fail the WebSocket Connection_.
@@ -2709,13 +2709,13 @@ sources:
     snippet: The ABNF for the value of this header field is 1#token, where the definitions of constructs and rules are as given in [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 229
+      line: 239
   - label: sec_websocket_headers_consistent (2)
     section: § 4.1
     snippet: The elements that comprise this value MUST be non-empty strings with characters in the range U+0021 to U+007E not including separator characters as defined in [RFC2616] and MUST all be unique strings.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 228
+      line: 238
     - file: lint-http-rules/src/violations/sec_websocket_protocol.rs
       line: 69
   - label: sec_websocket_headers_consistent (3)
@@ -2723,7 +2723,7 @@ sources:
     snippet: The request MUST include a header field with the name |Sec-WebSocket-Key|.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 199
+      line: 209
     - file: lint-http-rules/src/violations/sec_websocket_key.rs
       line: 63
   - label: sec_websocket_headers_consistent (4)
@@ -2731,7 +2731,7 @@ sources:
     snippet: The request MUST include a header field with the name |Sec-WebSocket-Version|.  The value of this header field MUST be 13.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 137
+      line: 147
     - file: lint-http-rules/src/violations/sec_websocket_version.rs
       line: 119
     - file: lint-http-rules/src/violations/sec_websocket_version.rs
@@ -2741,33 +2741,33 @@ sources:
     snippet: A |Connection| header field that includes the token "Upgrade", treated as an ASCII case-insensitive value.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 114
+      line: 120
   - label: sec_websocket_headers_consistent (6)
     section: § 4.2.1
     snippet: An HTTP/1.1 or higher GET request
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 434
+      line: 445
   - label: sec_websocket_headers_consistent (7)
     section: § 4.2.1
     snippet: the server MUST stop processing the client's handshake and return an HTTP response with an appropriate error code (such as 400 Bad Request)
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 435
+      line: 446
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 139
+      line: 147
   - label: Sec-WebSocket-Protocol-Client
     section: § 4.3
     snippet: Sec-WebSocket-Protocol-Client = 1#token
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 234
+      line: 244
   - label: Sec-WebSocket-Version-Server
     section: § 4.3
     snippet: Sec-WebSocket-Version-Server = 1#version
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 145
+      line: 155
     - file: lint-http-rules/src/rules/sec_websocket_version_advertised.rs
       line: 78
   - label: sec_websocket_headers_consistent (8)
@@ -2775,7 +2775,7 @@ sources:
     snippet: If the server doesn't support the requested version, it MUST respond with a |Sec-WebSocket-Version| header field (or multiple |Sec-WebSocket-Version| header fields) containing all versions it is willing to use.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 176
+      line: 186
     - file: lint-http-rules/src/rules/sec_websocket_version_advertised.rs
       line: 79
   - label: sec_websocket_headers_consistent (9)
@@ -2783,7 +2783,7 @@ sources:
     snippet: a client can initially request the version of the WebSocket Protocol that it prefers (which doesn't necessarily have to be the latest supported by the client)
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 175
+      line: 185
   - label: sec_websocket_key
     section: § 4.1
     snippet: The value of this header field MUST be a nonce consisting of a randomly selected 16-byte value that has been base64-encoded (see Section 4 of [RFC4648]).
@@ -2969,79 +2969,79 @@ sources:
     snippet: If the response includes a |Sec-WebSocket-Extensions| header field and this header field indicates the use of an extension that was not present in the client's handshake (the server has indicated an extension not requested by the client), the client MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 328
+      line: 346
   - label: websocket_handshake_valid (2)
     section: § 4.1
     snippet: If the response includes a |Sec-WebSocket-Protocol| header field and this header field indicates the use of a subprotocol that was not present in the client's handshake (the server has indicated a subprotocol not requested by the client), the client MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 380
+      line: 398
   - label: websocket_handshake_valid (3)
     section: § 4.1
     snippet: If the response lacks a |Connection| header field or the |Connection| header field doesn't contain a token that is an ASCII case-insensitive match for the value "Upgrade", the client MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 234
+      line: 248
   - label: websocket_handshake_valid (4)
     section: § 4.1
     snippet: If the response lacks a |Sec-WebSocket-Accept| header field or the |Sec-WebSocket-Accept| contains a value other than the base64-encoded SHA-1 of the concatenation of the |Sec-WebSocket-Key| (as a string, not base64-decoded) with the string "258EAFA5-E914-47DA-95CA-C5AB0DC85B11" but ignoring any leading and trailing whitespace, the client MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 269
+      line: 287
   - label: websocket_handshake_valid (5)
     section: § 4.1
     snippet: If the response lacks an |Upgrade| header field or the |Upgrade| header field contains a value that is not an ASCII case-insensitive match for the value "websocket", the client MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 199
+      line: 207
   - label: websocket_handshake_valid (6)
     section: § 4.1
     snippet: If the status code received from the server is not 101, the client handles the response per HTTP [RFC2616] procedures.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 604
+      line: 623
   - label: websocket_handshake_valid (7)
     section: § 4.1
     snippet: In particular, the client might perform authentication if it receives a 401 status code; the server might redirect the client using a 3xx status code (but clients are not required to follow them), etc.  Otherwise, proceed as follows.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 605
+      line: 624
   - label: websocket_handshake_valid (8)
     section: § 4.2.1
     snippet: A |Sec-WebSocket-Key| header field with a base64-encoded (see Section 4 of [RFC4648]) value that, when decoded, is 16 bytes in length.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 141
+      line: 149
   - label: websocket_handshake_valid (9)
     section: § 4.2.1
     snippet: A |Sec-WebSocket-Version| header field, with a value of 13.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 142
+      line: 150
   - label: websocket_handshake_valid (10)
     section: § 4.2.1
     snippet: including but not limited to any violations of the ABNF grammar specified for the components of the handshake
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 140
+      line: 148
   - label: websocket_handshake_valid (11)
     section: § 4.2.2
     snippet: A Status-Line with a 101 response code as per RFC 2616 [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 611
+      line: 630
   - label: websocket_handshake_valid (12)
     section: § 4.2.2
     snippet: A |Connection| header field with value "Upgrade".
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 235
+      line: 249
   - label: websocket_handshake_valid (13)
     section: § 4.2.2
     snippet: A |Sec-WebSocket-Accept| header field.  The value of this header field is constructed by concatenating /key/, defined above in step 4 in Section 4.2.2, with the string "258EAFA5-E914-47DA-95CA-C5AB0DC85B11", taking the SHA-1 hash of this concatenated value to obtain a 20-byte value and base64-encoding (see Section 4 of [RFC4648]) this 20-byte hash.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 270
+      line: 288
     - file: lint-http-rules/src/violations/sec_websocket_accept.rs
       line: 51
     - file: lint-http-rules/src/violations/sec_websocket_accept.rs
@@ -3051,67 +3051,67 @@ sources:
     snippet: An |Upgrade| header field with value "websocket" as per RFC 2616 [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 200
+      line: 208
   - label: websocket_handshake_valid (15)
     section: § 4.2.2
     snippet: If the requested service is not available, the server MUST send an appropriate HTTP error code (such as 404 Not Found) and abort the WebSocket handshake.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 610
+      line: 629
   - label: websocket_handshake_valid (16)
     section: § 4.2.2
     snippet: If the server chooses to accept the incoming connection, it MUST reply with a valid HTTP response indicating the following.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 606
+      line: 625
   - label: websocket_handshake_valid (17)
     section: § 4.2.2
     snippet: If the server does not wish to accept this connection, it MUST return an appropriate HTTP error code (e.g., 403 Forbidden) and abort the WebSocket handshake described in this section.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 609
+      line: 628
   - label: websocket_handshake_valid (18)
     section: § 4.2.2
     snippet: If this version does not match a version understood by the server, the server MUST abort the WebSocket handshake described in this section and instead send an appropriate HTTP error code (such as 426 Upgrade Required) and a |Sec-WebSocket-Version| header field indicating the version(s) the server is capable of understanding.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 143
+      line: 151
   - label: websocket_handshake_valid (19)
     section: § 4.2.2
     snippet: The server MAY redirect the client using a 3xx status code [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 608
+      line: 627
   - label: websocket_handshake_valid (20)
     section: § 4.2.2
     snippet: The server can perform additional client authentication, for example, by returning a 401 status code with the corresponding |WWW-Authenticate| header field as described in [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 607
+      line: 626
   - label: websocket_handshake_valid (21)
     section: § 4.2.2
     snippet: if the server does not wish to agree to one of the suggested subprotocols, it MUST NOT send back a |Sec-WebSocket-Protocol| header field in its response
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 381
+      line: 399
   - label: Sec-WebSocket-Protocol-Server
     section: § 4.3
     snippet: Sec-WebSocket-Protocol-Server = token
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 382
+      line: 400
   - label: extension
     section: § 4.3
     snippet: extension = extension-token *( ";" extension-param )
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 450
+      line: 468
   - label: websocket_handshake_valid (22)
     section: § 9.1
     snippet: any extension parameters, and what constitutes a valid response by a server to a requested set of parameters by a client, will be defined by each such extension.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 330
+      line: 348
 - label: RFC 6585
   url: https://www.rfc-editor.org/rfc/rfc6585.html
   fragments:
@@ -6665,7 +6665,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 324
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 242
+      line: 252
   - label: lint-http-rules/src/helpers/auth.rs
     section: § 11.1
     snippet: It uses a case-insensitive token to identify the authentication scheme
@@ -7629,7 +7629,7 @@ sources:
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
       line: 197
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 235
+      line: 245
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 506
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs


### PR DESCRIPTION
Both websocket rules take `upgrade_connection_option_missing` for their `Connection` readings — the request's half and the response's — and with the general rule already reporting it, one message can now name the same id from three rules instead of three wordings of one absence.

RFC 6455 §4.1 asks the request for a `Connection` whose value includes the `Upgrade` token, and §4.2.2 asks the same of the `101` that answers it. Neither is a requirement HTTP was not already making: a sender of `Upgrade` owes the option whatever protocol it names, and a handshake missing it is not a different defect from `Upgrade: h2c` missing it. A restatement earns no id of its own.

`sec_websocket_headers_consistent`'s last judge lands with it, so its `Defect` drops the `Option` around the entry — the shape a rule sheds when its last arm is named. What is still unnamed there is not a judge at all: the HTTP version the handshake was sent over is read before any field is.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
