### PR TITLE
Which protocol a handoff may name

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1923,6 +1923,10 @@ severity = "info"
 # A 101 response names no protocol on its Upgrade field
 severity = "error"
 
+[violations.upgrade_101_invalid]
+# A 101 response names a protocol its handshake does not permit
+severity = "error"
+
 [violations.upgrade_101_missing]
 # A 101 response carries no Upgrade field
 severity = "error"

--- a/docs/rules/websocket_handshake_valid.md
+++ b/docs/rules/websocket_handshake_valid.md
@@ -35,6 +35,7 @@ Two neighbours own the sentences this rule does not. The obligation to send an `
 - [RFC 9220 §3](https://www.rfc-editor.org/rfc/rfc9220.html#section-3): Carries RFC 8441's mechanism to HTTP/3 with identical semantics
 - [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 - [RFC 9110 §7.8](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8): Upgrade — the sender's obligation to name the field as a connection-option beside it, and the `#protocol` grammar that makes the field's presence the thing the obligation turns on
+- [RFC 9110 §15.2.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.2.2): 101 Switching Protocols — the status code is a change in the application protocol being used on this connection, and the response MUST generate an `Upgrade` field naming the protocol(s) in effect after it
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/websocket_handshake_valid.rs
+++ b/lint-http-rules/src/rules/websocket_handshake_valid.rs
@@ -22,7 +22,10 @@ use crate::violations::token::{
     token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
     TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
 };
-use crate::violations::upgrade::{RFC_9110_7_8, UPGRADE_CONNECTION_OPTION_MISSING};
+use crate::violations::upgrade::{
+    RFC_9110_15_2_2, RFC_9110_7_8, UPGRADE_101_EMPTY, UPGRADE_101_INVALID, UPGRADE_101_MISSING,
+    UPGRADE_CONNECTION_OPTION_MISSING,
+};
 use crate::violations::ViolationDef;
 
 /// The server's half of a WebSocket opening handshake, measured against the
@@ -79,9 +82,16 @@ pub struct WebsocketHandshakeValid;
 /// measuring the request made, so one id now answers for both halves of the
 /// exchange and for every other protocol an `Upgrade` may name.
 ///
-/// What is left unnamed is the response's `Upgrade` value and the `101` that
-/// completed a handshake a server was required to refuse. Both say so through
-/// [`Defect`], which is a finding no subject has claimed.
+/// The response's `Upgrade` splits three ways and only one of them is this
+/// document's. A `101` with no field, and one naming no protocol, are what
+/// § 15.2.2 asks of *every* `101` — [`upgrade`](crate::violations::upgrade)'s
+/// pair, reported here from a second rule — while a field naming anything
+/// besides `websocket` is § 4.2.2's ceiling on the value, which HTTP does not
+/// set.
+///
+/// What is left unnamed is the `101` that completed a handshake a server was
+/// required to refuse, which says so through [`Defect`] — a finding no subject
+/// has claimed.
 static DECLARED: &[&ViolationDef] = &[
     &SEC_WEBSOCKET_ACCEPT_CONFLICTING,
     &SEC_WEBSOCKET_ACCEPT_MISSING,
@@ -90,6 +100,9 @@ static DECLARED: &[&ViolationDef] = &[
     &SEC_WEBSOCKET_PROTOCOL_UNSOLICITED,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
     &TOKEN_CHARACTER_FORBIDDEN,
+    &UPGRADE_101_EMPTY,
+    &UPGRADE_101_INVALID,
+    &UPGRADE_101_MISSING,
     &UPGRADE_CONNECTION_OPTION_MISSING,
 ];
 
@@ -206,15 +219,21 @@ impl WebsocketHandshakeValid {
     /// `status_101_switching_protocols`'.
     // cite(RFC 6455 § 4.1): "If the response lacks an |Upgrade| header field or the |Upgrade| header field contains a value that is not an ASCII case-insensitive match for the value "websocket", the client MUST _Fail the WebSocket Connection_."
     // cite(RFC 6455 § 4.2.2): "An |Upgrade| header field with value "websocket" as per RFC 2616 [RFC2616]."
-    fn upgrade_defect(resp_headers: &hyper::HeaderMap) -> Option<String> {
+    fn upgrade_defect(resp_headers: &hyper::HeaderMap) -> Option<Defect> {
         let Some(raw) = combined_field_value_as_written(resp_headers, "upgrade") else {
-            return Some("it carries no Upgrade header field".into());
+            return Some(Defect::named(
+                &UPGRADE_101_MISSING,
+                "it carries no Upgrade header field".into(),
+            ));
         };
         if let Some(other) = list_members(&raw).find(|m| !m.eq_ignore_ascii_case("websocket")) {
-            return Some(format!(
-                "its Upgrade header field names `{}`, and the only protocol this response's \
-                 Upgrade may name is `websocket`",
-                shown_in_finding(other)
+            return Some(Defect::named(
+                &UPGRADE_101_INVALID,
+                format!(
+                    "its Upgrade header field names `{}`, and the only protocol this response's \
+                     Upgrade may name is `websocket`",
+                    shown_in_finding(other)
+                ),
             ));
         }
         // A field that is present and names nothing is the first clause's case
@@ -222,10 +241,13 @@ impl WebsocketHandshakeValid {
         // neighbour reports the same message as a 101 whose `Upgrade` indicates no
         // protocol, from RFC 9110's side of it.
         if list_members(&raw).next().is_none() {
-            return Some(format!(
-                "its Upgrade header field is `{}`, which names no protocol at all where this \
-                 response's Upgrade is defined with the value `websocket`",
-                shown_in_finding(trim_ows(&raw))
+            return Some(Defect::named(
+                &UPGRADE_101_EMPTY,
+                format!(
+                    "its Upgrade header field is `{}`, which names no protocol at all where this \
+                     response's Upgrade is defined with the value `websocket`",
+                    shown_in_finding(trim_ows(&raw))
+                ),
             ));
         }
         None
@@ -550,6 +572,7 @@ severity = "warn"
             RFC_9220_3,
             RFC_9110_5_6_2,
             RFC_9110_7_8,
+            RFC_9110_15_2_2,
         ]
     }
 
@@ -642,7 +665,7 @@ impl Rule for WebsocketHandshakeValid {
             // one finding, so the first defect is the one reported.
             let defect = [
                 Self::refusable_handshake(&req.headers).map(Defect::unnamed),
-                Self::upgrade_defect(&resp.headers).map(Defect::unnamed),
+                Self::upgrade_defect(&resp.headers),
                 Self::connection_defect(&resp.headers),
                 Self::accept_defect(&req.headers, &resp.headers),
                 Self::extensions_defect(&req.headers, &resp.headers),
@@ -782,13 +805,13 @@ mod tests {
     #[case("WebSocket", None)]
     #[case("  websocket\t", None)]
     #[case("websocket, websocket", None)]
-    #[case("notwebsocket", Some("names `notwebsocket`"))]
-    #[case("websocket, h2c", Some("names `h2c`"))]
-    #[case("", Some("names no protocol at all"))]
-    #[case("  ,  ", Some("names no protocol at all"))]
+    #[case("notwebsocket", Some(("names `notwebsocket`", "upgrade_101_invalid")))]
+    #[case("websocket, h2c", Some(("names `h2c`", "upgrade_101_invalid")))]
+    #[case("", Some(("names no protocol at all", "upgrade_101_empty")))]
+    #[case("  ,  ", Some(("names no protocol at all", "upgrade_101_empty")))]
     fn the_response_upgrade_names_websocket_and_nothing_else(
         #[case] value: &str,
-        #[case] expected: Option<&str>,
+        #[case] expected: Option<(&str, &str)>,
     ) {
         let tx = make_ws_tx(
             handshake_request(),
@@ -801,7 +824,13 @@ mod tests {
         );
         match expected {
             None => assert!(run(&tx).is_none(), "{value}"),
-            Some(text) => assert!(run(&tx).unwrap().message.contains(text), "{value}"),
+            Some((text, id)) => {
+                let found = run(&tx).unwrap();
+                assert!(found.message.contains(text), "{value}");
+                // The emptiness is every `101`'s and the wrong name is this
+                // handshake's, which is the whole of why they are two entries.
+                assert_eq!(found.violation, id, "{value}");
+            }
         }
     }
 
@@ -829,10 +858,9 @@ mod tests {
             101,
             vec![("connection", "Upgrade"), ("sec-websocket-accept", ACCEPT)],
         );
-        assert!(run(&tx)
-            .unwrap()
-            .message
-            .contains("carries no Upgrade header field"));
+        let found = run(&tx).unwrap();
+        assert!(found.message.contains("carries no Upgrade header field"));
+        assert_eq!(found.violation, "upgrade_101_missing");
     }
 
     /// `Connection` is a list, and it is one list however many field lines carry
@@ -1103,11 +1131,18 @@ mod tests {
         let tx = make_ws_tx(req, 101, resp);
         assert_eq!(run(&tx).unwrap().severity, crate::lint::Severity::Error);
 
-        // The `Upgrade` reading, which no subject has claimed.
+        // The one reading left that no subject has claimed: a `101` completing a
+        // handshake whose key is not a nonce, which is about the exchange rather
+        // than about any field's value.
         let tx = make_ws_tx(
-            handshake_request(),
+            vec![
+                ("upgrade", "websocket"),
+                ("connection", "Upgrade"),
+                ("sec-websocket-key", "dG9vLXNob3J0"),
+                ("sec-websocket-version", "13"),
+            ],
             101,
-            vec![("connection", "Upgrade"), ("sec-websocket-accept", ACCEPT)],
+            vec![("upgrade", "websocket"), ("connection", "Upgrade")],
         );
         let found = run(&tx).unwrap();
         assert_eq!(found.severity, crate::lint::Severity::Warn);

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -425,7 +425,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 229;
+        const FLOOR: usize = 230;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/upgrade.rs
+++ b/lint-http-rules/src/violations/upgrade.rs
@@ -35,7 +35,14 @@
 //! not make the requirement shared, and [`te`](crate::violations::te) already
 //! carries its own.
 //!
-//! **Four of the five are the same two defects under each of the two status
+//! **A sixth entry is the only one about a value.** The two `101` entries below
+//! ask whether a protocol was named at all; RFC 6455 asks *which*, because a
+//! WebSocket handshake's response carries the field with the value `websocket`
+//! and nothing beside it. HTTP sets no such ceiling — § 15.2.2's field names
+//! *which protocol(s) will be in effect* — so an entry about the value can only
+//! come from the protocol the handshake belongs to.
+//!
+//! **Four of the six are the same two defects under each of the two status
 //! codes**,
 //! and the ids say which because the conditions and the sentences both differ.
 //! An entry naming § 15.2.2 and § 15.5.22 together would give up the citation
@@ -52,6 +59,10 @@
 use crate::lint::Severity;
 use crate::rules::SpecRef;
 use crate::violations::defects;
+// The section a server's half of a WebSocket handshake is written from, defined
+// where its first entry landed and named here for the one entry of this subject
+// that is not HTTP's own requirement.
+use crate::violations::sec_websocket_protocol::RFC_6455_4_2_2;
 
 /// The status code's section: what the code indicates, and the requirement on
 /// the field written into the same paragraph. Shared with
@@ -157,6 +168,42 @@ defects! {
         message: "",
         default_severity: Severity::Error,
         spec: &[RFC_9110_15_2_2],
+    }
+
+    /// A `101` whose `Upgrade` names a protocol the exchange it completes does
+    /// not permit there.
+    ///
+    /// **The third thing that can be wrong with a `101`'s `Upgrade`, and the
+    /// only one about the value rather than its presence.** The two entries
+    /// above are read from § 15.2.2 alone and apply to every `101`; this one
+    /// takes a second sentence from whichever protocol the handshake belongs
+    /// to, because HTTP itself sets no ceiling — `Upgrade` names *which
+    /// protocol(s) will be in effect*, and several is a value § 15.2.2 admits.
+    /// RFC 6455 does set one: a WebSocket handshake's response carries the field
+    /// *with value "websocket"*, so a member beside it is a protocol this
+    /// connection cannot be speaking.
+    ///
+    /// Not [`STATUS_101_PROTOCOL_FORBIDDEN`](crate::violations::status), which
+    /// is § 7.8's MUST NOT about switching to something the *client* never
+    /// indicated. A client that offered `websocket, h2c` indicated both, so that
+    /// entry is silent on a response naming both — and this one is not, because
+    /// what the handshake permits is not a matter of what was offered.
+    ///
+    /// `_invalid` and not `_forbidden`: the value derives from `#protocol` and
+    /// every member is a protocol name, and what it fails is a requirement past
+    /// the grammar about which name may appear.
+    ///
+    /// `error`, with the `101` pair above and for their reason: the connection
+    /// has been handed over, so there is no later message in which a client that
+    /// cannot tell what it is now speaking can ask.
+    ///
+    // cite(RFC 6455 § 4.2.2): "An |Upgrade| header field with value "websocket" as per RFC 2616 [RFC2616]."
+    UPGRADE_101_INVALID = {
+        id: "upgrade_101_invalid",
+        title: "A 101 response names a protocol its handshake does not permit",
+        message: "",
+        default_severity: Severity::Error,
+        spec: &[RFC_6455_4_2_2],
     }
 
     /// A `426` response with no `Upgrade` field on it at all. The status code

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -2505,7 +2505,7 @@ sources:
     - file: lint-http-proxy/src/proxy/websocket/mod.rs
       line: 73
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 347
+      line: 369
   - label: lint-http-proxy/src/proxy/websocket/frame.rs
     section: § 5.2
     snippet: '%x3-7 are reserved for further non-control frames'
@@ -2683,7 +2683,7 @@ sources:
     - file: lint-http-rules/src/rules/sec_websocket_extensions_syntax.rs
       line: 123
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 349
+      line: 371
   - label: sec_websocket_extensions_syntax (3)
     section: § 9.1
     snippet: If a value is received by either the client or the server during negotiation that does not conform to the ABNF below, the recipient of such malformed data MUST immediately _Fail the WebSocket Connection_.
@@ -2755,7 +2755,7 @@ sources:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
       line: 446
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 147
+      line: 160
   - label: Sec-WebSocket-Protocol-Client
     section: § 4.3
     snippet: Sec-WebSocket-Protocol-Client = 1#token
@@ -2969,79 +2969,79 @@ sources:
     snippet: If the response includes a |Sec-WebSocket-Extensions| header field and this header field indicates the use of an extension that was not present in the client's handshake (the server has indicated an extension not requested by the client), the client MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 346
+      line: 368
   - label: websocket_handshake_valid (2)
     section: § 4.1
     snippet: If the response includes a |Sec-WebSocket-Protocol| header field and this header field indicates the use of a subprotocol that was not present in the client's handshake (the server has indicated a subprotocol not requested by the client), the client MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 398
+      line: 420
   - label: websocket_handshake_valid (3)
     section: § 4.1
     snippet: If the response lacks a |Connection| header field or the |Connection| header field doesn't contain a token that is an ASCII case-insensitive match for the value "Upgrade", the client MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 248
+      line: 270
   - label: websocket_handshake_valid (4)
     section: § 4.1
     snippet: If the response lacks a |Sec-WebSocket-Accept| header field or the |Sec-WebSocket-Accept| contains a value other than the base64-encoded SHA-1 of the concatenation of the |Sec-WebSocket-Key| (as a string, not base64-decoded) with the string "258EAFA5-E914-47DA-95CA-C5AB0DC85B11" but ignoring any leading and trailing whitespace, the client MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 287
+      line: 309
   - label: websocket_handshake_valid (5)
     section: § 4.1
     snippet: If the response lacks an |Upgrade| header field or the |Upgrade| header field contains a value that is not an ASCII case-insensitive match for the value "websocket", the client MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 207
+      line: 220
   - label: websocket_handshake_valid (6)
     section: § 4.1
     snippet: If the status code received from the server is not 101, the client handles the response per HTTP [RFC2616] procedures.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 623
+      line: 646
   - label: websocket_handshake_valid (7)
     section: § 4.1
     snippet: In particular, the client might perform authentication if it receives a 401 status code; the server might redirect the client using a 3xx status code (but clients are not required to follow them), etc.  Otherwise, proceed as follows.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 624
+      line: 647
   - label: websocket_handshake_valid (8)
     section: § 4.2.1
     snippet: A |Sec-WebSocket-Key| header field with a base64-encoded (see Section 4 of [RFC4648]) value that, when decoded, is 16 bytes in length.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 149
+      line: 162
   - label: websocket_handshake_valid (9)
     section: § 4.2.1
     snippet: A |Sec-WebSocket-Version| header field, with a value of 13.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 150
+      line: 163
   - label: websocket_handshake_valid (10)
     section: § 4.2.1
     snippet: including but not limited to any violations of the ABNF grammar specified for the components of the handshake
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 148
+      line: 161
   - label: websocket_handshake_valid (11)
     section: § 4.2.2
     snippet: A Status-Line with a 101 response code as per RFC 2616 [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 630
+      line: 653
   - label: websocket_handshake_valid (12)
     section: § 4.2.2
     snippet: A |Connection| header field with value "Upgrade".
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 249
+      line: 271
   - label: websocket_handshake_valid (13)
     section: § 4.2.2
     snippet: A |Sec-WebSocket-Accept| header field.  The value of this header field is constructed by concatenating /key/, defined above in step 4 in Section 4.2.2, with the string "258EAFA5-E914-47DA-95CA-C5AB0DC85B11", taking the SHA-1 hash of this concatenated value to obtain a 20-byte value and base64-encoding (see Section 4 of [RFC4648]) this 20-byte hash.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 288
+      line: 310
     - file: lint-http-rules/src/violations/sec_websocket_accept.rs
       line: 51
     - file: lint-http-rules/src/violations/sec_websocket_accept.rs
@@ -3051,67 +3051,69 @@ sources:
     snippet: An |Upgrade| header field with value "websocket" as per RFC 2616 [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 208
+      line: 221
+    - file: lint-http-rules/src/violations/upgrade.rs
+      line: 200
   - label: websocket_handshake_valid (15)
     section: § 4.2.2
     snippet: If the requested service is not available, the server MUST send an appropriate HTTP error code (such as 404 Not Found) and abort the WebSocket handshake.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 629
+      line: 652
   - label: websocket_handshake_valid (16)
     section: § 4.2.2
     snippet: If the server chooses to accept the incoming connection, it MUST reply with a valid HTTP response indicating the following.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 625
+      line: 648
   - label: websocket_handshake_valid (17)
     section: § 4.2.2
     snippet: If the server does not wish to accept this connection, it MUST return an appropriate HTTP error code (e.g., 403 Forbidden) and abort the WebSocket handshake described in this section.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 628
+      line: 651
   - label: websocket_handshake_valid (18)
     section: § 4.2.2
     snippet: If this version does not match a version understood by the server, the server MUST abort the WebSocket handshake described in this section and instead send an appropriate HTTP error code (such as 426 Upgrade Required) and a |Sec-WebSocket-Version| header field indicating the version(s) the server is capable of understanding.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 151
+      line: 164
   - label: websocket_handshake_valid (19)
     section: § 4.2.2
     snippet: The server MAY redirect the client using a 3xx status code [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 627
+      line: 650
   - label: websocket_handshake_valid (20)
     section: § 4.2.2
     snippet: The server can perform additional client authentication, for example, by returning a 401 status code with the corresponding |WWW-Authenticate| header field as described in [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 626
+      line: 649
   - label: websocket_handshake_valid (21)
     section: § 4.2.2
     snippet: if the server does not wish to agree to one of the suggested subprotocols, it MUST NOT send back a |Sec-WebSocket-Protocol| header field in its response
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 399
+      line: 421
   - label: Sec-WebSocket-Protocol-Server
     section: § 4.3
     snippet: Sec-WebSocket-Protocol-Server = token
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 400
+      line: 422
   - label: extension
     section: § 4.3
     snippet: extension = extension-token *( ";" extension-param )
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 468
+      line: 490
   - label: websocket_handshake_valid (22)
     section: § 9.1
     snippet: any extension parameters, and what constitutes a valid response by a server to a requested set of parameters by a client, will be defined by each such extension.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 348
+      line: 370
 - label: RFC 6585
   url: https://www.rfc-editor.org/rfc/rfc6585.html
   fragments:
@@ -8969,9 +8971,9 @@ sources:
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
       line: 137
     - file: lint-http-rules/src/violations/upgrade.rs
-      line: 179
+      line: 226
     - file: lint-http-rules/src/violations/upgrade.rs
-      line: 199
+      line: 246
   - label: status_426_upgrade_valid (3)
     section: § 7.8
     snippet: A server MAY send an Upgrade header field in any other response to advertise that it implements support for upgrading to the listed protocols, in order of descending preference, when appropriate for a future request.
@@ -9241,15 +9243,15 @@ sources:
     snippet: The server MUST generate an Upgrade header field in the response that indicates which protocol(s) will be in effect after this response.
     cited_by:
     - file: lint-http-rules/src/violations/upgrade.rs
-      line: 134
+      line: 145
     - file: lint-http-rules/src/violations/upgrade.rs
-      line: 153
+      line: 164
   - label: upgrade (2)
     section: § 7.8
     snippet: A sender of Upgrade MUST also send an "Upgrade" connection option in the Connection header field (Section 7.6.1) to inform intermediaries not to forward this field.
     cited_by:
     - file: lint-http-rules/src/violations/upgrade.rs
-      line: 121
+      line: 132
   - label: upgrade_and_connection_consistent
     section: § 7.6.1
     snippet: In contrast, a connection-specific field received without a corresponding connection option usually indicates that the field has been improperly forwarded by an intermediary and ought to be ignored by the recipient.


### PR DESCRIPTION
The `101`'s `Upgrade` splits three ways, and two of them were already written. A response with no field, and one naming no protocol at all, are what RFC 9110 §15.2.2 asks of *every* `101` — so `websocket_handshake_valid` reports `upgrade_101_missing` and `upgrade_101_empty` as their second declarer, with the messages it had.

The third is new, and it is the only entry in this subject about a value. HTTP sets no ceiling: the field names *which protocol(s) will be in effect*, and several is a value §15.2.2 admits. RFC 6455 §4.2.2 does set one — the response carries the field with value `websocket` — so a member beside it is a protocol this connection cannot be speaking, and an entry about *which* name may appear can only come from the protocol the handshake belongs to.

Not `status_101_protocol_forbidden`, which is §7.8's MUST NOT about switching to something the client never indicated: a client that offered `websocket, h2c` indicated both, and what the handshake permits is not a matter of what was offered. `_invalid` and not `_forbidden`, since every member derives from `#protocol` and what fails is a requirement past the grammar.

`error`, with the pair beside it: the connection has been handed over, so there is no later message in which a client that cannot tell what it is now speaking can ask.

Floor: 230 of 237 entries cite a sentence.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
