### PR TITLE
A handshake that should have been refused

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1791,6 +1791,10 @@ severity = "error"
 # WebSocket handshake carries no Sec-WebSocket-Version
 severity = "error"
 
+[violations.status_101_forbidden]
+# A 101 completes a WebSocket handshake the server had to refuse
+severity = "warn"
+
 [violations.status_101_ignored]
 # HTTP continues on a connection a 101 handed off
 severity = "warn"

--- a/lint-http-rules/src/rules/websocket_handshake_valid.rs
+++ b/lint-http-rules/src/rules/websocket_handshake_valid.rs
@@ -18,6 +18,7 @@ use crate::violations::sec_websocket_extensions::SEC_WEBSOCKET_EXTENSIONS_UNSOLI
 use crate::violations::sec_websocket_protocol::{
     RFC_6455_4_2_2, SEC_WEBSOCKET_PROTOCOL_EMPTY, SEC_WEBSOCKET_PROTOCOL_UNSOLICITED,
 };
+use crate::violations::status::{RFC_6455_4_2_1, STATUS_101_FORBIDDEN};
 use crate::violations::token::{
     token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
     TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
@@ -89,15 +90,19 @@ pub struct WebsocketHandshakeValid;
 /// besides `websocket` is § 4.2.2's ceiling on the value, which HTTP does not
 /// set.
 ///
-/// What is left unnamed is the `101` that completed a handshake a server was
-/// required to refuse, which says so through [`Defect`] — a finding no subject
-/// has claimed.
+/// The `101` that completed a handshake a server was required to refuse is the
+/// [`status`](crate::violations::status) subject's, and it is the last of this
+/// rule's readings to land: what is wrong there is the response's control data
+/// rather than any field on it, which is exactly what that subject holds.
+///
+/// **Nothing here is unnamed any more**, so [`Defect`] carries no `Option`.
 static DECLARED: &[&ViolationDef] = &[
     &SEC_WEBSOCKET_ACCEPT_CONFLICTING,
     &SEC_WEBSOCKET_ACCEPT_MISSING,
     &SEC_WEBSOCKET_EXTENSIONS_UNSOLICITED,
     &SEC_WEBSOCKET_PROTOCOL_EMPTY,
     &SEC_WEBSOCKET_PROTOCOL_UNSOLICITED,
+    &STATUS_101_FORBIDDEN,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
     &TOKEN_CHARACTER_FORBIDDEN,
     &UPGRADE_101_EMPTY,
@@ -106,30 +111,21 @@ static DECLARED: &[&ViolationDef] = &[
     &UPGRADE_CONNECTION_OPTION_MISSING,
 ];
 
-/// One finding from the reading, and the defect it reports as where the
-/// catalogue names that defect.
+/// One finding from the reading, and the entry it reports as.
 ///
-/// The shape `expect_header_valid` settled and the rule measuring the other half
-/// of this handshake reuses: a judge that is half converted says so in its type
-/// rather than being split in two.
+/// The shape `expect_header_valid` settled, carried here while the readings were
+/// converting one at a time — **and the `Option` around `def` is gone now that
+/// the last one has landed**, which is what a rule does when nothing it reports
+/// is nameless.
 struct Defect {
-    def: Option<&'static ViolationDef>,
+    def: &'static ViolationDef,
     message: String,
 }
 
 impl Defect {
     /// A defect the catalogue names.
     fn named(def: &'static ViolationDef, message: String) -> Self {
-        Self {
-            def: Some(def),
-            message,
-        }
-    }
-
-    /// A defect no subject has claimed yet, reported at the rule's severity the
-    /// way every finding here was before the catalogue existed.
-    fn unnamed(message: String) -> Self {
-        Self { def: None, message }
+        Self { def, message }
     }
 }
 
@@ -162,13 +158,14 @@ impl WebsocketHandshakeValid {
     // cite(RFC 6455 § 4.2.1): "A |Sec-WebSocket-Key| header field with a base64-encoded (see Section 4 of [RFC4648]) value that, when decoded, is 16 bytes in length."
     // cite(RFC 6455 § 4.2.1): "A |Sec-WebSocket-Version| header field, with a value of 13."
     // cite(RFC 6455 § 4.2.2): "If this version does not match a version understood by the server, the server MUST abort the WebSocket handshake described in this section and instead send an appropriate HTTP error code (such as 426 Upgrade Required) and a |Sec-WebSocket-Version| header field indicating the version(s) the server is capable of understanding."
-    fn refusable_handshake(req_headers: &hyper::HeaderMap) -> Option<String> {
+    fn refusable_handshake(req_headers: &hyper::HeaderMap) -> Option<Defect> {
         let Some(raw) = combined_field_value_as_written(req_headers, "sec-websocket-key") else {
-            return Some(
+            return Some(Defect::named(
+                &STATUS_101_FORBIDDEN,
                 "the request it answers carries no Sec-WebSocket-Key header field, and a \
                  handshake missing one is a handshake the server was required to refuse"
                     .into(),
-            );
+            ));
         };
         let defect = sec_websocket_key_defect(&raw)?;
         // The one verdict that is not this sentence's business, and it is the
@@ -188,11 +185,14 @@ impl WebsocketHandshakeValid {
         ) {
             return None;
         }
-        Some(format!(
-            "the request it answers offers the Sec-WebSocket-Key `{}`, which is not the nonce \
-             that field is defined as ({defect}) — a handshake the server was required to refuse \
-             rather than complete",
-            shown_in_finding(trim_ows(&raw))
+        Some(Defect::named(
+            &STATUS_101_FORBIDDEN,
+            format!(
+                "the request it answers offers the Sec-WebSocket-Key `{}`, which is not the \
+                 nonce that field is defined as ({defect}) — a handshake the server was required \
+                 to refuse rather than complete",
+                shown_in_finding(trim_ows(&raw))
+            ),
         ))
     }
 
@@ -499,6 +499,10 @@ fn extension_token(member: &str) -> &str {
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
 ///
+/// § 4.2.1 is not written here either, for the same reason: the entry a `101`
+/// over a refusable handshake reports is
+/// [`status`](crate::violations::status)', and the reference lives beside it.
+///
 /// § 4.2.2 is not written here and neither is RFC 9110 § 5.6.2: the first is
 /// what the two subprotocol entries in
 /// [`sec_websocket_protocol`](crate::violations::sec_websocket_protocol)
@@ -510,12 +514,6 @@ const RFC_6455_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("4.1"),
     url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.1",
     note: "Client Requirements — the numbered list a client validates the server's response against, and the sentence handing every non-101 back to plain HTTP",
-};
-const RFC_6455_4_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 6455",
-    section: Some("4.2.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.2.1",
-    note: "Reading the Client's Opening Handshake — the description a handshake has to match, and the requirement to refuse one that does not, which is what makes a 101 over a malformed key the server's defect",
 };
 const RFC_6455_4_3: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 6455",
@@ -664,7 +662,7 @@ impl Rule for WebsocketHandshakeValid {
             // admissibility ahead of the questions about its fields. One message carries
             // one finding, so the first defect is the one reported.
             let defect = [
-                Self::refusable_handshake(&req.headers).map(Defect::unnamed),
+                Self::refusable_handshake(&req.headers),
                 Self::upgrade_defect(&resp.headers),
                 Self::connection_defect(&resp.headers),
                 Self::accept_defect(&req.headers, &resp.headers),
@@ -675,14 +673,13 @@ impl Rule for WebsocketHandshakeValid {
             .flatten()
             .next()?;
 
-            let message = format!(
-                "This 101 completes a WebSocket opening handshake, but {}",
-                defect.message
-            );
-            match defect.def {
-                Some(def) => Some(ctx.report_with(def, message)),
-                None => Some(self.violation(ctx.severity, message)),
-            }
+            Some(ctx.report_with(
+                defect.def,
+                format!(
+                    "This 101 completes a WebSocket opening handshake, but {}",
+                    defect.message
+                ),
+            ))
         };
         Vec::from_iter(finding())
     }
@@ -1118,12 +1115,13 @@ mod tests {
         assert_eq!(found.violation, "sec_websocket_protocol_unsolicited");
     }
 
-    /// The rank a subprotocol finding carries is its entry's and no longer the
-    /// rule's: the fixture configures this rule at `warn`, and both halves of
-    /// what a server may write wrong come out at the `error` their defs
-    /// default to — while everything still unnamed here keeps the rule's.
+    /// Every finding this rule makes now carries its entry's rank rather than the
+    /// rule's: the fixture configures the rule at `warn`, an unoffered subprotocol
+    /// comes out at the `error` its entry defaults to, and the handshake a server
+    /// had to refuse stays at `warn` because that is what *its* entry says — not
+    /// because the rule's severity reached it.
     #[rstest]
-    fn a_named_defect_takes_its_entrys_rank_and_an_unnamed_one_the_rules() {
+    fn every_finding_takes_its_entrys_rank_and_not_the_rules() {
         let mut resp = handshake_response();
         resp.push(("sec-websocket-protocol", "mqtt"));
         let mut req = handshake_request();
@@ -1131,7 +1129,7 @@ mod tests {
         let tx = make_ws_tx(req, 101, resp);
         assert_eq!(run(&tx).unwrap().severity, crate::lint::Severity::Error);
 
-        // The one reading left that no subject has claimed: a `101` completing a
+        // The reading that lands in the status subject: a `101` completing a
         // handshake whose key is not a nonce, which is about the exchange rather
         // than about any field's value.
         let tx = make_ws_tx(
@@ -1146,7 +1144,7 @@ mod tests {
         );
         let found = run(&tx).unwrap();
         assert_eq!(found.severity, crate::lint::Severity::Warn);
-        assert!(found.violation.is_empty());
+        assert_eq!(found.violation, "status_101_forbidden");
     }
 
     /// Extensions are compared on the name half of each member; the parameters

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -425,7 +425,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 230;
+        const FLOOR: usize = 231;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/status.rs
+++ b/lint-http-rules/src/violations/status.rs
@@ -48,7 +48,14 @@
 //! answers; this one compares a connection with a response earlier on it, which
 //! is why it needs the history and a connection id to be reported at all.
 //!
-//! So five of the six default to `warn`, which is the severity the rules
+//! **The seventh is the first here whose sentence is not HTTP's**, and it is
+//! the shape the subject was always going to reach: a `101` answering a
+//! WebSocket handshake that RFC 6455 § 4.2.1 required the server to refuse. The
+//! status code contradicts its request exactly as the others do; what is new is
+//! that the contradiction is spelled out by the protocol being upgraded to,
+//! which is the only document that says what makes such a request refusable.
+//!
+//! So six of the seven default to `warn`, which is the severity the rules
 //! reporting them had already chosen for themselves: a client handed a response
 //! it did not ask for, or cannot parse, has to notice that on its own, and the
 //! exchange carries on around it. **The question that separates the levels is
@@ -114,6 +121,17 @@ pub const RFC_9114_4_5: SpecRef = SpecRef {
     section: Some("4.5"),
     url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.5",
     note: "HTTP Upgrade — the only place RFC 9114 mentions 101, withholding the upgrade mechanism and the status code together",
+};
+
+/// Reading the Client's Opening Handshake: the description a request has to
+/// match for a server to accept it, and the sentence saying what a server does
+/// with one that does not. The entry it carries is the second half — a `101` is
+/// a server having done the opposite.
+pub const RFC_6455_4_2_1: SpecRef = SpecRef {
+    spec: "RFC 6455",
+    section: Some("4.2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.2.1",
+    note: "Reading the Client's Opening Handshake — the description a handshake has to match, and the requirement to refuse one that does not, which is what makes a 101 over a malformed key the server's defect",
 };
 
 defects! {
@@ -296,6 +314,41 @@ defects! {
         message: "HTTP traffic after 101 Switching Protocols on the same connection; the connection should have been handed off to the upgraded protocol",
         default_severity: Severity::Warn,
         spec: &[RFC_9110_15_2_2],
+    }
+
+    /// A `101` completing a handshake the server was required to refuse: the
+    /// WebSocket opening handshake it answers carries no `Sec-WebSocket-Key`,
+    /// or one that is not the sixteen-byte nonce the field is defined as.
+    ///
+    /// **The request's defect is somebody else's finding and this is not it.**
+    /// The value belongs to [`sec_websocket_key`](crate::violations::sec_websocket_key)
+    /// and is reported against the client by the rule that reads the request;
+    /// what this entry names is the *answer* — § 4.2.1 opens the description a
+    /// server matches a handshake against by saying what to do when it does not
+    /// match, which is to stop and return an error status. A `101` is that
+    /// server having done the opposite, and only a rule holding both messages
+    /// can see it.
+    ///
+    /// `_forbidden` rather than `_unsolicited`: the sentence prohibits the
+    /// response in as many words, which is the test the two `_unsolicited`
+    /// entries above are on the other side of.
+    ///
+    /// `warn`, and unlike [`STATUS_101_PROTOCOL_FORBIDDEN`] the hand-off is not
+    /// what is wrong here — the client asked for WebSocket and got WebSocket,
+    /// and both endpoints can speak it. **What is missing is a guard rather than
+    /// a statement**, the line
+    /// [`te_connection_option_missing`](crate::violations::te) drew: the nonce
+    /// is how a server tells a client that meant to open this handshake from one
+    /// that was aimed at it, and a server that skips the check is exposed rather
+    /// than confused.
+    ///
+    // cite(RFC 6455 § 4.2.1): "the server MUST stop processing the client's handshake and return an HTTP response with an appropriate error code (such as 400 Bad Request)"
+    STATUS_101_FORBIDDEN = {
+        id: "status_101_forbidden",
+        title: "A 101 completes a WebSocket handshake the server had to refuse",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_6455_4_2_1],
     }
 
     /// A 304 carrying representation metadata beyond the fields it is required

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -2755,7 +2755,9 @@ sources:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
       line: 446
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 160
+      line: 156
+    - file: lint-http-rules/src/violations/status.rs
+      line: 345
   - label: Sec-WebSocket-Protocol-Client
     section: § 4.3
     snippet: Sec-WebSocket-Protocol-Client = 1#token
@@ -2999,37 +3001,37 @@ sources:
     snippet: If the status code received from the server is not 101, the client handles the response per HTTP [RFC2616] procedures.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 646
+      line: 644
   - label: websocket_handshake_valid (7)
     section: § 4.1
     snippet: In particular, the client might perform authentication if it receives a 401 status code; the server might redirect the client using a 3xx status code (but clients are not required to follow them), etc.  Otherwise, proceed as follows.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 647
+      line: 645
   - label: websocket_handshake_valid (8)
     section: § 4.2.1
     snippet: A |Sec-WebSocket-Key| header field with a base64-encoded (see Section 4 of [RFC4648]) value that, when decoded, is 16 bytes in length.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 162
+      line: 158
   - label: websocket_handshake_valid (9)
     section: § 4.2.1
     snippet: A |Sec-WebSocket-Version| header field, with a value of 13.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 163
+      line: 159
   - label: websocket_handshake_valid (10)
     section: § 4.2.1
     snippet: including but not limited to any violations of the ABNF grammar specified for the components of the handshake
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 161
+      line: 157
   - label: websocket_handshake_valid (11)
     section: § 4.2.2
     snippet: A Status-Line with a 101 response code as per RFC 2616 [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 653
+      line: 651
   - label: websocket_handshake_valid (12)
     section: § 4.2.2
     snippet: A |Connection| header field with value "Upgrade".
@@ -3059,37 +3061,37 @@ sources:
     snippet: If the requested service is not available, the server MUST send an appropriate HTTP error code (such as 404 Not Found) and abort the WebSocket handshake.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 652
+      line: 650
   - label: websocket_handshake_valid (16)
     section: § 4.2.2
     snippet: If the server chooses to accept the incoming connection, it MUST reply with a valid HTTP response indicating the following.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 648
+      line: 646
   - label: websocket_handshake_valid (17)
     section: § 4.2.2
     snippet: If the server does not wish to accept this connection, it MUST return an appropriate HTTP error code (e.g., 403 Forbidden) and abort the WebSocket handshake described in this section.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 651
+      line: 649
   - label: websocket_handshake_valid (18)
     section: § 4.2.2
     snippet: If this version does not match a version understood by the server, the server MUST abort the WebSocket handshake described in this section and instead send an appropriate HTTP error code (such as 426 Upgrade Required) and a |Sec-WebSocket-Version| header field indicating the version(s) the server is capable of understanding.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 164
+      line: 160
   - label: websocket_handshake_valid (19)
     section: § 4.2.2
     snippet: The server MAY redirect the client using a 3xx status code [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 650
+      line: 648
   - label: websocket_handshake_valid (20)
     section: § 4.2.2
     snippet: The server can perform additional client authentication, for example, by returning a 401 status code with the corresponding |WWW-Authenticate| header field as described in [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 649
+      line: 647
   - label: websocket_handshake_valid (21)
     section: § 4.2.2
     snippet: if the server does not wish to agree to one of the suggested subprotocols, it MUST NOT send back a |Sec-WebSocket-Protocol| header field in its response
@@ -5197,7 +5199,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
       line: 118
     - file: lint-http-rules/src/violations/status.rs
-      line: 132
+      line: 150
   - label: accept_ranges_on_partial_content
     section: § 14.2
     snippet: A server MUST ignore a Range header field received with a request method that is unrecognized or for which range handling is not defined.
@@ -8817,37 +8819,37 @@ sources:
     snippet: The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field (Section 7.8), for a change in the application protocol being used on this connection.
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 292
+      line: 310
   - label: status (2)
     section: § 15.3.7.2
     snippet: A server MUST NOT generate a multipart response to a request for a single range, since a client that does not request multiple parts might not support multipart responses.
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 179
+      line: 197
   - label: status (3)
     section: § 15.4.5
     snippet: Since the goal of a 304 response is to minimize information transfer when the recipient already has one or more cached representations, a sender SHOULD NOT generate representation metadata other than the above listed fields unless said metadata exists for the purpose of guiding cache updates (e.g., Last-Modified might be useful if the response does not have an ETag field).
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 318
+      line: 371
   - label: status (4)
     section: § 15.5.17
     snippet: The 416 (Range Not Satisfiable) status code indicates that the set of ranges in the request's Range header field (Section 14.2) has been rejected either because none of the requested ranges are satisfiable or because the client has requested an excessive number of small or overlapping ranges (a potential denial of service attack).
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 152
+      line: 170
   - label: status (5)
     section: § 7.8
     snippet: A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field.
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 256
+      line: 274
   - label: status (6)
     section: § 7.8
     snippet: A server that receives an Upgrade header field in an HTTP/1.0 request MUST ignore that Upgrade field.
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 219
+      line: 237
   - label: status_101_switching_protocols
     section: § 7.8
     snippet: Although protocol names are registered with a preferred case, recipients SHOULD use case-insensitive comparison when matching each protocol-name to supported protocols.
@@ -10686,7 +10688,7 @@ sources:
     snippet: HTTP/2 does not support the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 220
+      line: 238
   - label: the TE exception
     section: § 8.2.2
     snippet: The only exception to this is the TE header field, which MAY be present in an HTTP/2 request; when it is, it MUST NOT contain any value other than "trailers".
@@ -10893,7 +10895,7 @@ sources:
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
       line: 181
     - file: lint-http-rules/src/violations/status.rs
-      line: 221
+      line: 239
   - label: lint-http-core/src/http_version.rs
     section: § 4.3.1
     snippet: HTTP/3 does not define a way to carry the version identifier that is included in the HTTP/1.1 request line.


### PR DESCRIPTION
`websocket_handshake_valid` converts whole with its last reading: a `101` answering a WebSocket handshake whose `Sec-WebSocket-Key` is absent, or is not the sixteen-byte nonce the field is defined as. §4.2.1 opens the description a server matches a handshake against by saying what to do with one that does not match — stop, and return an error status — so a `101` is that server having done the opposite, and only a rule holding both messages can see it.

The entry is the status code's. What is wrong is not the key, which belongs to the client and is reported against it by the rule reading the request; it is the response's control data, and a status code that contradicts its request is what this subject holds. It is also the first entry there whose sentence is not HTTP's: the only document that says what makes such a request refusable is the protocol being upgraded to.

`_forbidden` and not `_unsolicited`, because a sentence prohibits the response in as many words. `warn`, and unlike a `101` switching to a protocol nobody named the hand-off is not what is wrong — the client asked for WebSocket and got it, and both endpoints can speak it. What is missing is a guard rather than a statement: the nonce is how a server tells a client that meant to open this handshake from one that was aimed at it.

Both websocket rules now report nothing nameless, so their `Defect` types drop the `Option` around the entry.

Floor: 231 of 238 entries cite a sentence.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
