### PR TITLE
The third field that travels with its name

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1475,6 +1475,10 @@ severity = "info"
 # Timestamp is padded with whitespace the grammar does not print
 severity = "warn"
 
+[violations.keep_alive_connection_option_missing]
+# Keep-Alive is sent with no keep-alive connection-option in Connection
+severity = "warn"
+
 [violations.language_tag_character_forbidden]
 # Language tag holds a character outside letters, digits and hyphen
 severity = "warn"

--- a/lint-http-rules/src/rules/keep_alive_header_valid.rs
+++ b/lint-http-rules/src/rules/keep_alive_header_valid.rs
@@ -9,6 +9,7 @@ use crate::helpers::shown::{describe_char, shown_in_finding};
 use crate::helpers::word::{token_or_quoted_string, WordDefect};
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::keep_alive::{KEEP_ALIVE_CONNECTION_OPTION_MISSING, RFC_2068_19_7_1_1};
 use crate::violations::quoted_pair::QUOTED_PAIR_MALFORMED;
 use crate::violations::quoted_string::{
     quoted_string_defect, QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
@@ -84,14 +85,20 @@ pub struct KeepAliveHeaderValid;
 /// value may not hold answers here with the id an `Accept` parameter, an
 /// `auth-param` or a `Content-Type` parameter answers with.
 ///
+/// The connection option the field must travel with is
+/// [`keep_alive`](crate::violations::keep_alive)'s, and the third of a family
+/// each of whose members sits in its own subject: the sentence requiring the
+/// option is written once per field, so an identical defect under a different
+/// sentence is a different entry.
+///
 /// Everything else is this document's own and stays: a member with no `=` at
 /// all (the expired draft would have allowed it and the document in force does
 /// not), a member that names no parameter, a `timeout` that is not
-/// `delta-seconds`, a `timeout` above the bound an operator configured, and the
-/// connection option the field must travel with. **The empty value is unnamed
-/// too** — `word_defect` declines that verdict because six fields answered it
+/// `delta-seconds`, and a `timeout` above the bound an operator configured.
+/// **The empty value is unnamed too** — `word_defect` declines that verdict because six fields answered it
 /// four ways, and this one answers it in its own words.
 static DECLARED: &[&ViolationDef] = &[
+    &KEEP_ALIVE_CONNECTION_OPTION_MISSING,
     &TOKEN_CHARACTER_FORBIDDEN,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
     &QUOTED_STRING_DELIMITER_MISSING,
@@ -137,16 +144,12 @@ impl Defect {
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_2068_19_7_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 2068",
-    section: Some("19.7.1.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc2068.html#section-19.7.1.1",
-    note: "The `Keep-Alive` grammar, the sentence saying HTTP/1.1 defines no \
-           parameters for it, and the field's one requirement on a sender — the \
-           matching connection token. Obsoleted, and still the document RFC 9110 \
-           §7.6.1 names for this field, so this is where the productions are read \
-           from. The reference here used to be RFC 7230 §6.7, which is `Upgrade`",
-};
+///
+/// § 19.7.1.1 is not written here: it is the sentence the connection-option
+/// entry enforces, so the reference lives beside that entry in
+/// [`keep_alive`](crate::violations::keep_alive) and is imported back — and the
+/// rest of this field's grammar is read from the same section, which is why the
+/// docs still name it.
 const RFC_9110_7_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
     section: Some("7.6.1"),
@@ -499,7 +502,7 @@ fn judge(
 
     validate_keep_alive(&value, max_timeout_seconds)
         .err()
-        .or_else(|| missing_connection_option(headers, version).map(Defect::unnamed))
+        .or_else(|| missing_connection_option(headers, version))
         .map(|defect| defect.in_context(|message| format!("{side} Keep-Alive header: {message}")))
 }
 
@@ -515,20 +518,20 @@ fn judge(
 /// a connection option would be asking it to violate RFC 9113 §8.2.2 —
 /// `no_connection_specific_fields` owns that question for both versions.
 // cite(RFC 9110 § 7.6.1): "Keep-Alive (Section 19.7.1 of [RFC2068])"
-fn missing_connection_option(headers: &hyper::HeaderMap, version: &str) -> Option<String> {
+fn missing_connection_option(headers: &hyper::HeaderMap, version: &str) -> Option<Defect> {
     if !crate::http_version::is_major(version, 1) {
         return None;
     }
     let connection = combined_field_value_as_written(headers, "connection");
-    // cite(RFC 2068 § 19.7.1.1): "If the Keep-Alive header is sent, the corresponding connection token MUST be transmitted."
     if is_nominated_by_connection("keep-alive", connection.as_deref()) {
         return None;
     }
-    Some(
+    Some(Defect::named(
+        &KEEP_ALIVE_CONNECTION_OPTION_MISSING,
         "the field was sent with no `keep-alive` connection option in `Connection`, and the \
          corresponding connection token must be transmitted with it"
             .into(),
-    )
+    ))
 }
 
 /// Validate a whole `Keep-Alive` field value.
@@ -934,6 +937,10 @@ mod tests {
             "{}",
             found.message
         );
+        // The third id of a family that ranks together and cites apart: the
+        // sentence behind this one is the field's own, and it is RFC 2068's.
+        assert_eq!(found.violation, "keep_alive_connection_option_missing");
+        assert_eq!(found.severity, crate::lint::Severity::Warn);
     }
 
     /// The option is a field name, so the comparison folds case, and it is one

--- a/lint-http-rules/src/violations/keep_alive.rs
+++ b/lint-http-rules/src/violations/keep_alive.rs
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `Keep-Alive` defects — a field the current specification defines by pointing
+//! somewhere else.
+//!
+//! RFC 9110 § 7.6.1 lists this field among the connection-specific ones and
+//! annotates it *Section 19.7.1 of \[RFC2068\]*, which is where the grammar and
+//! the field's one requirement on a sender are written. So the sentences this
+//! subject cites are a 1997 document's, and that is the document in force for
+//! this field: **obsolete is not the same as superseded**, and nothing since has
+//! restated what a `Keep-Alive` is.
+//!
+//! **The first entry is the third of a family**, and each member of it sits in
+//! its own subject: a connection-specific field travels with its name written
+//! as a `connection-option`, and the sentence saying so is written once per
+//! field — § 7.8 for [`upgrade`](crate::violations::upgrade), § 10.1.4 for
+//! [`te`](crate::violations::te), and § 19.7.1.1 here. The shape is identical
+//! and the requirement is not shared, which is why one shared id would have to
+//! name § 7.6.1's general wording as the sentence behind findings whose
+//! evidence is a field-specific MUST.
+//!
+//! **What comes next in this subject is everything the field's own grammar
+//! says**, and it is all still the rule's: a member written with no `=` at all,
+//! a member naming no parameter, a `timeout` whose value is no `delta-seconds`,
+//! and a `timeout` above the bound an operator configured — the last of which
+//! will be uncited, since nothing published states a maximum and the bound is a
+//! deployment's policy.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// The field's definition: the grammar, the sentence saying HTTP/1.1 defines no
+/// parameters for it, and the one requirement on a sender that this subject's
+/// first entry carries.
+pub const RFC_2068_19_7_1_1: SpecRef = SpecRef {
+    spec: "RFC 2068",
+    section: Some("19.7.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc2068.html#section-19.7.1.1",
+    note: "The `Keep-Alive` grammar, the sentence saying HTTP/1.1 defines no \
+           parameters for it, and the field's one requirement on a sender — the \
+           matching connection token. Obsoleted, and still the document RFC 9110 \
+           §7.6.1 names for this field, so this is where the productions are read \
+           from. The reference here used to be RFC 7230 §6.7, which is `Upgrade`",
+};
+
+defects! {
+    /// A message carrying `Keep-Alive` with no `keep-alive` connection-option
+    /// in `Connection`. The field describes the connection it is sent on and
+    /// nothing further; the option is what stops an intermediary from relaying
+    /// a timeout that belongs to a hop the recipient is not on.
+    ///
+    /// **One entry for both shapes of the absence**, the line
+    /// [`upgrade_connection_option_missing`](crate::violations::upgrade) drew:
+    /// a `Connection` naming other options and a message with no `Connection`
+    /// at all are one missing name, and the site's message is where the two
+    /// part company.
+    ///
+    /// **Asked only of HTTP/1.x**, which is the reading of the rule reporting
+    /// it: HTTP/2 and HTTP/3 forbid both fields outright, so asking for the
+    /// option there would be asking a sender to make its own message malformed.
+    ///
+    /// `warn`, with the two siblings: nothing about the message is unreadable,
+    /// and a guard that was not set risks a *later* hop being misled — which no
+    /// recipient of this message can detect.
+    ///
+    // cite(RFC 2068 § 19.7.1.1): "If the Keep-Alive header is sent, the corresponding connection token MUST be transmitted."
+    KEEP_ALIVE_CONNECTION_OPTION_MISSING = {
+        id: "keep_alive_connection_option_missing",
+        title: "Keep-Alive is sent with no keep-alive connection-option in Connection",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_2068_19_7_1_1],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::violations::te::TE_CONNECTION_OPTION_MISSING;
+    use crate::violations::upgrade::UPGRADE_CONNECTION_OPTION_MISSING;
+
+    /// Three fields, one shape, three ids — and one rank, because what an
+    /// operator is being told is the same thing about a different name. The ids
+    /// differ because the sentences do; the rank does not, because the
+    /// consequence does not.
+    #[test]
+    fn the_family_ranks_together_and_cites_apart() {
+        for def in [
+            &KEEP_ALIVE_CONNECTION_OPTION_MISSING,
+            &TE_CONNECTION_OPTION_MISSING,
+            &UPGRADE_CONNECTION_OPTION_MISSING,
+        ] {
+            assert_eq!(def.default_severity, Severity::Warn, "{}", def.id);
+            assert_eq!(def.spec.len(), 1, "{}", def.id);
+        }
+        let sections: Vec<_> = [
+            &KEEP_ALIVE_CONNECTION_OPTION_MISSING,
+            &TE_CONNECTION_OPTION_MISSING,
+            &UPGRADE_CONNECTION_OPTION_MISSING,
+        ]
+        .iter()
+        .map(|def| def.spec[0].section)
+        .collect();
+        assert_eq!(
+            sections.len(),
+            sections
+                .iter()
+                .collect::<std::collections::BTreeSet<_>>()
+                .len(),
+            "no two of the family enforce one sentence"
+        );
+    }
+}

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -51,6 +51,7 @@ pub mod domain;
 pub mod etag;
 pub mod field;
 pub mod http_date;
+pub mod keep_alive;
 pub mod language;
 pub mod list;
 pub mod mailbox;
@@ -425,7 +426,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 231;
+        const FLOOR: usize = 232;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -768,19 +768,19 @@ sources:
     snippet: keep-alive-extension = token [ "=" ( token / quoted-string ) ]
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 588
+      line: 591
   - label: keep_alive_header_valid (2)
     section: § 2
     snippet: keep-alive-info      =   "timeout" "=" delta-seconds
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 631
+      line: 634
   - label: keep_alive_header_valid (3)
     section: § 2.1
     snippet: The value of the "timeout" parameter is a single integer in seconds.
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 709
+      line: 712
 - label: MDN Content-Type
   url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Type
   fragments:
@@ -1015,90 +1015,90 @@ sources:
 - label: RFC 2068
   url: https://www.rfc-editor.org/rfc/rfc2068.html
   fragments:
+  - label: keep_alive
+    section: § 19.7.1.1
+    snippet: If the Keep-Alive header is sent, the corresponding connection token MUST be transmitted.
+    cited_by:
+    - file: lint-http-rules/src/violations/keep_alive.rs
+      line: 69
   - label: keep_alive_header_valid
     section: § 19.7.1.1
     snippet: HTTP/1.1 does not define any parameters.
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 632
+      line: 635
   - label: keep_alive_header_valid (2)
-    section: § 19.7.1.1
-    snippet: If the Keep-Alive header is sent, the corresponding connection token MUST be transmitted.
-    cited_by:
-    - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 523
-  - label: keep_alive_header_valid (3)
     section: § 19.7.1.1
     snippet: Keep-Alive-header = "Keep-Alive" ":" 0# keepalive-param
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 536
-  - label: keep_alive_header_valid (4)
+      line: 539
+  - label: keep_alive_header_valid (3)
     section: § 19.7.1.1
     snippet: The Keep-Alive header itself is optional, and is used only if a parameter is being sent.
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 554
-  - label: keep_alive_header_valid (5)
+      line: 557
+  - label: keep_alive_header_valid (4)
     section: § 19.7.1.1
     snippet: When the Keep-Alive connection-token has been transmitted with a request or a response, a Keep-Alive header field MAY also be included.
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 425
-  - label: keep_alive_header_valid (6)
+      line: 428
+  - label: keep_alive_header_valid (5)
     section: § 19.7.1.1
     snippet: keepalive-param = param-name "=" value
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 587
-  - label: keep_alive_header_valid (7)
+      line: 590
+  - label: keep_alive_header_valid (6)
     section: § 2.1
     snippet: At least one delimiter (tspecials) must exist between any two tokens, since they would otherwise be interpreted as a single token.
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 597
-  - label: keep_alive_header_valid (8)
+      line: 600
+  - label: keep_alive_header_valid (7)
     section: § 2.1
     snippet: Wherever this construct is used, null elements are allowed, but do not contribute
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 553
-  - label: keep_alive_header_valid (9)
+      line: 556
+  - label: keep_alive_header_valid (8)
     section: § 2.1
     snippet: linear whitespace (LWS) can be included between any two adjacent words (token or quoted-string), and between adjacent tokens and delimiters (tspecials), without changing the interpretation of a field.
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 610
+      line: 613
   - label: LWS grammar
     section: § 2.2
     snippet: LWS            = [CRLF] 1*( SP | HT )
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 611
-  - label: keep_alive_header_valid (10)
+      line: 614
+  - label: keep_alive_header_valid (9)
     section: § 2.2
     snippet: The backslash character ("\") may be used as a single-character quoting mechanism only within quoted-string and comment constructs.
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 668
-  - label: keep_alive_header_valid (11)
+      line: 671
+  - label: keep_alive_header_valid (10)
     section: § 2.2
     snippet: quoted-string  = ( <"> *(qdtext) <"> )
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 667
-  - label: keep_alive_header_valid (12)
+      line: 670
+  - label: keep_alive_header_valid (11)
     section: § 2.2
     snippet: token          = 1*<any CHAR except CTLs or tspecials>
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 666
-  - label: keep_alive_header_valid (13)
+      line: 669
+  - label: keep_alive_header_valid (12)
     section: § 3.7
     snippet: value          = token | quoted-string
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 665
+      line: 668
 - label: RFC 2616
   url: https://www.rfc-editor.org/rfc/rfc2616.html
   fragments:
@@ -5311,7 +5311,7 @@ sources:
     - file: lint-http-rules/src/rules/http_version_syntax.rs
       line: 170
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 535
+      line: 538
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 590
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
@@ -6359,7 +6359,7 @@ sources:
     snippet: Keep-Alive (Section 19.7.1 of [RFC2068])
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 517
+      line: 520
   - label: language_tag_syntax
     section: § 8.5
     snippet: 'Content-Language = #language-tag'
@@ -7011,7 +7011,7 @@ sources:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
       line: 436
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 538
+      line: 541
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 593
     - file: lint-http-rules/src/rules/refresh_header_syntax.rs
@@ -9638,7 +9638,7 @@ sources:
     - file: lint-http-rules/src/helpers/cache_control.rs
       line: 83
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 710
+      line: 713
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
       line: 100
     - file: lint-http-rules/src/violations/delta_seconds.rs


### PR DESCRIPTION
`violations/keep_alive.rs`, and with it the family is complete: a connection-specific field is relayed unless its own name is written as a `connection-option`, and the sentence saying so exists once per field. §7.8 for `Upgrade`, §10.1.4 for `TE`, and RFC 2068 §19.7.1.1 for this one — three subjects, three ids, one shape.

The document is the point of the subject. RFC 9110 §7.6.1 lists `Keep-Alive` among the fields an intermediary removes and annotates it *Section 19.7.1 of [RFC2068]*, which is where the grammar and this requirement are written. Nothing since has restated what a `Keep-Alive` is, so the obsolete document is the one in force for it: obsolete is not the same as superseded.

One entry for both shapes of the absence, and `warn` with its two siblings — what is missing is a guard rather than a statement, and the hop it protects is not one any recipient of this message can see.

The test that carries the design lives in the new file and reads across all three: one rank, three sections, and no two of them enforcing one sentence. What comes next in this subject is the field's own grammar, written into the module doc — including the one entry that will be uncited, since no document states a maximum for `timeout` and the bound is a deployment's policy.

Floor: 232 of 239 entries cite a sentence.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
