### PR TITLE
The joins an expectation is made of

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1443,6 +1443,14 @@ severity = "warn"
 # Weakness indicator is not written W/
 severity = "warn"
 
+[violations.expect_member_malformed]
+# Expect member holds octets the expectation production does not admit
+severity = "warn"
+
+[violations.expect_value_empty]
+# Expect writes an expectation '=' with no value after it
+severity = "warn"
+
 [violations.field_connection_specific_forbidden]
 # A connection-specific field is written on a version that has none
 severity = "error"

--- a/lint-http-rules/src/rules/expect_header_valid.rs
+++ b/lint-http-rules/src/rules/expect_header_valid.rs
@@ -12,6 +12,7 @@ use crate::helpers::shown::describe_octet;
 use crate::helpers::token::{find_invalid_token_char, token_run_end};
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::expect::{EXPECT_MEMBER_MALFORMED, EXPECT_VALUE_EMPTY, RFC_9110_10_1_1};
 use crate::violations::list::{LIST_MEMBER_EMPTY, RFC_9110_5_6_1_1};
 use crate::violations::parameter::{
     PARAMETER_EQUALS_MISSING, PARAMETER_EQUALS_WHITESPACE_FORBIDDEN, PARAMETER_VALUE_EMPTY,
@@ -37,11 +38,15 @@ pub struct ExpectHeaderValid;
 ///
 /// What stays on the older API is § 10.1.1's, and it is what the rule is for:
 /// a `100-continue` in a request with no content, a request repeating one a 417
-/// already refused, a `100-continue` written with an argument, and the two
-/// shapes an `expectation` itself can fail in — a member that does not begin
-/// with a token's `=`, and an `=` with no value after it. The last two belong
-/// to an `expectation` subject nothing has written.
+/// already refused, and a `100-continue` written with an argument — three
+/// statements about what the one defined expectation *means*, which
+/// [`expect`](crate::violations::expect) is written with room for. The two
+/// shapes an `expectation` itself can fail in are that subject's already: a
+/// member holding octets the production does not admit, and an `=` with no value
+/// after it.
 static DECLARED: &[&ViolationDef] = &[
+    &EXPECT_MEMBER_MALFORMED,
+    &EXPECT_VALUE_EMPTY,
     &LIST_MEMBER_EMPTY,
     &TOKEN_EMPTY,
     &TOKEN_CHARACTER_FORBIDDEN,
@@ -95,12 +100,11 @@ const HUNDRED_CONTINUE: &str = "100-continue";
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_9110_10_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("10.1.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.1",
-    note: "Expect: the field's grammar, the one expectation this specification defines, and the four client requirements — of which the MUST NOT on a request without content and the SHOULD after a 417 are the two a captured message can measure",
-};
+///
+/// § 10.1.1 is not written here: the two entries the member's assembly reports
+/// enforce its production, so the reference lives beside them in
+/// [`expect`](crate::violations::expect) and is imported back — which is also
+/// where the three entries about what `100-continue` means will name it.
 const RFC_9110_A: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
     section: Some("A"),
@@ -424,16 +428,18 @@ pub(crate) fn parse_expectation(member: &str) -> Result<Expectation<'_>, Defect>
         return Ok(Expectation { name, member });
     };
     if stopper != '=' {
-        // Left unnamed: what failed is `expectation = token [ "=" ( token /
-        // quoted-string ) parameters ]` — the shape of the member rather than
-        // the name, which is a well-formed token that simply ended here. The
-        // `expectation` subject that would hold it is unwritten.
-        return Err(Defect::unnamed(format!(
-            "Invalid octet {} after the Expect expectation name '{}': the production admits only \
-             '=' there, and `parameters` are inside the group the '=' opens",
-            describe_octet(stopper as u8),
-            crate::helpers::shown::shown_in_finding(name)
-        )));
+        // The shape of the member rather than the name, which is a well-formed
+        // token that simply ended here — so the entry is the field's assembly
+        // and not the `token` subject's.
+        return Err(Defect::named(
+            &EXPECT_MEMBER_MALFORMED,
+            format!(
+                "Invalid octet {} after the Expect expectation name '{}': the production admits \
+                 only '=' there, and `parameters` are inside the group the '=' opens",
+                describe_octet(stopper as u8),
+                crate::helpers::shown::shown_in_finding(name)
+            ),
+        ));
     }
     let rest = &tail[1..];
 
@@ -469,15 +475,19 @@ pub(crate) fn parse_expectation(member: &str) -> Result<Expectation<'_>, Defect>
         // follows has to be `parameters`.
         let end = token_run_end(rest);
         if end == 0 {
-            // Also unnamed, and for the alternation's reason: an *expectation's* value
-            // being empty is a per-field verdict, not the alternation's, and
+            // The alternation's reason for having no entry of its own: an
+            // *expectation's* value being empty is a per-field verdict, and
             // `parameter_value_empty` answers for a parameter rather than for
-            // whatever else `( token / quoted-string )` is read as.
-            return Err(Defect::unnamed(format!(
-                "Expect member '{}' has '=' with no token or quoted-string after it: found {}",
-                crate::helpers::shown::shown_in_finding(member),
-                first_octet_of(rest)
-            )));
+            // whatever else `( token / quoted-string )` is read as. So the field
+            // says it, in the field's subject.
+            return Err(Defect::named(
+                &EXPECT_VALUE_EMPTY,
+                format!(
+                    "Expect member '{}' has '=' with no token or quoted-string after it: found {}",
+                    crate::helpers::shown::shown_in_finding(member),
+                    first_octet_of(rest)
+                ),
+            ));
         }
         &rest[end..]
     };
@@ -519,13 +529,17 @@ fn validate_parameters(after_value: &str, member: &str) -> Result<(), Defect> {
     // allows before the semicolon. The splitter always yields that leading
     // segment, empty or not.
     if !segments[0].is_empty() {
-        // The expectation's own shape again: what is wrong is that the value
-        // ended and the member did not, which no parameter defect describes.
-        return Err(Defect::unnamed(format!(
-            "Expect member '{}' has octets after its value that are not parameters: '{}'",
-            crate::helpers::shown::shown_in_finding(member),
-            crate::helpers::shown::shown_in_finding(segments[0])
-        )));
+        // The expectation's own shape again, and the same entry: what is wrong
+        // is that the value ended and the member did not, which no parameter
+        // defect describes and which the position does not change.
+        return Err(Defect::named(
+            &EXPECT_MEMBER_MALFORMED,
+            format!(
+                "Expect member '{}' has octets after its value that are not parameters: '{}'",
+                crate::helpers::shown::shown_in_finding(member),
+                crate::helpers::shown::shown_in_finding(segments[0])
+            ),
+        ));
     }
 
     for seg in &segments[1..] {

--- a/lint-http-rules/src/violations/expect.rs
+++ b/lint-http-rules/src/violations/expect.rs
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `Expect` defects — the shape of an expectation, and what the one defined
+//! expectation means.
+//!
+//! `expectation = token [ "=" ( token / quoted-string ) parameters ]`, and
+//! almost every way of failing it belongs to something else: the name is a
+//! [`token`](crate::violations::token), the value's quoted arm is a
+//! [`quoted_string`](crate::violations::quoted_string), everything after the
+//! first `;` is [`parameter`](crate::violations::parameter)'s — § 5.6.6's
+//! production, imported here by name rather than restated — and an empty member
+//! is the [`list`](crate::violations::list)'s.
+//!
+//! **What is left is the assembly**, which is what this subject holds: the
+//! optional group is opened by an `=` and by nothing else, so an octet where the
+//! `=` would go, and octets left over after the value ends, are both the member
+//! failing to derive rather than any of its parts failing. They are one entry:
+//! the position differs and the defect does not.
+//!
+//! **The value's emptiness is this field's own verdict and not the
+//! alternation's.** `( token / quoted-string )` derives no empty string, and
+//! the catalogue declines that verdict in general — six fields settled it four
+//! ways — so each production says what it means for itself.
+//! [`parameter_value_empty`](crate::violations::parameter) answers for a
+//! parameter, which is a different half of the same member.
+//!
+//! **What the one defined expectation *means* is not written yet**, and it is
+//! three more entries: a `100-continue` in a request with no content (§ 10.1.1
+//! states it as a MUST NOT), the same expectation repeated after a `417` said
+//! the response chain does not support expectations, and a `100-continue`
+//! written with an argument — which the grammar admits, no sentence forbids,
+//! and a recipient comparing members may answer `417` to.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// Where the field, its production and its one defined expectation are all
+/// written — including the sentences about what `100-continue` means, which the
+/// entries this subject has yet to gain will name.
+pub const RFC_9110_10_1_1: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.1",
+    note: "Expect: the field's grammar, the one expectation this specification defines, and the four client requirements — of which the MUST NOT on a request without content and the SHOULD after a 417 are the two a captured message can measure",
+};
+
+defects! {
+    /// A member holding octets the production does not admit: an octet after
+    /// the expectation's name where only the `=` opening the optional group may
+    /// stand, or octets left over after the value ended and before any `;`.
+    ///
+    /// **One entry for two positions.** Both are the same failure — the member
+    /// does not derive from `expectation` — and neither is a defect of any part
+    /// the member is assembled from: the name is a well-formed `token` that
+    /// ended, and the value is a well-formed `token` or `quoted-string` that
+    /// ended. What is wrong is what came next. The site's message says where.
+    ///
+    /// `warn`, with the rest of the grammar entries a member can reach: a
+    /// recipient that cannot read an expectation answers `417` at worst, and the
+    /// request itself is intact.
+    ///
+    // cite(RFC 9110 § 10.1.1, label: expectation production): "expectation = token [ "=" ( token / quoted-string ) parameters ]"
+    EXPECT_MEMBER_MALFORMED = {
+        id: "expect_member_malformed",
+        title: "Expect member holds octets the expectation production does not admit",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_9110_10_1_1],
+    }
+
+    /// A member ending on its `=`. The optional group writes the delimiter and
+    /// the value together, and neither arm of `( token / quoted-string )`
+    /// derives the empty string — a `token` has a one-character floor and the
+    /// shortest `quoted-string` is its two DQUOTEs — so the `=` says a value was
+    /// due and nothing the grammar can generate followed it.
+    ///
+    /// **This field's verdict rather than the alternation's**, which is the line
+    /// the catalogue draws wherever `( token / quoted-string )` appears: the
+    /// shared reader answers "empty" without naming a defect, because six fields
+    /// settled that question four ways and two tolerate it outright. This one
+    /// does not tolerate it, and says so here rather than in the reader.
+    ///
+    // cite(RFC 9110 § 10.1.1, label: expectation production): "expectation = token [ "=" ( token / quoted-string ) parameters ]"
+    EXPECT_VALUE_EMPTY = {
+        id: "expect_value_empty",
+        title: "Expect writes an expectation '=' with no value after it",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_9110_10_1_1],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The assembly and the empty value are two entries of one rank, and both
+    /// name the section that writes the production — the same section the three
+    /// entries about what `100-continue` *means* will name, which is why the
+    /// reference is defined here rather than inside either.
+    #[test]
+    fn the_assembly_and_the_empty_value_are_two_entries_of_one_rank() {
+        assert_ne!(EXPECT_MEMBER_MALFORMED.id, EXPECT_VALUE_EMPTY.id);
+        for def in [&EXPECT_MEMBER_MALFORMED, &EXPECT_VALUE_EMPTY] {
+            assert_eq!(def.default_severity, Severity::Warn, "{}", def.id);
+            assert_eq!(def.spec, [RFC_9110_10_1_1], "{}", def.id);
+        }
+    }
+}

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -49,6 +49,7 @@ pub mod credentials;
 pub mod delta_seconds;
 pub mod domain;
 pub mod etag;
+pub mod expect;
 pub mod field;
 pub mod http_date;
 pub mod keep_alive;
@@ -433,7 +434,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 235;
+        const FLOOR: usize = 237;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -5309,7 +5309,7 @@ sources:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
       line: 369
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 402
+      line: 406
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
       line: 303
     - file: lint-http-rules/src/rules/http_version_syntax.rs
@@ -5901,7 +5901,7 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 28
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 193
+      line: 197
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
       line: 222
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
@@ -5915,7 +5915,7 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 29
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 209
+      line: 213
   - label: context_fields_direction (3)
     section: § 10.1.2
     snippet: The "From" header field contains an Internet email address for a human user who controls the requesting user agent.
@@ -6059,77 +6059,81 @@ sources:
     snippet: A "100-continue" expectation informs recipients that the client is about to send (presumably large) content in this request
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 297
+      line: 301
   - label: expect_header_valid (2)
     section: § 10.1.1
     snippet: A client MUST NOT generate a 100-continue expectation in a request that does not include content.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 296
+      line: 300
   - label: expect_header_valid (3)
     section: § 10.1.1
     snippet: A client that receives a 417 (Expectation Failed) status code in response to a request containing a 100-continue expectation SHOULD repeat that request without a 100-continue expectation, since the 417 response merely indicates that the response chain does not support expectations (e.g., it passes through an HTTP/1.0 server).
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 315
+      line: 319
   - label: expect_header_valid (4)
     section: § 10.1.1
     snippet: A server that receives an Expect field value containing a member other than 100-continue MAY respond with a 417 (Expectation Failed) status code to indicate that the unexpected expectation cannot be met.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 338
+      line: 342
   - label: expect_header_valid (5)
     section: § 10.1.1
     snippet: The Expect field value is case-insensitive.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 92
+      line: 97
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 260
+      line: 264
   - label: expect_header_valid (6)
     section: § 10.1.1
     snippet: The only expectation defined by this specification is "100-continue" (with no defined parameters).
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 91
-  - label: expect_header_valid (7)
+      line: 96
+  - label: expectation production
     section: § 10.1.1
     snippet: expectation = token [ "=" ( token / quoted-string ) parameters ]
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 401
-  - label: expect_header_valid (8)
+      line: 405
+    - file: lint-http-rules/src/violations/expect.rs
+      line: 65
+    - file: lint-http-rules/src/violations/expect.rs
+      line: 86
+  - label: expect_header_valid (7)
     section: § 15.5.18
     snippet: The 417 (Expectation Failed) status code indicates that the expectation given in the request's Expect header field (Section 10.1.1) could not be met by at least one of the inbound servers.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 314
-  - label: expect_header_valid (9)
+      line: 318
+  - label: expect_header_valid (8)
     section: § 5.6.6
     snippet: 'Note: Parameters do not allow whitespace (not even "bad" whitespace) around the "=" character.'
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 570
+      line: 584
     - file: lint-http-rules/src/violations/parameter.rs
       line: 119
-  - label: expect_header_valid (10)
+  - label: expect_header_valid (9)
     section: § A
     snippet: Expect = [ expectation *( OWS "," OWS expectation ) ]
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 245
-  - label: expect_header_valid (11)
+      line: 249
+  - label: expect_header_valid (10)
     section: § B.3
     snippet: List-based grammar for Expect has been restored for compatibility with RFC 2616.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 224
-  - label: expect_header_valid (12)
+      line: 228
+  - label: expect_header_valid (11)
     section: § B.3
     snippet: Parameters in media type, media range, and expectation can be empty via one or more trailing semicolons.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 538
+      line: 552
   - label: extension_headers_registered
     section: § 16.3
     snippet: Most fields are designed with the expectation that a recipient can safely ignore (but forward downstream) any field not recognized
@@ -7429,7 +7433,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 383
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 502
+      line: 512
   - label: parameter-value grammar
     section: § 5.6.6
     snippet: parameter-value = ( token / quoted-string )
@@ -7439,7 +7443,7 @@ sources:
     - file: lint-http-rules/src/helpers/word.rs
       line: 26
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 503
+      line: 513
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 89
     - file: lint-http-rules/src/violations/parameter.rs
@@ -7457,7 +7461,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 221
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 500
+      line: 510
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
       line: 266
   - label: lint-http-rules/src/helpers/media_type.rs (5)
@@ -7523,7 +7527,7 @@ sources:
     - file: lint-http-rules/src/helpers/parameter.rs
       line: 107
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 501
+      line: 511
     - file: lint-http-rules/src/violations/parameter.rs
       line: 69
   - label: lint-http-rules/src/helpers/product.rs


### PR DESCRIPTION
`violations/expect.rs`, and what it holds is the assembly. Every part of an `expectation` already had a subject — the name is a token, a quoted value is a quoted-string, everything past the first `;` is §5.6.6's parameters, an empty member is the list's — and nothing held the production that joins them.

Two entries. The optional group is opened by an `=` and by nothing else, so an octet standing where the `=` would go, and octets left over after the value ended, are one defect at two positions: the member does not derive from `expectation`, while every part of it is well formed and simply ended. The site's message says where; the id does not need to.

The second is a member ending on its `=`. Neither arm of `( token / quoted-string )` derives the empty string, and the catalogue declines that verdict in general — the shared reader answers "empty" without naming a defect, because six fields settled it four ways and two tolerate it outright. This field does not, and now says so in its own subject rather than in the reader.

What the one defined expectation *means* is three more entries and is written into the module doc as next: a `100-continue` in a request with no content, one repeated after a `417`, and one written with an argument the grammar admits.

Floor: 237 of 245 entries cite a sentence.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
