### PR TITLE
What a hundred-continue is worth saying

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1443,6 +1443,14 @@ severity = "warn"
 # Weakness indicator is not written W/
 severity = "warn"
 
+[violations.expect_100_continue_forbidden]
+# A 100-continue expectation is sent in a request with no content
+severity = "warn"
+
+[violations.expect_100_continue_invalid]
+# The 100-continue expectation is written with an argument
+severity = "info"
+
 [violations.expect_member_malformed]
 # Expect member holds octets the expectation production does not admit
 severity = "warn"
@@ -1849,6 +1857,10 @@ severity = "warn"
 
 [violations.status_416_unsolicited]
 # 416 Range Not Satisfiable answers a request that named no range
+severity = "warn"
+
+[violations.status_417_ignored]
+# A request repeats an expectation a 417 already refused
 severity = "warn"
 
 [violations.status_metadata_redundant]

--- a/lint-http-rules/src/rules/expect_header_valid.rs
+++ b/lint-http-rules/src/rules/expect_header_valid.rs
@@ -12,7 +12,10 @@ use crate::helpers::shown::describe_octet;
 use crate::helpers::token::{find_invalid_token_char, token_run_end};
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
-use crate::violations::expect::{EXPECT_MEMBER_MALFORMED, EXPECT_VALUE_EMPTY, RFC_9110_10_1_1};
+use crate::violations::expect::{
+    EXPECT_100_CONTINUE_FORBIDDEN, EXPECT_100_CONTINUE_INVALID, EXPECT_MEMBER_MALFORMED,
+    EXPECT_VALUE_EMPTY, RFC_9110_10_1_1,
+};
 use crate::violations::list::{LIST_MEMBER_EMPTY, RFC_9110_5_6_1_1};
 use crate::violations::parameter::{
     PARAMETER_EQUALS_MISSING, PARAMETER_EQUALS_WHITESPACE_FORBIDDEN, PARAMETER_VALUE_EMPTY,
@@ -23,6 +26,7 @@ use crate::violations::quoted_string::{
     quoted_string_defect, QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
     QUOTED_STRING_DELIMITER_MISSING, QUOTED_STRING_QUOTE_ESCAPE_MISSING, RFC_9110_5_6_4,
 };
+use crate::violations::status::STATUS_417_IGNORED;
 use crate::violations::token::{
     token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN, TOKEN_EMPTY,
 };
@@ -36,15 +40,19 @@ pub struct ExpectHeaderValid;
 /// `( token / quoted-string )` — so a stray comma, a parameter with no `=` and
 /// an unterminated quote are the same defects twenty-odd other fields report.
 ///
-/// What stays on the older API is § 10.1.1's, and it is what the rule is for:
-/// a `100-continue` in a request with no content, a request repeating one a 417
-/// already refused, and a `100-continue` written with an argument — three
-/// statements about what the one defined expectation *means*, which
-/// [`expect`](crate::violations::expect) is written with room for. The two
-/// shapes an `expectation` itself can fail in are that subject's already: a
-/// member holding octets the production does not admit, and an `=` with no value
-/// after it.
+/// What § 10.1.1 says about the one defined expectation is what this rule is
+/// for, and it lands in two subjects rather than one.
+/// [`expect`](crate::violations::expect) holds the assembly of a member, the
+/// value it may not leave empty, the MUST NOT against sending `100-continue`
+/// with no content, and the argument that costs the expectation its meaning.
+/// The request that repeats one a `417` already refused is
+/// [`status_417_ignored`](crate::violations::status): what it disregards is a
+/// status code, the evidence is an earlier exchange, and an id built on this
+/// field would have named the expectation as the thing ignored — which is a
+/// server's behaviour and the opposite of the finding.
 static DECLARED: &[&ViolationDef] = &[
+    &EXPECT_100_CONTINUE_FORBIDDEN,
+    &EXPECT_100_CONTINUE_INVALID,
     &EXPECT_MEMBER_MALFORMED,
     &EXPECT_VALUE_EMPTY,
     &LIST_MEMBER_EMPTY,
@@ -57,37 +65,24 @@ static DECLARED: &[&ViolationDef] = &[
     &QUOTED_PAIR_MALFORMED,
     &QUOTED_STRING_QUOTE_ESCAPE_MISSING,
     &QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
+    &STATUS_417_IGNORED,
 ];
 
-/// One finding the reading produced: its wording, and the defect it reports as
-/// where the catalogue has a name for that defect.
+/// One finding the reading produced: its wording, and the entry it reports as.
 ///
-/// The first judge converted in this tree — `x_forwarded_consistent`'s —
-/// returns `(&'static ViolationDef, String)`, because every arm of it had an
-/// entry. This rule's judges are half
-/// converted — an `expectation`'s own two failures are its field's and no
-/// subject holds them — so the def is an `Option`, and the site that reports
-/// picks the API from it. **A partially converted judge says which arms are
-/// converted in its type**, which is the smallest honest shape for it and
-/// cheaper than splitting the reading in two.
+/// This type carried an `Option` while an `expectation`'s own failures had no
+/// subject to belong to, which is what a half-converted judge says in its type
+/// rather than by being split in two. **The field has a subject now**, so the
+/// `Option` is gone and the site reports one way.
 pub(crate) struct Defect {
-    def: Option<&'static ViolationDef>,
+    def: &'static ViolationDef,
     message: String,
 }
 
 impl Defect {
     /// A defect the catalogue names.
     fn named(def: &'static ViolationDef, message: String) -> Self {
-        Self {
-            def: Some(def),
-            message,
-        }
-    }
-
-    /// A defect no subject has claimed yet, reported at the rule's severity the
-    /// way every finding was before the catalogue existed.
-    fn unnamed(message: String) -> Self {
-        Self { def: None, message }
+        Self { def, message }
     }
 }
 
@@ -101,10 +96,11 @@ const HUNDRED_CONTINUE: &str = "100-continue";
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
 ///
-/// § 10.1.1 is not written here: the two entries the member's assembly reports
-/// enforce its production, so the reference lives beside them in
-/// [`expect`](crate::violations::expect) and is imported back — which is also
-/// where the three entries about what `100-continue` means will name it.
+/// § 10.1.1 is not written here: every entry this rule reports out of that
+/// section enforces one of its sentences, so the reference lives beside them in
+/// [`expect`](crate::violations::expect) and is imported back — including by the
+/// [`status`](crate::violations::status) entry, whose sentence is written in the
+/// field's section rather than the status code's.
 const RFC_9110_A: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
     section: Some("A"),
@@ -231,15 +227,9 @@ impl Rule for ExpectHeaderValid {
             // Read after the field, not before it: both this and a missing `Expect`
             // end the rule, and the header probe is one map lookup where the config
             // read is several.
-            // Two APIs behind one closure: a defect the catalogue names resolves
-            // the severity configured for it, and one it does not still emits at
-            // the rule's.
-            let report = |defect: Defect| {
-                Some(match defect.def {
-                    Some(def) => ctx.report_with(def, defect.message),
-                    None => self.violation(ctx.severity, defect.message),
-                })
-            };
+            // One API now that every finding here names an entry: the severity is
+            // the entry's, resolved from the configuration by identity.
+            let report = |defect: Defect| Some(ctx.report_with(defect.def, defect.message));
 
             // A list of no members, which is not a list with an empty member in it —
             // the two look alike and only one of them is a defect. The sender-expanded
@@ -300,7 +290,8 @@ impl Rule for ExpectHeaderValid {
                 // cite(RFC 9110 § 10.1.1): "A client MUST NOT generate a 100-continue expectation in a request that does not include content."
                 // cite(RFC 9110 § 10.1.1): "A "100-continue" expectation informs recipients that the client is about to send (presumably large) content in this request"
                 if content_evidence(&tx.request.headers, tx.request.body_length).is_none() {
-                    return report(Defect::unnamed(
+                    return report(Defect::named(
+                        &EXPECT_100_CONTINUE_FORBIDDEN,
                         "Request carries a 100-continue expectation but no content: the expectation \
                          asks the server to weigh in before content the message never had"
                             .to_string(),
@@ -325,7 +316,8 @@ impl Rule for ExpectHeaderValid {
                             && carries_hundred_continue(&prev.request.headers)
                     })
                 {
-                    return report(Defect::unnamed(
+                    return report(Defect::named(
+                        &STATUS_417_IGNORED,
                         "Request repeats one the response chain answered with 417 (Expectation Failed) \
                          and still carries a 100-continue expectation"
                             .to_string(),
@@ -341,13 +333,17 @@ impl Rule for ExpectHeaderValid {
                 //
                 // cite(RFC 9110 § 10.1.1): "A server that receives an Expect field value containing a member other than 100-continue MAY respond with a 417 (Expectation Failed) status code to indicate that the unexpected expectation cannot be met."
                 if e.has_arguments() {
-                    return report(Defect::unnamed(format!(
-                        "Expect writes the 100-continue expectation with an argument ('{}'); the \
-                         specification defines no value or parameters for it, so a recipient matching \
-                         the member against 100-continue sees a different expectation and may answer \
-                         417 (Expectation Failed). This is advice: the grammar admits the argument",
-                        crate::helpers::shown::shown_in_finding(e.member)
-                    )));
+                    return report(Defect::named(
+                        &EXPECT_100_CONTINUE_INVALID,
+                        format!(
+                            "Expect writes the 100-continue expectation with an argument ('{}'); \
+                             the specification defines no value or parameters for it, so a \
+                             recipient matching the member against 100-continue sees a different \
+                             expectation and may answer 417 (Expectation Failed). This is advice: \
+                             the grammar admits the argument",
+                            crate::helpers::shown::shown_in_finding(e.member)
+                        ),
+                    ));
                 }
             }
 
@@ -799,10 +795,11 @@ mod tests {
 
     /// This rule's own severity is `error`, chosen for the requirements it is
     /// named after, and until the catalogue existed every grammar quibble it
-    /// noticed inherited that level. Three findings out of one rule now come out
-    /// three different ways: the spelling of a `=` at `info`, a stray comma at
-    /// `warn`, and the MUST NOT about content at the `error` the rule was
-    /// configured with.
+    /// noticed inherited that level. **The configured level now reaches none of
+    /// them**: three findings out of one rule come out at the three levels their
+    /// entries default to — the spelling of a `=` at `info`, a stray comma at
+    /// `warn`, and the MUST NOT about content at `warn` because the exchange
+    /// survives it, whatever the rule was configured with.
     #[test]
     fn one_rule_now_reports_at_three_levels() {
         let severity_of = |value: &str| {
@@ -824,9 +821,9 @@ mod tests {
         assert_eq!(comma.violation, "list_member_empty");
         assert_eq!(comma.severity, crate::lint::Severity::Warn);
 
-        // The 100-continue expectation on a request with no content:
-        // unconverted, and still the rule's own severity. The fixture above
-        // gives every request content, so this one is built without it.
+        // The 100-continue expectation on a request with no content: its own
+        // entry now, and its own rank. The fixture above gives every request
+        // content, so this one is built without it.
         let mut tx = tx_with_expect_lines(&[b"100-continue"]);
         tx.request.body_length = None;
         let framing = crate::test_helpers::run_rule(
@@ -836,8 +833,8 @@ mod tests {
             &crate::test_helpers::make_test_config_with_severity(ExpectHeaderValid.id(), "error"),
         )
         .expect("the MUST NOT about content");
-        assert!(framing.violation.is_empty());
-        assert_eq!(framing.severity, crate::lint::Severity::Error);
+        assert_eq!(framing.violation, "expect_100_continue_forbidden");
+        assert_eq!(framing.severity, crate::lint::Severity::Warn);
     }
 
     #[test]
@@ -888,8 +885,9 @@ mod tests {
     fn hundred_continue_without_content_is_the_must_not() {
         let mut tx = tx_with_expect_lines(&[b"100-continue"]);
         tx.request.body_length = Some(0);
-        let msg = judge(&tx).expect("MUST NOT").message;
-        assert!(msg.contains("no content"), "{msg}");
+        let defect = judge(&tx).expect("MUST NOT");
+        assert!(defect.message.contains("no content"), "{}", defect.message);
+        assert_eq!(defect.violation, "expect_100_continue_forbidden");
     }
 
     #[test]
@@ -931,9 +929,12 @@ mod tests {
 
     #[test]
     fn an_argument_on_hundred_continue_is_advice_not_a_grammar_defect() {
-        let msg = judge_value("100-continue=param").expect("advice").message;
-        assert!(msg.contains("417"), "{msg}");
-        assert!(msg.contains("advice"), "{msg}");
+        let defect = judge_value("100-continue=param").expect("advice");
+        assert!(defect.message.contains("417"), "{}", defect.message);
+        assert!(defect.message.contains("advice"), "{}", defect.message);
+        // The argument is not a grammar defect and the entry says so: `_invalid`
+        // at `info`, where the member's assembly is `warn`.
+        assert_eq!(defect.violation, "expect_100_continue_invalid");
     }
 
     #[test]
@@ -977,10 +978,12 @@ mod tests {
 
     #[test]
     fn repeating_after_a_417_still_expecting_is_reported() {
-        let msg = judge_with_history(vec![prior("POST", 417, Some("100-continue"))])
-            .expect("417 repeat")
-            .message;
-        assert!(msg.contains("417"), "{msg}");
+        let defect =
+            judge_with_history(vec![prior("POST", 417, Some("100-continue"))]).expect("417 repeat");
+        assert!(defect.message.contains("417"), "{}", defect.message);
+        // The status code is the subject: what was not acted on is the `417`,
+        // and an id built on this field would have said the expectation was.
+        assert_eq!(defect.violation, "status_417_ignored");
     }
 
     #[test]
@@ -1025,10 +1028,7 @@ mod tests {
             "{}",
             defect.message
         );
-        assert_eq!(
-            defect.def.map(|d| d.id),
-            Some("quoted_string_control_character_forbidden"),
-        );
+        assert_eq!(defect.def.id, "quoted_string_control_character_forbidden");
     }
 
     #[test]

--- a/lint-http-rules/src/violations/expect.rs
+++ b/lint-http-rules/src/violations/expect.rs
@@ -26,12 +26,15 @@
 //! [`parameter_value_empty`](crate::violations::parameter) answers for a
 //! parameter, which is a different half of the same member.
 //!
-//! **What the one defined expectation *means* is not written yet**, and it is
-//! three more entries: a `100-continue` in a request with no content (§ 10.1.1
-//! states it as a MUST NOT), the same expectation repeated after a `417` said
-//! the response chain does not support expectations, and a `100-continue`
-//! written with an argument — which the grammar admits, no sentence forbids,
-//! and a recipient comparing members may answer `417` to.
+//! **What the one defined expectation *means* is two more entries here and one
+//! somewhere else.** § 10.1.1 states a MUST NOT against sending it in a request
+//! with no content, and defines the expectation *with no defined parameters*, so
+//! a member carrying an argument is no longer the expectation it was written to
+//! be — those two are the field's. The third is not: a request repeating one a
+//! `417` already refused is read out of an *earlier exchange*, and what it
+//! disregards is a status code, so it is
+//! [`status_417_ignored`](crate::violations::status) and sits beside the other
+//! entry that needs a third message to see.
 
 use crate::lint::Severity;
 use crate::rules::SpecRef;
@@ -89,6 +92,58 @@ defects! {
         title: "Expect writes an expectation '=' with no value after it",
         message: "",
         default_severity: Severity::Warn,
+        spec: &[RFC_9110_10_1_1],
+    }
+
+    /// A `100-continue` expectation in a request that carries no content.
+    ///
+    /// The expectation exists to let a server weigh in *before* content it may
+    /// not want; a request with none asks for a judgement on nothing and then
+    /// waits — and a server that answers `100 (Continue)` is inviting a body
+    /// that will never arrive. § 10.1.1 states it as a MUST NOT, which is why
+    /// this is `_forbidden` and not a reading of what the expectation is for.
+    ///
+    /// **Content, not a field.** What the sentence turns on is content — the
+    /// octet stream after framing is removed — so the evidence is a recorded
+    /// body length or a framing field, and a capture that shows neither cannot
+    /// produce this finding. That limit belongs to the capture and is the rule's
+    /// to describe.
+    ///
+    /// `warn`. The exchange survives: the server answers or it does not, and a
+    /// client that sends nothing after a `100` has an idle round trip rather
+    /// than a broken request.
+    ///
+    // cite(RFC 9110 § 10.1.1): "A client MUST NOT generate a 100-continue expectation in a request that does not include content."
+    EXPECT_100_CONTINUE_FORBIDDEN = {
+        id: "expect_100_continue_forbidden",
+        title: "A 100-continue expectation is sent in a request with no content",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_9110_10_1_1],
+    }
+
+    /// A `100-continue` written with a value or parameters hung off it.
+    ///
+    /// The grammar admits the argument — `expectation` brackets a value and
+    /// `parameters` for *any* expectation — and no sentence forbids writing one
+    /// here. What the section does say is that the one expectation it defines is
+    /// `100-continue` **with no defined parameters**, and that is enough: a
+    /// recipient matching the member against the expectation it knows finds
+    /// something else, and the section's next sentence lets it answer `417`. So
+    /// the argument does not break the member, it costs the member its meaning.
+    ///
+    /// `_invalid` for that reason: the value derives from its production and
+    /// fails a requirement past it. `info` rather than `warn`, alone in this
+    /// subject — nothing is malformed, no MUST is broken, and what an operator
+    /// is being told is that a request is likely to be answered `417` by a
+    /// recipient that is within its rights.
+    ///
+    // cite(RFC 9110 § 10.1.1): "The only expectation defined by this specification is "100-continue" (with no defined parameters)."
+    EXPECT_100_CONTINUE_INVALID = {
+        id: "expect_100_continue_invalid",
+        title: "The 100-continue expectation is written with an argument",
+        message: "",
+        default_severity: Severity::Info,
         spec: &[RFC_9110_10_1_1],
     }
 }

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -434,7 +434,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 237;
+        const FLOOR: usize = 240;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/status.rs
+++ b/lint-http-rules/src/violations/status.rs
@@ -55,7 +55,16 @@
 //! that the contradiction is spelled out by the protocol being upgraded to,
 //! which is the only document that says what makes such a request refusable.
 //!
-//! So six of the seven default to `warn`, which is the severity the rules
+//! **The eighth is the second read out of a third message**, and it is the first
+//! entry here about a *request*: a `417` says the response chain cannot meet an
+//! expectation, and a repeat that keeps the expectation asks again for what was
+//! refused. The word is `_ignored` for the reason the `101` entry carries it —
+//! nothing is malformed, and what was not acted on is what the status code said.
+//! **The subject is why the id reads correctly**: an id built on the field would
+//! have named the expectation as the thing ignored, which is a server's
+//! behaviour and the opposite of this finding.
+//!
+//! So seven of the eight default to `warn`, which is the severity the rules
 //! reporting them had already chosen for themselves: a client handed a response
 //! it did not ask for, or cannot parse, has to notice that on its own, and the
 //! exchange carries on around it. **The question that separates the levels is
@@ -65,8 +74,12 @@
 
 use crate::lint::Severity;
 use crate::rules::SpecRef;
+// The sentence a `417` leaves a client with, written in the field's section
+// rather than the status code's — defined where the field's entries are, and
+// named here for the entry about a request that disregarded it.
 use crate::violations::content_range::RFC_9110_15_3_7_2;
 use crate::violations::defects;
+use crate::violations::expect::RFC_9110_10_1_1;
 use crate::violations::upgrade::RFC_9110_15_2_2;
 
 /// What a 206 says it is doing, and the field a single-part one has to carry
@@ -349,6 +362,39 @@ defects! {
         message: "",
         default_severity: Severity::Warn,
         spec: &[RFC_6455_4_2_1],
+    }
+
+    /// A request carrying a `100-continue` expectation after a `417
+    /// (Expectation Failed)` answered the same request without one being
+    /// dropped.
+    ///
+    /// The status code says the expectation could not be met by at least one of
+    /// the inbound servers, which is a fact about the *chain* and not about this
+    /// request: an HTTP/1.0 hop in the middle will fail it again tomorrow. So
+    /// § 10.1.1 tells a client that receives one to repeat the request without
+    /// the expectation, and a repeat that keeps it asks again for something
+    /// already refused.
+    ///
+    /// **`_ignored`, and the sibling that carries the word is the reason it
+    /// reads correctly here**: the subject is the status code, so what was not
+    /// acted on is the `417` — never the expectation, which is what an id built
+    /// on `expect` would have said instead.
+    ///
+    /// **Read out of a third message**, like [`STATUS_101_IGNORED`] and unlike
+    /// everything else in this subject: the evidence is an *earlier* exchange
+    /// with the same method on the same resource, so a rule reporting it needs
+    /// the history, and a capture holding one request cannot produce it.
+    ///
+    /// `warn`. Nothing is malformed and the request is answerable; what it
+    /// costs is a round trip that was already known to fail.
+    ///
+    // cite(RFC 9110 § 10.1.1): "A client that receives a 417 (Expectation Failed) status code in response to a request containing a 100-continue expectation SHOULD repeat that request without a 100-continue expectation, since the 417 response merely indicates that the response chain does not support expectations (e.g., it passes through an HTTP/1.0 server)."
+    STATUS_417_IGNORED = {
+        id: "status_417_ignored",
+        title: "A request repeats an expectation a 417 already refused",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_9110_10_1_1],
     }
 
     /// A 304 carrying representation metadata beyond the fields it is required

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -2763,7 +2763,7 @@ sources:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
       line: 156
     - file: lint-http-rules/src/violations/status.rs
-      line: 345
+      line: 358
   - label: Sec-WebSocket-Protocol-Client
     section: § 4.3
     snippet: Sec-WebSocket-Protocol-Client = 1#token
@@ -5205,7 +5205,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
       line: 118
     - file: lint-http-rules/src/violations/status.rs
-      line: 150
+      line: 163
   - label: accept_ranges_on_partial_content
     section: § 14.2
     snippet: A server MUST ignore a Range header field received with a request method that is unrecognized or for which range handling is not defined.
@@ -5309,7 +5309,7 @@ sources:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
       line: 369
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 406
+      line: 402
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
       line: 303
     - file: lint-http-rules/src/rules/http_version_syntax.rs
@@ -5901,7 +5901,7 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 28
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 197
+      line: 193
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
       line: 222
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
@@ -5915,7 +5915,7 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 29
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 213
+      line: 209
   - label: context_fields_direction (3)
     section: § 10.1.2
     snippet: The "From" header field contains an Internet email address for a human user who controls the requesting user agent.
@@ -6059,61 +6059,67 @@ sources:
     snippet: A "100-continue" expectation informs recipients that the client is about to send (presumably large) content in this request
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 301
+      line: 291
   - label: expect_header_valid (2)
     section: § 10.1.1
     snippet: A client MUST NOT generate a 100-continue expectation in a request that does not include content.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 300
+      line: 290
+    - file: lint-http-rules/src/violations/expect.rs
+      line: 116
   - label: expect_header_valid (3)
     section: § 10.1.1
     snippet: A client that receives a 417 (Expectation Failed) status code in response to a request containing a 100-continue expectation SHOULD repeat that request without a 100-continue expectation, since the 417 response merely indicates that the response chain does not support expectations (e.g., it passes through an HTTP/1.0 server).
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 319
+      line: 310
+    - file: lint-http-rules/src/violations/status.rs
+      line: 391
   - label: expect_header_valid (4)
     section: § 10.1.1
     snippet: A server that receives an Expect field value containing a member other than 100-continue MAY respond with a 417 (Expectation Failed) status code to indicate that the unexpected expectation cannot be met.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 342
+      line: 334
   - label: expect_header_valid (5)
     section: § 10.1.1
     snippet: The Expect field value is case-insensitive.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 97
+      line: 92
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 264
+      line: 254
   - label: expect_header_valid (6)
     section: § 10.1.1
     snippet: The only expectation defined by this specification is "100-continue" (with no defined parameters).
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 96
+      line: 91
+    - file: lint-http-rules/src/violations/expect.rs
+      line: 141
   - label: expectation production
     section: § 10.1.1
     snippet: expectation = token [ "=" ( token / quoted-string ) parameters ]
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 405
+      line: 401
     - file: lint-http-rules/src/violations/expect.rs
-      line: 65
+      line: 68
     - file: lint-http-rules/src/violations/expect.rs
-      line: 86
+      line: 89
   - label: expect_header_valid (7)
     section: § 15.5.18
     snippet: The 417 (Expectation Failed) status code indicates that the expectation given in the request's Expect header field (Section 10.1.1) could not be met by at least one of the inbound servers.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 318
+      line: 309
   - label: expect_header_valid (8)
     section: § 5.6.6
     snippet: 'Note: Parameters do not allow whitespace (not even "bad" whitespace) around the "=" character.'
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 584
+      line: 580
     - file: lint-http-rules/src/violations/parameter.rs
       line: 119
   - label: expect_header_valid (9)
@@ -6121,19 +6127,19 @@ sources:
     snippet: Expect = [ expectation *( OWS "," OWS expectation ) ]
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 249
+      line: 239
   - label: expect_header_valid (10)
     section: § B.3
     snippet: List-based grammar for Expect has been restored for compatibility with RFC 2616.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 228
+      line: 224
   - label: expect_header_valid (11)
     section: § B.3
     snippet: Parameters in media type, media range, and expectation can be empty via one or more trailing semicolons.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 552
+      line: 548
   - label: extension_headers_registered
     section: § 16.3
     snippet: Most fields are designed with the expectation that a recipient can safely ignore (but forward downstream) any field not recognized
@@ -7433,7 +7439,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 383
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 512
+      line: 508
   - label: parameter-value grammar
     section: § 5.6.6
     snippet: parameter-value = ( token / quoted-string )
@@ -7443,7 +7449,7 @@ sources:
     - file: lint-http-rules/src/helpers/word.rs
       line: 26
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 513
+      line: 509
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 89
     - file: lint-http-rules/src/violations/parameter.rs
@@ -7461,7 +7467,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 221
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 510
+      line: 506
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
       line: 266
   - label: lint-http-rules/src/helpers/media_type.rs (5)
@@ -7527,7 +7533,7 @@ sources:
     - file: lint-http-rules/src/helpers/parameter.rs
       line: 107
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 511
+      line: 507
     - file: lint-http-rules/src/violations/parameter.rs
       line: 69
   - label: lint-http-rules/src/helpers/product.rs
@@ -8829,37 +8835,37 @@ sources:
     snippet: The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field (Section 7.8), for a change in the application protocol being used on this connection.
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 310
+      line: 323
   - label: status (2)
     section: § 15.3.7.2
     snippet: A server MUST NOT generate a multipart response to a request for a single range, since a client that does not request multiple parts might not support multipart responses.
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 197
+      line: 210
   - label: status (3)
     section: § 15.4.5
     snippet: Since the goal of a 304 response is to minimize information transfer when the recipient already has one or more cached representations, a sender SHOULD NOT generate representation metadata other than the above listed fields unless said metadata exists for the purpose of guiding cache updates (e.g., Last-Modified might be useful if the response does not have an ETag field).
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 371
+      line: 417
   - label: status (4)
     section: § 15.5.17
     snippet: The 416 (Range Not Satisfiable) status code indicates that the set of ranges in the request's Range header field (Section 14.2) has been rejected either because none of the requested ranges are satisfiable or because the client has requested an excessive number of small or overlapping ranges (a potential denial of service attack).
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 170
+      line: 183
   - label: status (5)
     section: § 7.8
     snippet: A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field.
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 274
+      line: 287
   - label: status (6)
     section: § 7.8
     snippet: A server that receives an Upgrade header field in an HTTP/1.0 request MUST ignore that Upgrade field.
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 237
+      line: 250
   - label: status_101_switching_protocols
     section: § 7.8
     snippet: Although protocol names are registered with a preferred case, recipients SHOULD use case-insensitive comparison when matching each protocol-name to supported protocols.
@@ -10698,7 +10704,7 @@ sources:
     snippet: HTTP/2 does not support the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/violations/status.rs
-      line: 238
+      line: 251
   - label: the TE exception
     section: § 8.2.2
     snippet: The only exception to this is the TE header field, which MAY be present in an HTTP/2 request; when it is, it MUST NOT contain any value other than "trailers".
@@ -10905,7 +10911,7 @@ sources:
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
       line: 181
     - file: lint-http-rules/src/violations/status.rs
-      line: 239
+      line: 252
   - label: lint-http-core/src/http_version.rs
     section: § 4.3.1
     snippet: HTTP/3 does not define a way to carry the version identifier that is included in the HTTP/1.1 request line.


### PR DESCRIPTION
`expect_header_valid` converts whole with the three statements §10.1.1 makes about the one expectation it defines — and they land in two subjects.

Two are the field's. A `100-continue` in a request with no content is a MUST NOT in as many words: the expectation asks a server to weigh in before content, and a server that answers `100 (Continue)` is inviting a body that will never arrive. And an argument hung off the expectation is `_invalid` rather than malformed — the grammar admits a value and parameters on any expectation, and what the section says is that the one it defines is `100-continue` *with no defined parameters*, so the argument does not break the member, it costs the member its meaning. That one defaults to `info`: nothing is wrong on the wire, and a recipient answering `417` would be within its rights.

The third is the status code's. A request repeating one a `417` already refused is read out of an earlier exchange, and what it disregards is what the status code said — so it sits beside the `101` entry that also needs a third message, and carries the same word. The subject is what makes the id readable: built on the field, `_ignored` would have named the expectation as the thing ignored, which is a server's behaviour and the opposite of this finding.

The rule whose test says it reports at three levels still does, and the configured severity now reaches none of them.

Floor: 240 of 248 entries cite a sentence.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
