### PR TITLE
Which octets a client may ask for

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1727,6 +1727,22 @@ severity = "warn"
 # Weight is not a qvalue
 severity = "warn"
 
+[violations.range_position_malformed]
+# Range position is not 1*DIGIT
+severity = "warn"
+
+[violations.range_positions_conflicting]
+# Range asks for a last-pos below its first-pos
+severity = "error"
+
+[violations.range_spec_character_forbidden]
+# Range specifier holds an octet no range-spec admits
+severity = "warn"
+
+[violations.range_spec_malformed]
+# A bytes range specifier derives from neither of the unit's two forms
+severity = "warn"
+
 [violations.request_target_asterisk_forbidden]
 # The asterisk target is sent with a method other than OPTIONS
 severity = "error"

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1381,7 +1381,16 @@ severity = "warn"
         /// never carried. **A count of cited sites falls fastest where one site
         /// was standing in for several defects**, which is the shape a
         /// half-converted judge has by construction.
-        const FLOOR: usize = 105;
+        /// **The `range` subject took the next one, and it is the shape this
+        /// note has described three times**: `range_header_syntax` cited
+        /// § 14.1.1 once, from the arm that reported everything a *specifier*
+        /// got wrong — an octet no alternative admits, a `bytes` value in
+        /// neither numeric form, a position that is not `1*DIGIT`, a range
+        /// running backwards. Four entries hold those now, three of them naming
+        /// § 14.1.1 and one naming the unit's own section, so every one of those
+        /// findings is still cited and one of them is cited more precisely than
+        /// the site ever was.
+        const FLOOR: usize = 104;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/rules/range_header_syntax.rs
+++ b/lint-http-rules/src/rules/range_header_syntax.rs
@@ -7,6 +7,10 @@ use crate::rules::{Rule, RuleMeta};
 use crate::violations::list::{
     LIST_MEMBER_EMPTY, LIST_MEMBER_MISSING, RFC_9110_5_6_1_1, RFC_9110_5_6_1_2,
 };
+use crate::violations::range::{
+    RANGE_POSITIONS_CONFLICTING, RANGE_POSITION_MALFORMED, RANGE_SPEC_CHARACTER_FORBIDDEN,
+    RANGE_SPEC_MALFORMED, RFC_9110_14_1_1, RFC_9110_14_1_2,
+};
 use crate::violations::ViolationDef;
 
 pub struct RangeHeaderSyntax;
@@ -19,62 +23,50 @@ pub struct RangeHeaderSyntax;
 /// them with the ids an `Accept-Ranges`, a `Warning` or an `Accept-Patch`
 /// reports them with.
 ///
-/// **Everything else here is § 14.1.1's, including the arithmetic that looks
-/// shared.** `last-pos` below `first-pos` is stated twice in this document, once
-/// for this field and once for `Content-Range`, and the catalogue holds the
-/// other one as `content_range_positions_conflicting`: two sections, two
-/// sentences, two fields, and one of the ids is spelled for the field it was
-/// written at. The numerals, the two `bytes` forms, the `other-range` octets and
-/// the `range-unit` this rule does not model are all the same — a specifier
-/// grammar the section says in as many words is generic, whose meaning each unit
-/// supplies for itself.
-static DECLARED: &[&ViolationDef] = &[&LIST_MEMBER_MISSING, &LIST_MEMBER_EMPTY];
+/// **Everything else here is the [`range`](crate::violations::range) subject's,
+/// including the arithmetic that looks shared.** `last-pos` below `first-pos` is
+/// stated twice in this document, once for this field and once for
+/// `Content-Range`, and the catalogue holds the other one as
+/// `content_range_positions_conflicting`: two sections, two sentences, two
+/// fields, and neither id is the other's to borrow. The three positions are one
+/// entry between them — one production written three times, and a sender that
+/// put a sign in one of them made one mistake — while the octets and the
+/// withdrawn `other-range` are two, because the first is true of every unit and
+/// the second only of `bytes`.
+static DECLARED: &[&ViolationDef] = &[
+    &LIST_MEMBER_MISSING,
+    &LIST_MEMBER_EMPTY,
+    &RANGE_SPEC_CHARACTER_FORBIDDEN,
+    &RANGE_SPEC_MALFORMED,
+    &RANGE_POSITION_MALFORMED,
+    &RANGE_POSITIONS_CONFLICTING,
+];
 
-/// One finding from the reading, and the defect it reports as where the
-/// catalogue names that defect.
+/// One finding from the reading, and the entry it reports as.
 ///
-/// The shape `expect_header_valid` settled, at its smallest: two of this rule's
-/// eight verdicts are the list construct's and the other six are the range
-/// specifier's own, so the `None` is the common case rather than the exception.
+/// The shape `expect_header_valid` settled, carried here while two of this
+/// rule's eight verdicts were the list construct's and the other six had no
+/// subject — **and the `Option` is gone now that the specifier has one**, which
+/// is what a rule does when its last arm is named.
 struct Defect {
-    def: Option<&'static ViolationDef>,
+    def: &'static ViolationDef,
     message: String,
 }
 
 impl Defect {
     /// A defect the catalogue names.
     fn named(def: &'static ViolationDef, message: String) -> Self {
-        Self {
-            def: Some(def),
-            message,
-        }
-    }
-
-    /// A defect no subject has claimed: what this section says about a
-    /// specifier rather than about the list carrying it.
-    fn unnamed(message: impl Into<String>) -> Self {
-        Self {
-            def: None,
-            message: message.into(),
-        }
+        Self { def, message }
     }
 }
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_9110_14_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("14.1.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.1.1",
-    note: "Range Specifiers: `ranges-specifier = range-unit \"=\" range-set`, and the grammar under it is generic — each range unit says which of `int-range`, `suffix-range` and `other-range` its specifiers may use. A ranges-specifier is invalid when it holds a range-spec \"that is invalid or undefined for the indicated range-unit\", which is the sentence every check here rests on and the one that bounds them to the unit the rule knows",
-};
-const RFC_9110_14_1_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("14.1.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.1.2",
-    note: "Byte Ranges: the two forms the `bytes` unit defines, both `1*DIGIT`, with `other-range` withdrawn for this unit. It also requires recipients to anticipate potentially large decimal numerals and prevent parsing errors due to integer conversion overflows — so positions are compared as digits and no ceiling is imposed — and it defines satisfiability, which is a question about the representation and not about the field",
-};
+///
+/// § 14.1.1 and § 14.1.2 are not written here: they are the sentences the
+/// [`range`](crate::violations::range) entries enforce, so both references live
+/// beside those entries and are imported back.
 const RFC_9110_14_2: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
     section: Some("14.2"),
@@ -235,10 +227,7 @@ impl Rule for RangeHeaderSyntax {
             // cite(RFC 9110 § 14.1.1): "A ranges-specifier is invalid if it contains any range-spec that is invalid or undefined for the indicated range-unit."
             if let Err(defect) = validate_range_set(&unit, range_set) {
                 let message = format!("Invalid Range header '{}': {}", value, defect.message);
-                return Some(match defect.def {
-                    Some(def) => ctx.report_with(def, message),
-                    None => self.cited(&RFC_9110_14_1_1, ctx.severity, message),
-                });
+                return Some(ctx.report_with(defect.def, message));
             }
 
             // Three things a well-formed ranges-specifier can still be, none of them
@@ -341,10 +330,13 @@ fn validate_range_set(unit: &str, range_set: &str) -> Result<(), Defect> {
         //
         // cite(RFC 9110 § 14.1.1, label: other-range grammar): "other-range   = 1*( %x21-2B / %x2D-7E )"
         if let Some(c) = spec.chars().find(|c| !c.is_ascii_graphic()) {
-            return Err(Defect::unnamed(format!(
-                "range-spec '{}' holds {:?}, which no range-spec admits",
-                spec, c
-            )));
+            return Err(Defect::named(
+                &RANGE_SPEC_CHARACTER_FORBIDDEN,
+                format!(
+                    "range-spec '{}' holds {:?}, which no range-spec admits",
+                    spec, c
+                ),
+            ));
         }
 
         // The one unit whose specifiers this rule can go on to read. The name is
@@ -391,25 +383,28 @@ fn validate_bytes_range_spec(spec: &str) -> Result<(), Defect> {
         return if is_digits(suffix_length) {
             Ok(())
         } else {
-            Err(Defect::unnamed(format!(
-                "suffix-range '{}' is not '-' followed by 1*DIGIT",
-                spec
-            )))
+            Err(Defect::named(
+                &RANGE_POSITION_MALFORMED,
+                format!("suffix-range '{}' is not '-' followed by 1*DIGIT", spec),
+            ))
         };
     }
 
     // cite(RFC 9110 § 14.1.1, label: int-range grammar): "int-range     = first-pos "-" [ last-pos ]"
     let Some((first, last)) = spec.split_once('-') else {
-        return Err(Defect::unnamed(format!(
-            "byte range-spec '{}' is neither an int-range nor a suffix-range",
-            spec
-        )));
+        return Err(Defect::named(
+            &RANGE_SPEC_MALFORMED,
+            format!(
+                "byte range-spec '{}' is neither an int-range nor a suffix-range",
+                spec
+            ),
+        ));
     };
     if !is_digits(first) {
-        return Err(Defect::unnamed(format!(
-            "first-pos '{}' is not 1*DIGIT",
-            first
-        )));
+        return Err(Defect::named(
+            &RANGE_POSITION_MALFORMED,
+            format!("first-pos '{}' is not 1*DIGIT", first),
+        ));
     }
 
     // The square brackets. A `first-pos` with no `last-pos` after it is the whole
@@ -422,18 +417,18 @@ fn validate_bytes_range_spec(spec: &str) -> Result<(), Defect> {
         return Ok(());
     }
     if !is_digits(last) {
-        return Err(Defect::unnamed(format!(
-            "last-pos '{}' is not 1*DIGIT",
-            last
-        )));
+        return Err(Defect::named(
+            &RANGE_POSITION_MALFORMED,
+            format!("last-pos '{}' is not 1*DIGIT", last),
+        ));
     }
 
     // cite(RFC 9110 § 14.1.1): "An int-range is invalid if the last-pos value is present and less than the first-pos."
     if is_less_than(last, first) {
-        return Err(Defect::unnamed(format!(
-            "last-pos {} is less than first-pos {}",
-            last, first
-        )));
+        return Err(Defect::named(
+            &RANGE_POSITIONS_CONFLICTING,
+            format!("last-pos {} is less than first-pos {}", last, first),
+        ));
     }
     Ok(())
 }
@@ -556,21 +551,22 @@ mod tests {
     }
 
     /// The two floors of `1#range-spec`, answering with the ids every other
-    /// list-valued field answers with, and the verdicts that stay this
-    /// section's. The last row is the one worth reading twice: the arithmetic
-    /// is `Content-Range`'s too and the sentence is not, so the id the
-    /// catalogue already holds for that field is not borrowed here.
+    /// list-valued field answers with, and the verdicts that are this section's
+    /// own. The last row is the one worth reading twice: the arithmetic is
+    /// `Content-Range`'s too and the sentence is not, so that field's id is not
+    /// borrowed here — the two run in opposite directions and cite different
+    /// sections.
     #[rstest]
     #[case("bytes=", "list_member_missing")]
     #[case("items=", "list_member_missing")]
     #[case("bytes=1-2,,3-4", "list_member_empty")]
     #[case("bytes=1-2,", "list_member_empty")]
-    #[case("items=0 1", "")]
-    #[case("bytes=abc", "")]
-    #[case("bytes=-", "")]
-    #[case("bytes=a-5", "")]
-    #[case("bytes=5-a", "")]
-    #[case("bytes=5-3", "")]
+    #[case("items=0 1", "range_spec_character_forbidden")]
+    #[case("bytes=abc", "range_spec_malformed")]
+    #[case("bytes=-", "range_position_malformed")]
+    #[case("bytes=a-5", "range_position_malformed")]
+    #[case("bytes=5-a", "range_position_malformed")]
+    #[case("bytes=5-3", "range_positions_conflicting")]
     fn the_list_construct_is_borrowed_and_the_specifier_is_not(
         #[case] value: &str,
         #[case] id: &str,

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -64,6 +64,7 @@ pub mod parameter;
 pub mod quoted_pair;
 pub mod quoted_string;
 pub mod qvalue;
+pub mod range;
 pub mod request_target;
 pub mod sec_websocket_accept;
 pub mod sec_websocket_extensions;
@@ -434,7 +435,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 240;
+        const FLOOR: usize = 244;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/range.rs
+++ b/lint-http-rules/src/violations/range.rs
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `Range` defects — what a client asks for, in the units the request names.
+//!
+//! The mirror of [`content_range`](crate::violations::content_range), and the
+//! two subjects are worth reading side by side: the same numerals, the same
+//! backwards range, and two sections stating them once each because a request
+//! asking for octets and a response describing octets are not the same message.
+//! **A requirement written once per direction is two entries**, which is the
+//! opposite of a requirement written once per protocol version — there the
+//! defect is one and the entry names both sections.
+//!
+//! `Range = ranges-specifier`, and `ranges-specifier = range-unit "="
+//! range-set` with `range-set = 1#range-spec`. So the list construct's two
+//! floors are [`list`](crate::violations::list)'s, reported here with the ids
+//! any other `1#` field reports them with, and everything below the `=` is this
+//! subject's.
+//!
+//! **The unit decides how much of a specifier can be read.** § 14.1.1 writes a
+//! generic `range-spec` whose third alternative, `other-range`, is any run of
+//! `%x21-2B / %x2D-7E` — everything visible except the comma that separates
+//! members — and each unit supplies the meaning. For `bytes` the specification
+//! withdraws that alternative outright, so a specifier that is neither an
+//! `int-range` nor a `suffix-range` derives from nothing. **The octet entry
+//! applies to every unit and the three below it only to `bytes`**, which is why
+//! the first is about a character and the rest are about arithmetic.
+//!
+//! Not here: whether the range can be satisfied. A `suffix-length` of zero and a
+//! `first-pos` past the end of the representation are both inside the production
+//! and outside what the representation holds — questions about a document this
+//! request has not seen.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// The field's grammar: the generic specifier, the two `bytes` forms under it,
+/// and the sentence that makes a backwards `int-range` invalid.
+pub const RFC_9110_14_1_1: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("14.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.1.1",
+    note: "Range Specifiers: `ranges-specifier = range-unit \"=\" range-set`, and the grammar under it is generic — each range unit says which of `int-range`, `suffix-range` and `other-range` its specifiers may use. A ranges-specifier is invalid when it holds a range-spec \"that is invalid or undefined for the indicated range-unit\", which is the sentence every check here rests on and the one that bounds them to the unit the rule knows",
+};
+
+/// What the `bytes` unit means by a specifier, and the alternative it withdraws.
+pub const RFC_9110_14_1_2: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("14.1.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.1.2",
+    note: "Byte Ranges: the two forms the `bytes` unit defines, both `1*DIGIT`, with `other-range` withdrawn for this unit. It also requires recipients to anticipate potentially large decimal numerals and prevent parsing errors due to integer conversion overflows — so positions are compared as digits and no ceiling is imposed — and it defines satisfiability, which is a question about the representation and not about the field",
+};
+
+defects! {
+    /// An octet no `range-spec` admits, whatever the unit is.
+    ///
+    /// The three alternatives are digits, a hyphen, and `other-range`'s
+    /// `%x21-2B / %x2D-7E` — so a space, a control octet or anything at or above
+    /// %x80 is outside all of them at once, and the finding needs no knowledge
+    /// of the unit to be certain. **The comma is not measured here** and cannot
+    /// be: the list has already been cut on it, so no member reaching this entry
+    /// holds one.
+    ///
+    /// `warn`, with the rest of the subject's grammar. A recipient that cannot
+    /// read a `range-spec` ignores the field and sends the whole
+    /// representation, which is a larger response rather than a wrong one.
+    ///
+    // cite(RFC 9110 § 14.1.1, label: other-range octets): "other-range   = 1*( %x21-2B / %x2D-7E )"
+    RANGE_SPEC_CHARACTER_FORBIDDEN = {
+        id: "range_spec_character_forbidden",
+        title: "Range specifier holds an octet no range-spec admits",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_9110_14_1_1],
+    }
+
+    /// A `bytes` specifier that is neither an `int-range` nor a
+    /// `suffix-range` — most often one with no hyphen in it at all.
+    ///
+    /// **The alternative that would have caught it is withdrawn by name.**
+    /// `other-range` is what any other unit falls back on, and § 14.1.2 says
+    /// byte ranges do not use it, so for this one unit a specifier that derives
+    /// from neither numeric form derives from nothing. That is why the entry
+    /// cites the unit's section rather than the grammar's.
+    ///
+    // cite(RFC 9110 § 14.1.2): "Each byte range is expressed as an integer range at some offset, relative to either the beginning (int-range) or end (suffix-range) of the representation data.  Byte ranges do not use the other-range specifier."
+    RANGE_SPEC_MALFORMED = {
+        id: "range_spec_malformed",
+        title: "A bytes range specifier derives from neither of the unit's two forms",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_9110_14_1_2],
+    }
+
+    /// A position that is not `1*DIGIT`: the `first-pos`, the `last-pos`, or the
+    /// `suffix-length` after a leading hyphen.
+    ///
+    /// **One entry for three positions**, because the production is the same one
+    /// written three times and a sender that put a sign or a letter in a
+    /// position made one mistake, not three. Which position it was is in the
+    /// message; the id is what an operator configures, and nobody silences a bad
+    /// `first-pos` while keeping a bad `last-pos`.
+    ///
+    /// An *absent* `last-pos` is not this entry: `int-range = first-pos "-" [
+    /// last-pos ]` brackets it, and a client that omits it is asking for the
+    /// remainder of the representation without needing to know its length.
+    ///
+    // cite(RFC 9110 § 14.1.1, label: range position grammar): "first-pos     = 1*DIGIT last-pos      = 1*DIGIT"
+    RANGE_POSITION_MALFORMED = {
+        id: "range_position_malformed",
+        title: "Range position is not 1*DIGIT",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_9110_14_1_1],
+    }
+
+    /// A `last-pos` below its `first-pos`: a range that runs backwards.
+    ///
+    /// Every octet derives from the production and the arithmetic is what fails,
+    /// which is the same shape
+    /// [`content_range_positions_conflicting`](crate::violations::content_range)
+    /// has one direction over. **Two entries and not one**, because the sentence
+    /// is written once per field — § 14.1.1 for what a client may ask and § 14.4
+    /// for what a server may answer — and an id spelled for one of them would
+    /// name the wrong section on half its findings.
+    ///
+    /// `error`, matching the sibling: the value states something no
+    /// representation can satisfy, and a recipient that acts on it is addressing
+    /// octets in an order the representation does not have.
+    ///
+    // cite(RFC 9110 § 14.1.1): "An int-range is invalid if the last-pos value is present and less than the first-pos."
+    RANGE_POSITIONS_CONFLICTING = {
+        id: "range_positions_conflicting",
+        title: "Range asks for a last-pos below its first-pos",
+        message: "",
+        default_severity: Severity::Error,
+        spec: &[RFC_9110_14_1_1],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::violations::content_range::CONTENT_RANGE_POSITIONS_CONFLICTING;
+
+    /// The backwards range is one defect written once per direction, so the two
+    /// ids rank together and name different sections — which is exactly the
+    /// arrangement a requirement written once per *version* refuses, where one
+    /// entry names both.
+    #[test]
+    fn the_backwards_range_is_two_ids_of_one_rank() {
+        assert_ne!(
+            RANGE_POSITIONS_CONFLICTING.id,
+            CONTENT_RANGE_POSITIONS_CONFLICTING.id
+        );
+        assert_eq!(
+            RANGE_POSITIONS_CONFLICTING.default_severity,
+            CONTENT_RANGE_POSITIONS_CONFLICTING.default_severity
+        );
+        assert_ne!(
+            RANGE_POSITIONS_CONFLICTING.spec[0].section,
+            CONTENT_RANGE_POSITIONS_CONFLICTING.spec[0].section
+        );
+    }
+
+    /// The grammar entries rank below it, and the one that reads a unit's
+    /// withdrawal of `other-range` is the only one citing the unit's section.
+    #[test]
+    fn the_grammar_entries_rank_below_the_arithmetic() {
+        for def in [
+            &RANGE_SPEC_CHARACTER_FORBIDDEN,
+            &RANGE_SPEC_MALFORMED,
+            &RANGE_POSITION_MALFORMED,
+        ] {
+            assert_eq!(def.default_severity, Severity::Warn, "{}", def.id);
+        }
+        assert_eq!(RANGE_SPEC_MALFORMED.spec, [RFC_9110_14_1_2]);
+    }
+}

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -5139,7 +5139,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 175
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 169
+      line: 161
   - label: accept_ranges_and_206_consistent (2)
     section: § 14.2
     snippet: If all of the preconditions are true, the server supports the Range header field for the target resource, the received Range field-value contains a valid ranges-specifier with a range-unit supported for that target resource, and that ranges-specifier is satisfiable with respect to the selected representation, the server SHOULD send a 206 (Partial Content) response with content containing one or more partial representations that correspond to the satisfiable range-spec(s) requested.
@@ -5225,7 +5225,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 155
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 149
+      line: 141
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
       line: 183
   - label: accept_ranges_on_partial_content (4)
@@ -6619,7 +6619,7 @@ sources:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
       line: 109
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 293
+      line: 282
     - file: lint-http-rules/src/violations/content_range.rs
       line: 97
   - label: lint-http-rules/src/helpers/accept_ranges.rs (2)
@@ -6633,7 +6633,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 316
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 294
+      line: 283
   - label: Accept-Ranges grammar
     section: § 14.3
     snippet: Accept-Ranges     = acceptable-ranges acceptable-ranges = 1#range-unit
@@ -6767,7 +6767,7 @@ sources:
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
       line: 288
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 317
+      line: 306
   - label: lint-http-rules/src/helpers/auth.rs (6)
     section: § 5.6.1.1
     snippet: In any production that uses the list construct, a sender MUST NOT generate empty list elements.
@@ -6809,7 +6809,7 @@ sources:
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
       line: 302
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 326
+      line: 315
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 470
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
@@ -6931,7 +6931,7 @@ sources:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 51
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 295
+      line: 284
   - label: ranges-specifier grammar
     section: § 14.1.1
     snippet: ranges-specifier = range-unit "=" range-set
@@ -6939,7 +6939,7 @@ sources:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 50
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 221
+      line: 213
   - label: lint-http-rules/src/helpers/content_range.rs (3)
     section: § 14.1.2
     snippet: In the byte-range syntax, first-pos, last-pos, and suffix-length are expressed as decimal number of octets.  Since there is no predefined limit to the length of content, recipients MUST anticipate potentially large decimal numerals and prevent parsing errors due to integer conversion overflows.
@@ -6947,7 +6947,7 @@ sources:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 338
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 458
+      line: 453
     - file: lint-http-rules/src/violations/content_range.rs
       line: 186
   - label: lint-http-rules/src/helpers/content_range.rs (4)
@@ -7119,7 +7119,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 205
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 210
+      line: 202
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 411
   - label: lint-http-rules/src/helpers/headers.rs (3)
@@ -7263,7 +7263,7 @@ sources:
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
       line: 239
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 318
+      line: 307
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 609
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -7327,7 +7327,7 @@ sources:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 94
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 185
+      line: 177
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
       line: 48
     - file: lint-http-rules/src/violations/token.rs
@@ -8293,99 +8293,107 @@ sources:
     snippet: A ranges-specifier is invalid if it contains any range-spec that is invalid or undefined for the indicated range-unit.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 235
+      line: 227
   - label: range_header_syntax (2)
     section: § 14.1.1
     snippet: An int-range is invalid if the last-pos value is present and less than the first-pos.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 431
+      line: 426
+    - file: lint-http-rules/src/violations/range.rs
+      line: 133
   - label: int-range position grammar
     section: § 14.1.1
     snippet: first-pos     = 1*DIGIT last-pos      = 1*DIGIT
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 381
+      line: 373
+    - file: lint-http-rules/src/violations/range.rs
+      line: 110
   - label: int-range grammar
     section: § 14.1.1
     snippet: int-range     = first-pos "-" [ last-pos ]
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 401
+      line: 393
   - label: other-range grammar
     section: § 14.1.1
     snippet: other-range   = 1*( %x21-2B / %x2D-7E )
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 186
+      line: 178
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 342
+      line: 331
+    - file: lint-http-rules/src/violations/range.rs
+      line: 70
   - label: range-set grammar
     section: § 14.1.1
     snippet: range-set        = 1#range-spec
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 303
+      line: 292
   - label: suffix-length grammar
     section: § 14.1.1
     snippet: suffix-length = 1*DIGIT
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 385
+      line: 377
   - label: suffix-range grammar
     section: § 14.1.1
     snippet: suffix-range  = "-" suffix-length
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 384
+      line: 376
   - label: range_header_syntax (3)
     section: § 14.1.2
     snippet: A client can limit the number of bytes requested without knowing the size of the selected representation.  If the last-pos value is absent, or if the value is greater than or equal to the current length of the representation data, the byte range is interpreted as the remainder of the representation
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 420
+      line: 415
   - label: range_header_syntax (4)
     section: § 14.1.2
     snippet: A client can refer to the last N bytes (N > 0) of the selected representation using a suffix-range.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 389
+      line: 381
   - label: range_header_syntax (5)
     section: § 14.1.2
     snippet: Each byte range is expressed as an integer range at some offset, relative to either the beginning (int-range) or end (suffix-range) of the representation data.  Byte ranges do not use the other-range specifier.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 376
+      line: 368
+    - file: lint-http-rules/src/violations/range.rs
+      line: 88
   - label: range_header_syntax (6)
     section: § 14.1.2
     snippet: 'For a GET request, a valid bytes range-spec is satisfiable if it is either:'
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 260
+      line: 249
   - label: range_header_syntax (7)
     section: § 14.1.2
     snippet: The "bytes" range unit is used to express subranges of a representation data's octet sequence.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 354
+      line: 346
   - label: a bytes range-set the section prints with a leading space
     section: § 14.1.2
     snippet: bytes= 0-999, 4500-5499, -1000
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 297
+      line: 286
   - label: range_header_syntax (8)
     section: § 14.2
     snippet: A client that is requesting multiple ranges SHOULD list those ranges in ascending order (the order in which they would typically be received in a complete representation) unless there is a specific need to request a later part earlier.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 262
+      line: 251
   - label: range_header_syntax (9)
     section: § 14.2
     snippet: A server MUST ignore a Range header field received with a request method that is unrecognized or for which range handling is not defined.  For this specification, GET is the only method for which range handling is defined.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 261
+      line: 250
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
       line: 177
   - label: range_header_syntax (10)
@@ -8393,13 +8401,13 @@ sources:
     snippet: An origin server MUST ignore a Range header field that contains a range unit it does not understand.  A proxy MAY discard a Range header field that contains a range unit it does not understand.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 296
+      line: 285
   - label: Range grammar
     section: § 14.2
     snippet: Range = ranges-specifier
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 220
+      line: 212
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 48
   - label: range_request_and_caching


### PR DESCRIPTION
`violations/range.rs`, and `range_header_syntax` converts whole. Four entries: an octet no `range-spec` admits under any unit, a `bytes` specifier in neither of that unit's two forms, a position that is not `1*DIGIT`, and a `last-pos` below its `first-pos`.

The last one is the mirror of `content_range_positions_conflicting`, and the two stay two. A requirement written once per *direction* is two entries — §14.1.1 says what a client may ask for and §14.4 what a server may answer with, and an id spelled for one of them would name the wrong section on half its findings. That is the opposite of a requirement written once per protocol version, where the defect is one and the entry names both sections.

The three positions are one entry between them: `first-pos`, `last-pos` and `suffix-length` are the same production written three times, and a sender that put a sign in one of them made one mistake. Which position it was stays in the message. The octets and the withdrawn `other-range` do not collapse the same way — an octet outside `%x21-2B / %x2D-7E` fails whatever the unit is, while a specifier deriving from neither numeric form is only a defect because §14.1.2 withdraws the fallback for `bytes` alone, which is why that entry cites the unit's section and the others cite the grammar's.

Citation floor 105 → 104: the site that carried §14.1.1 stood for all four verdicts, three of which now name that section from their entries and one of which names a better one.

Floor: 244 of 252 entries cite a sentence.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
