### PR TITLE
A lifetime nobody meant to write

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1063,6 +1063,10 @@ severity = "warn"
 # ALPN protocol name is not one this deployment serves
 severity = "warn"
 
+[violations.alt_svc_ma_invalid]
+# Alt-Svc states a freshness lifetime that cannot be what was meant
+severity = "warn"
+
 [violations.auth_scheme_character_forbidden]
 # Authentication scheme holds a character outside token
 severity = "warn"

--- a/lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
+++ b/lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
@@ -10,6 +10,7 @@ use crate::helpers::shown::shown_in_finding;
 use crate::helpers::word::token_or_quoted_string;
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::alt_svc::ALT_SVC_MA_INVALID;
 use crate::violations::delta_seconds::{
     DELTA_SECONDS_CHARACTER_FORBIDDEN, DELTA_SECONDS_EMPTY, RFC_9111_1_2_2,
 };
@@ -72,41 +73,35 @@ const RFC_7838_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
         "Caching Alt-Svc Header Field Values — what the `ma` parameter's delta-seconds value means",
 };
 
-/// The two halves of `1*DIGIT`, and nothing else.
+/// The two halves of `1*DIGIT`, and what a conforming value can still be.
 ///
 /// RFC 7838 § 3.1 gives `ma` a `delta-seconds` value by importing the
 /// production, so both ways of failing it are the production's defects and
 /// neither is this field's — the same arithmetic `Age` and `max-age` carry, in
-/// a parameter of an alternative service. What stays the rule's own is
-/// everything `ma` *means*: a lifetime of zero, and a lifetime so long it is a
-/// typo. Those two have no sentence to cite and no subject to belong to, which
-/// is why this judge is half converted and says so in its type.
-static DECLARED: &[&ViolationDef] = &[&DELTA_SECONDS_EMPTY, &DELTA_SECONDS_CHARACTER_FORBIDDEN];
+/// a parameter of an alternative service. What `ma` *means* is the field's, and
+/// it is one entry rather than two: a lifetime of zero and a lifetime so long it
+/// is a typo are both conforming values that state nothing a client can use, and
+/// the number written is not the number meant either way.
+static DECLARED: &[&ViolationDef] = &[
+    &ALT_SVC_MA_INVALID,
+    &DELTA_SECONDS_EMPTY,
+    &DELTA_SECONDS_CHARACTER_FORBIDDEN,
+];
 
-/// One finding from the reading, and the def that names it where the catalogue
-/// has one.
+/// One finding from the reading, and the entry it reports as.
 ///
-/// The shape `expect_header_valid` settled and `alt_svc_header_syntax` uses one
-/// file over: a judge that is half converted carries the `Option` rather than
-/// pretending either half.
+/// The shape `expect_header_valid` settled and `alt_svc_header_syntax` still
+/// carries one file over — **without the `Option` here**, now that what `ma`
+/// means has a subject of its own and every arm of this judge names an entry.
 struct Defect {
-    def: Option<&'static ViolationDef>,
+    def: &'static ViolationDef,
     message: String,
 }
 
 impl Defect {
     /// A defect the catalogue names.
     fn named(def: &'static ViolationDef, message: String) -> Self {
-        Self {
-            def: Some(def),
-            message,
-        }
-    }
-
-    /// A defect no subject has claimed, reported at the rule's severity the way
-    /// every finding here was before the catalogue existed.
-    fn unnamed(message: String) -> Self {
-        Self { def: None, message }
+        Self { def, message }
     }
 }
 
@@ -287,10 +282,7 @@ impl Rule for AltSvcH3AdvertisementValid {
                 }
 
                 if let Some(defect) = h3_ma_defect(parameters) {
-                    return Some(match defect.def {
-                        Some(def) => ctx.report_with(def, defect.message),
-                        None => self.violation(ctx.severity, defect.message),
-                    });
+                    return Some(ctx.report_with(defect.def, defect.message));
                 }
             }
 
@@ -373,20 +365,28 @@ fn h3_ma_defect(parameters: &[&str]) -> Option<Defect> {
         // cite(RFC 9111 § 1.2.2): "or the greatest positive integer it can conveniently represent."
         let n = seconds.parse::<u64>().unwrap_or(u64::MAX);
 
+        // The two ends of one entry: a lifetime of zero and a lifetime past any
+        // deployment's horizon are both conforming `delta-seconds` and neither
+        // is a number a sender meant to write.
         if n == 0 {
-            return Some(Defect::unnamed(
+            return Some(Defect::named(
+                &ALT_SVC_MA_INVALID,
                 "Alt-Svc h3 entry has 'ma=0' which immediately invalidates the advertisement (RFC 7838 §3.1)"
                     .into(),
             ));
         }
         // Heuristic ceiling, not spec-derived: RFC 7838 places no upper bound
-        // on `ma` (see MAX_REASONABLE_MA). Flags likely misconfiguration only.
+        // on `ma` (see MAX_REASONABLE_MA). Flags likely misconfiguration only,
+        // which is why the entry it reports carries no reference.
         if n > MAX_REASONABLE_MA {
-            return Some(Defect::unnamed(format!(
-                "Alt-Svc h3 entry has unreasonably large 'ma={}' (exceeds 1 year / {} seconds)",
-                shown_in_finding(&seconds),
-                MAX_REASONABLE_MA
-            )));
+            return Some(Defect::named(
+                &ALT_SVC_MA_INVALID,
+                format!(
+                    "Alt-Svc h3 entry has unreasonably large 'ma={}' (exceeds 1 year / {} seconds)",
+                    shown_in_finding(&seconds),
+                    MAX_REASONABLE_MA
+                ),
+            ));
         }
     }
 
@@ -537,6 +537,9 @@ mod tests {
         )
         .unwrap();
         assert!(v.message.contains("ma=0"));
+        // Both ends of the lifetime report one entry; the message is where they
+        // differ.
+        assert_eq!(v.violation, "alt_svc_ma_invalid");
     }
 
     #[test]
@@ -555,6 +558,7 @@ mod tests {
         )
         .unwrap();
         assert!(v.message.contains("unreasonably large"));
+        assert_eq!(v.violation, "alt_svc_ma_invalid");
     }
 
     /// The message is pinned whole: it is assembled from a prefix and the value

--- a/lint-http-rules/src/violations/alt_svc.rs
+++ b/lint-http-rules/src/violations/alt_svc.rs
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `Alt-Svc` defects — what an alternative service advertisement says beyond
+//! its grammar.
+//!
+//! The field is `1#alt-value`, an `alt-value` is `alternative *( OWS ";" OWS
+//! parameter )`, and almost all of that is borrowed: the list floors are
+//! [`list`](crate::violations::list)'s, the protocol identifier is an
+//! [`alpn`](crate::violations::alpn) name, and a parameter's halves are
+//! [`token`](crate::violations::token) and
+//! [`quoted_string`](crate::violations::quoted_string). The `ma` parameter's
+//! value is a [`delta_seconds`](crate::violations::delta_seconds), read at both
+//! ends of that production.
+//!
+//! **What is left for this subject is what the numbers mean**, and the first
+//! entry is the whole of it: a freshness lifetime that conforms to its
+//! production and cannot be what the sender intended. RFC 7838 sets no bound in
+//! either direction — zero is a legal `delta-seconds` and so is a run of forty
+//! digits — so the entry carries no reference, and the message says which end of
+//! the range the value fell off.
+//!
+//! What `ma` states is the one sentence this subject rests on, and it states a
+//! meaning rather than a bound — which is the whole of the argument for the
+//! entry below carrying no reference.
+//!
+//! **The field's own grammar is not written here yet.** `alt_svc_header_syntax`
+//! reads it in both directions — an `alternative` with no `=`, an empty
+//! `protocol-id`, a percent-encoding this field's one-spelling constraint
+//! forbids, an unterminated DQUOTE — and those are this subject's entries when
+//! that rule converts.
+//
+// cite(RFC 7838 § 3.1): "The delta-seconds value indicates the number of seconds since the response was generated for which the alternative service is considered fresh."
+
+use crate::lint::Severity;
+use crate::violations::defects;
+
+defects! {
+    /// A freshness lifetime that derives from `delta-seconds` and states
+    /// nothing a client can use: `ma=0`, which is stale on arrival, or a value
+    /// so far above any deployment's horizon that it is a typo.
+    ///
+    /// **One entry for both ends, because the sender's mistake is one mistake**
+    /// — the number written is not the number meant — and an operator who wants
+    /// to hear about implausible lifetimes wants to hear about both. The message
+    /// says which end, and for the upper one it names the bound it compared
+    /// against rather than advising a smaller number.
+    ///
+    /// **Uncited, and this is the pair of reasons for it.** RFC 7838 § 3.1 gives
+    /// `ma` a meaning and no bound: zero seconds is a conforming value that says
+    /// the advertisement is already stale, which a sender is entitled to write,
+    /// and nothing published states a maximum — so the upper end is this
+    /// crate's own reading of where a policy stops being one. Both halves are
+    /// sentences that do not exist, which is what an entry with no reference is
+    /// for.
+    ///
+    /// `_invalid` rather than `_malformed`: every octet is a DIGIT and the
+    /// production is satisfied. What fails is the value's usefulness, one level
+    /// past the grammar.
+    ///
+    /// `warn`. Nothing is unreadable and no request is affected — the
+    /// advertisement is simply not one a client will act on, which is a cost to
+    /// the sender rather than to the exchange.
+    ALT_SVC_MA_INVALID = {
+        id: "alt_svc_ma_invalid",
+        title: "Alt-Svc states a freshness lifetime that cannot be what was meant",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The entry that carries no sentence, and the reason it may not gain one
+    /// later: what it reports is a value both of whose ends conform.
+    #[test]
+    fn the_only_entry_here_states_no_sentence() {
+        assert!(ALT_SVC_MA_INVALID.spec.is_empty());
+        assert_eq!(ALT_SVC_MA_INVALID.default_severity, Severity::Warn);
+    }
+}

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -31,6 +31,7 @@ use linkme::distributed_slice;
 use std::sync::LazyLock;
 
 pub mod alpn;
+pub mod alt_svc;
 pub mod auth_scheme;
 pub mod authority;
 pub mod base64;

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -3969,7 +3969,7 @@ sources:
     snippet: Alt-Svc       = clear / 1#alt-value
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 28
+      line: 29
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 132
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
@@ -3979,7 +3979,7 @@ sources:
     snippet: An HTTP(S) origin server can advertise the availability of alternative services to clients by adding an Alt-Svc header field to responses.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 219
+      line: 214
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 667
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
@@ -3989,7 +3989,7 @@ sources:
     snippet: Each "alt-value" is followed by an OPTIONAL semicolon-separated list of additional parameters, each such "parameter" comprising a name and a value.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 320
+      line: 312
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 376
   - label: alt_svc_h3_advertisement_valid (3)
@@ -3997,7 +3997,7 @@ sources:
     snippet: Unknown parameters MUST be ignored.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 44
+      line: 45
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 377
   - label: alt_svc_h3_advertisement_valid (4)
@@ -4005,7 +4005,7 @@ sources:
     snippet: clear         = %s"clear"; "clear", case-sensitive
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 29
+      line: 30
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 133
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
@@ -4017,9 +4017,9 @@ sources:
     snippet: parameter     = token "=" ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 43
+      line: 44
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 319
+      line: 311
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 375
   - label: alt_svc_h3_advertisement_valid (6)
@@ -4027,7 +4027,9 @@ sources:
     snippet: The delta-seconds value indicates the number of seconds since the response was generated for which the alternative service is considered fresh.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 345
+      line: 337
+    - file: lint-http-rules/src/violations/alt_svc.rs
+      line: 34
   - label: alt_svc_header_syntax
     section: § 1.1
     snippet: This document uses the Augmented BNF defined in [RFC5234] and updated by [RFC7405] along with the "#rule" extension defined in Section 7 of [RFC7230].
@@ -7781,7 +7783,7 @@ sources:
     - file: lint-http-rules/src/helpers/vary.rs
       line: 79
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 220
+      line: 215
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 701
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
@@ -9490,7 +9492,7 @@ sources:
     snippet: If a cache receives a delta-seconds value greater than the greatest integer it can represent, or if any of its subsequent calculations overflows, the cache MUST consider the value to be 2147483648
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 372
+      line: 364
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
       line: 270
     - file: lint-http-rules/src/violations/delta_seconds.rs
@@ -9500,7 +9502,7 @@ sources:
     snippet: The delta-seconds rule specifies a non-negative integer, representing time in seconds.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 346
+      line: 338
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
       line: 236
   - label: alt_svc_h3_advertisement_valid (3)
@@ -9508,7 +9510,7 @@ sources:
     snippet: or the greatest positive integer it can conveniently represent.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 373
+      line: 365
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
       line: 271
   - label: cache_coherence
@@ -10729,7 +10731,7 @@ sources:
     snippet: An HTTP origin can advertise the availability of an equivalent HTTP/3 endpoint via the Alt-Svc HTTP response header field or the HTTP/2 ALTSVC frame ([ALTSVC]) using the "h3" ALPN token.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 273
+      line: 268
   - label: authority
     section: § 4.3.1
     snippet: The authority MUST NOT include the deprecated userinfo subcomponent for URIs of scheme "http" or "https".


### PR DESCRIPTION
`alt_svc_h3_advertisement_valid` converts whole with one entry: a freshness lifetime that derives from `delta-seconds` and states nothing a client can use.

Both ends of it, in one entry. `ma=0` is stale on arrival and `ma=99999999` is a typo, and the sender's mistake is the same mistake — the number written is not the number meant — so an operator who wants to hear about implausible lifetimes wants to hear about both. The message says which end the value fell off, and for the upper one it names the bound it compared against rather than advising a smaller number.

Uncited, and both halves are why. RFC 7838 §3.1 gives `ma` a meaning and no bound: zero is a conforming value a sender is entitled to write, and nothing published states a maximum, so the ceiling is this crate's own reading of where a policy stops being one. `_invalid` rather than `_malformed`, since every octet is a DIGIT and what fails is one level past the grammar.

That sentence is also the file's only citation. The ratchet asks every subject file for one whether or not its entries carry references, and what the module quotes is exactly the sentence its argument rests on: `ma` states a meaning, not a bound.

Catalogue 253; the spec floor does not move.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
