### PR TITLE
The keyword beside what it invalidates

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1063,6 +1063,10 @@ severity = "warn"
 # ALPN protocol name is not one this deployment serves
 severity = "warn"
 
+[violations.alt_svc_clear_conflicting]
+# Alt-Svc carries the clear keyword beside an alternative service
+severity = "error"
+
 [violations.alt_svc_ma_invalid]
 # Alt-Svc states a freshness lifetime that cannot be what was meant
 severity = "warn"

--- a/docs/rules/alt_svc_header_syntax.md
+++ b/docs/rules/alt_svc_header_syntax.md
@@ -36,7 +36,7 @@ parameter     = token "=" ( token / quoted-string )
 
 ## Specifications
 
-- [RFC 7838 §3](https://www.rfc-editor.org/rfc/rfc7838.html#section-3): The Alt-Svc HTTP Header Field: the field's grammar, the `clear` keyword, the three percent-encoding constraints on a protocol-id, and the prose requiring a colon and a port inside the alt-authority
+- [RFC 7838 §3](https://www.rfc-editor.org/rfc/rfc7838.html#section-3): The Alt-Svc HTTP Header Field: `Alt-Svc = clear / 1#alt-value` and the productions under it, the case-sensitive `clear` keyword, the three percent-encoding constraints on a `protocol-id`, and the prose requiring a colon and a port inside the `alt-authority`
 - [RFC 7838 §3.1](https://www.rfc-editor.org/rfc/rfc7838.html#section-3.1): Caching Alt-Svc Header Field Values: `persist = "1"` is the whole syntax of that parameter, and clients ignore any other value
 - [RFC 7838 §1.1](https://www.rfc-editor.org/rfc/rfc7838.html#section-1.1): Notational Conventions: the field's terminals — `OWS`, `port`, `quoted-string`, `token`, `uri-host` — and the `#rule` extension are imported from RFC 7230, whose §3.2.3, §2.7, §3.2.6 and §7 are carried unchanged by RFC 9110 §5.6.3, §4.1, §5.6.4, §5.6.2 and §5.6.1
 - [RFC 7838 §8](https://www.rfc-editor.org/rfc/rfc7838.html#section-8): Internationalization Considerations: an internationalized domain name in this field is written as A-labels

--- a/lint-http-rules/src/rules/alt_svc_header_syntax.rs
+++ b/lint-http-rules/src/rules/alt_svc_header_syntax.rs
@@ -11,6 +11,7 @@ use crate::helpers::shown::{describe_char, shown_in_finding};
 use crate::helpers::word::{token_or_quoted_string, WordDefect};
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::alt_svc::{ALT_SVC_CLEAR_CONFLICTING, RFC_7838_3};
 use crate::violations::list::{
     LIST_MEMBER_EMPTY, LIST_MEMBER_MISSING, RFC_9110_5_6_1_1, RFC_9110_5_6_1_2,
 };
@@ -31,7 +32,12 @@ use crate::violations::uri::{
 };
 use crate::violations::ViolationDef;
 
-/// Sixteen defects over four subjects, and RFC 7838 defines not one of them.
+/// Seventeen defects over five subjects, and RFC 7838 defines one of them.
+///
+/// The one is the field's own: `Alt-Svc` is an alternation at the top, and a
+/// value carrying both of its halves is a state the document names. Everything
+/// else here is imported, and the paragraph below is where each import comes
+/// from.
 ///
 /// § 1.1 says where the notation comes from and § 3 says where the productions
 /// do: the `#rule` extension is RFC 7230 § 7's, whose sender requirement is the
@@ -41,15 +47,16 @@ use crate::violations::ViolationDef;
 /// `port` out of RFC 3986. So an `alt-authority` of `"a]b:443"` reports the
 /// same defect a `Forwarded` `for=` and a `Warning`'s `warn-agent` do.
 ///
-/// **Fifteen findings stay this document's, which is more than are named.**
+/// **Fourteen findings stay this document's and are not named yet.**
 /// Six are the two `=` delimiters RFC 7838 prints and the whitespace it does
 /// *not*; two are the ALPN name's percent-encoding spelling, which is this
 /// field's alone; two are `alt-authority`'s prose, which requires the colon and
 /// the port the ABNF leaves optional; one is a port outside the sixteen-bit
 /// namespace an ALPN name implies; one is `persist`'s single literal; one is
-/// § 8's A-labels; one is the case-sensitive spelling of `clear`; and one is
-/// `clear` beside an alternative, which is the alternation at the top of the
-/// field. Every one is a sentence about `Alt-Svc` and no other field.
+/// § 8's A-labels; and one is the case-sensitive spelling of `clear`. Every one
+/// is a sentence about `Alt-Svc` and no other field, so every one of them is
+/// the `alt_svc` subject's — the fifteenth was, and it went first because the
+/// document states the recipient behaviour that ranks it.
 ///
 /// **`parameter_equals_missing` and `parameter_equals_whitespace_forbidden` are
 /// refused, for the second commit running.** RFC 7838 § 3's `parameter` is not
@@ -70,6 +77,7 @@ use crate::violations::ViolationDef;
 /// because a literal that never closes leaves the composition with no port to
 /// find and is reported as that instead.
 static DECLARED: &[&ViolationDef] = &[
+    &ALT_SVC_CLEAR_CONFLICTING,
     &LIST_MEMBER_EMPTY,
     &LIST_MEMBER_MISSING,
     &TOKEN_EMPTY,
@@ -558,12 +566,11 @@ fn check_alt_value(member: &str) -> Option<Defect> {
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_7838_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 7838",
-    section: Some("3"),
-    url: "https://www.rfc-editor.org/rfc/rfc7838.html#section-3",
-    note: "The Alt-Svc HTTP Header Field: the field's grammar, the `clear` keyword, the three percent-encoding constraints on a protocol-id, and the prose requiring a colon and a port inside the alt-authority",
-};
+///
+/// § 3 is not among them: it belongs to the entry that names it, so it is
+/// defined in `violations/alt_svc.rs` beside that entry's quote and imported
+/// back here. A reference on a def and a reference in `specifications()` are
+/// compared by value, so there is one definition or there is a silent split.
 const RFC_7838_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 7838",
     section: Some("3.1"),
@@ -733,10 +740,11 @@ impl Rule for AltSvcHeaderSyntax {
 
             // The parenthetical is the finding, and it is the document's own word
             // for this state: `clear` is the whole field value or it is nothing.
-            // cite(RFC 7838 § 3): "A field value containing the special value "clear" indicates that the origin requests all alternatives for that origin to be invalidated (including those specified in the same response, in case of an invalid reply containing both "clear" and alternative services)."
+            // The sentence saying so is on the entry, with the recipient
+            // behaviour that ranks it above everything else this rule reports.
             if members.contains(&CLEAR) {
-                return Some(self.cited(&RFC_7838_3,
-                    severity,
+                return Some(ctx.report_with(
+                    &ALT_SVC_CLEAR_CONFLICTING,
                     format!(
                         "Alt-Svc response carries both the keyword `clear` and alternative services ('{}'). `Alt-Svc = clear / 1#alt-value` is an alternation, so a value holding both derives from neither half -- the document calls this an invalid reply and has a client invalidate the alternatives named beside the keyword",
                         shown_in_finding(value)
@@ -848,14 +856,15 @@ mod tests {
     /// a test asserting `is_some` cannot see the two disagree.
     ///
     /// The third column is the defect the finding reports as, and the table
-    /// splits cleanly in two. A named row is a production RFC 7838 imports —
-    /// the list, the `token`, the `quoted-string`, the `uri-host`, the `port`,
-    /// the `pct-encoded` triplet — and the id is the one every other reader of
-    /// that production answers with. An empty row is a sentence RFC 7838 writes
-    /// about `Alt-Svc` and nothing else: which of its `=` delimiters are
-    /// mandatory, that it prints no whitespace beside them, how an ALPN name is
-    /// spelled, what `persist` means, and that `clear` is the whole value or
-    /// none of it.
+    /// splits cleanly in three. Most named rows are a production RFC 7838
+    /// imports — the list, the `token`, the `quoted-string`, the `uri-host`,
+    /// the `port`, the `pct-encoded` triplet — and the id is the one every
+    /// other reader of that production answers with. One named row is the
+    /// field's own, `alt_svc_clear_conflicting`, which no other field can
+    /// report. An empty row is a sentence RFC 7838 writes about `Alt-Svc` and
+    /// nothing else, waiting for the entry that will hold it: which of its `=`
+    /// delimiters are mandatory, that it prints no whitespace beside them, how
+    /// an ALPN name is spelled, and what `persist` means.
     #[rstest]
     #[case(
         "h2=example.com:443",
@@ -936,7 +945,7 @@ mod tests {
     #[case(
         "clear, h2=\":443\"",
         "both the keyword `clear` and alternative services",
-        ""
+        "alt_svc_clear_conflicting"
     )]
     #[case("CLEAR", "case-sensitive string", "")]
     #[case(",", "empty field value", "list_member_missing")]

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1390,7 +1390,13 @@ severity = "warn"
         /// § 14.1.1 and one naming the unit's own section, so every one of those
         /// findings is still cited and one of them is cited more precisely than
         /// the site ever was.
-        const FLOOR: usize = 104;
+        /// **`alt_svc_clear_conflicting` took the next one, and it is the plain
+        /// shape**: one site, one sentence, one entry naming it. RFC 7838 § 3's
+        /// parenthetical moved from the site to the def, the finding still
+        /// carries the reference, and `alt_svc_header_syntax` — a rule with
+        /// fourteen findings this document writes about its own field — now has
+        /// no cited site left to lose.
+        const FLOOR: usize = 103;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/violations/alt_svc.rs
+++ b/lint-http-rules/src/violations/alt_svc.rs
@@ -14,29 +14,73 @@
 //! value is a [`delta_seconds`](crate::violations::delta_seconds), read at both
 //! ends of that production.
 //!
-//! **What is left for this subject is what the numbers mean**, and the first
-//! entry is the whole of it: a freshness lifetime that conforms to its
-//! production and cannot be what the sender intended. RFC 7838 sets no bound in
-//! either direction — zero is a legal `delta-seconds` and so is a run of forty
-//! digits — so the entry carries no reference, and the message says which end of
-//! the range the value fell off.
+//! **What is left is what the field states above its grammar**, and the two
+//! entries below are at opposite ends of it. One is the top production's
+//! alternation, where the document names the state it forbids and says what a
+//! recipient does about it. The other is what a number means: a freshness
+//! lifetime that conforms to `delta-seconds` and cannot be what the sender
+//! intended. RFC 7838 sets no bound in either direction — zero is a legal
+//! `delta-seconds` and so is a run of forty digits — so that entry carries no
+//! reference, and the message says which end of the range the value fell off.
 //!
-//! What `ma` states is the one sentence this subject rests on, and it states a
-//! meaning rather than a bound — which is the whole of the argument for the
-//! entry below carrying no reference.
+//! What `ma` states is a meaning rather than a bound, which is the whole of the
+//! argument for the uncited entry; the alternation, by contrast, is a sentence,
+//! and the entry naming it is cited on every finding.
 //!
-//! **The field's own grammar is not written here yet.** `alt_svc_header_syntax`
-//! reads it in both directions — an `alternative` with no `=`, an empty
-//! `protocol-id`, a percent-encoding this field's one-spelling constraint
-//! forbids, an unterminated DQUOTE — and those are this subject's entries when
-//! that rule converts.
+//! **The field's own grammar is only partly written here.** The top
+//! production's alternation is, because a value holding both of its halves is
+//! a state the document names in its own words. The rest —
+//! `alt_svc_header_syntax`'s reading of an `alternative` with no `=`, a
+//! percent-encoding this field's one-spelling constraint forbids, an
+//! `alt-authority` naming no port — is this subject's too and is not written
+//! yet.
 //
 // cite(RFC 7838 § 3.1): "The delta-seconds value indicates the number of seconds since the response was generated for which the alternative service is considered fresh."
 
 use crate::lint::Severity;
+use crate::rules::SpecRef;
 use crate::violations::defects;
 
+/// The field: its grammar, the `clear` keyword, and what a recipient does with
+/// a value carrying that keyword beside an alternative service.
+pub const RFC_7838_3: SpecRef = SpecRef {
+    spec: "RFC 7838",
+    section: Some("3"),
+    url: "https://www.rfc-editor.org/rfc/rfc7838.html#section-3",
+    note: "The Alt-Svc HTTP Header Field: `Alt-Svc = clear / 1#alt-value` and the productions under it, the case-sensitive `clear` keyword, the three percent-encoding constraints on a `protocol-id`, and the prose requiring a colon and a port inside the `alt-authority`",
+};
+
 defects! {
+    /// The keyword and an alternative service in one field value.
+    ///
+    /// `Alt-Svc = clear / 1#alt-value` is an alternation, so a value holding
+    /// both halves derives from neither — and the document does not leave that
+    /// to a reader to work out. It names the state in a parenthetical, calls it
+    /// an invalid reply, and says what a client does with it: invalidate every
+    /// alternative for the origin, *including the ones written beside the
+    /// keyword*.
+    ///
+    /// `_conflicting` because both halves are readable and each one contradicts
+    /// the other. Nothing is malformed at the octet level, nothing is missing,
+    /// and neither half is forbidden on its own — what fails is that one field
+    /// value says two things a recipient cannot both act on.
+    ///
+    /// **`error`, and it is the one entry in this subject that outranks its
+    /// rule.** Every other defect in an `Alt-Svc` costs the sender the one
+    /// alternative it is written in; this one costs the sender all of them,
+    /// because the recipient's defined answer is to discard the alternatives
+    /// this very response was sent to advertise. A field that is otherwise a
+    /// hint here does the opposite of what its sender meant.
+    ///
+    // cite(RFC 7838 § 3): "A field value containing the special value "clear" indicates that the origin requests all alternatives for that origin to be invalidated (including those specified in the same response, in case of an invalid reply containing both "clear" and alternative services)."
+    ALT_SVC_CLEAR_CONFLICTING = {
+        id: "alt_svc_clear_conflicting",
+        title: "Alt-Svc carries the clear keyword beside an alternative service",
+        message: "",
+        default_severity: Severity::Error,
+        spec: &[RFC_7838_3],
+    }
+
     /// A freshness lifetime that derives from `delta-seconds` and states
     /// nothing a client can use: `ma=0`, which is stale on arrival, or a value
     /// so far above any deployment's horizon that it is a typo.
@@ -78,8 +122,19 @@ mod tests {
     /// The entry that carries no sentence, and the reason it may not gain one
     /// later: what it reports is a value both of whose ends conform.
     #[test]
-    fn the_only_entry_here_states_no_sentence() {
+    fn the_uncited_entry_states_no_sentence() {
         assert!(ALT_SVC_MA_INVALID.spec.is_empty());
         assert_eq!(ALT_SVC_MA_INVALID.default_severity, Severity::Warn);
+    }
+
+    /// The two entries are the subject's two ends, and they rank apart for a
+    /// reason the file argues rather than assumes: a value nobody meant costs
+    /// its own alternative, and a value the document calls an invalid reply
+    /// costs every alternative the response carried.
+    #[test]
+    fn the_alternation_outranks_the_lifetime_and_names_its_sentence() {
+        assert_eq!(ALT_SVC_CLEAR_CONFLICTING.default_severity, Severity::Error);
+        assert_eq!(ALT_SVC_CLEAR_CONFLICTING.spec, [RFC_7838_3]);
+        assert!(ALT_SVC_MA_INVALID.default_severity < ALT_SVC_CLEAR_CONFLICTING.default_severity);
     }
 }

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -436,7 +436,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 244;
+        const FLOOR: usize = 245;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1258,7 +1258,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 167
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 171
+      line: 179
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 150
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
@@ -1428,7 +1428,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1142
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 271
+      line: 279
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 356
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
@@ -1448,7 +1448,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1335
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 291
+      line: 299
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 52
     - file: lint-http-rules/src/rules/via_header_syntax.rs
@@ -2453,7 +2453,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1311
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 336
+      line: 344
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 204
   - label: lint-http-rules/src/helpers/uri.rs (2)
@@ -2463,7 +2463,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1310
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 335
+      line: 343
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 203
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
@@ -3964,6 +3964,12 @@ sources:
     cited_by:
     - file: lint-http-rules/src/violations/alpn.rs
       line: 76
+  - label: alt_svc
+    section: § 3
+    snippet: A field value containing the special value "clear" indicates that the origin requests all alternatives for that origin to be invalidated (including those specified in the same response, in case of an invalid reply containing both "clear" and alternative services).
+    cited_by:
+    - file: lint-http-rules/src/violations/alt_svc.rs
+      line: 75
   - label: Alt-Svc grammar
     section: § 3
     snippet: Alt-Svc       = clear / 1#alt-value
@@ -3971,7 +3977,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 29
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 132
+      line: 140
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 27
   - label: alt_svc_h3_advertisement_valid
@@ -3981,7 +3987,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 214
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 667
+      line: 674
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 332
   - label: alt_svc_h3_advertisement_valid (2)
@@ -3991,7 +3997,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 312
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 376
+      line: 384
   - label: alt_svc_h3_advertisement_valid (3)
     section: § 3
     snippet: Unknown parameters MUST be ignored.
@@ -3999,7 +4005,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 45
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 377
+      line: 385
   - label: alt_svc_h3_advertisement_valid (4)
     section: § 3
     snippet: clear         = %s"clear"; "clear", case-sensitive
@@ -4007,9 +4013,9 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 30
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 133
+      line: 141
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 505
+      line: 513
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 372
   - label: alt_svc_h3_advertisement_valid (5)
@@ -4021,7 +4027,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 311
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 375
+      line: 383
   - label: alt_svc_h3_advertisement_valid (6)
     section: § 3.1
     snippet: The delta-seconds value indicates the number of seconds since the response was generated for which the alternative service is considered fresh.
@@ -4029,145 +4035,139 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 337
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 34
+      line: 38
   - label: alt_svc_header_syntax
     section: § 1.1
     snippet: This document uses the Augmented BNF defined in [RFC5234] and updated by [RFC7405] along with the "#rule" extension defined in Section 7 of [RFC7230].
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 751
+      line: 759
   - label: alt_svc_header_syntax (2)
     section: § 2
     snippet: Note that for the purpose of this specification, an ALPN protocol name implicitly includes TLS in the suite of protocols it identifies, unless specified otherwise in its definition.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 334
+      line: 342
   - label: alt_svc_header_syntax (3)
-    section: § 3
-    snippet: A field value containing the special value "clear" indicates that the origin requests all alternatives for that origin to be invalidated (including those specified in the same response, in case of an invalid reply containing both "clear" and alternative services).
-    cited_by:
-    - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 736
-  - label: alt_svc_header_syntax (4)
     section: § 3
     snippet: Alt-Svc MAY occur in any HTTP response message, regardless of the status code.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 684
+      line: 691
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 353
-  - label: alt_svc_header_syntax (5)
+  - label: alt_svc_header_syntax (4)
     section: § 3
     snippet: Consequently, the octet representing the percent character "%" (hex 25) MUST be percent-encoded as well.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 166
-  - label: alt_svc_header_syntax (6)
+      line: 174
+  - label: alt_svc_header_syntax (5)
     section: § 3
     snippet: 'In order to have precisely one way to represent any ALPN protocol name, the following additional constraints apply:'
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 167
-  - label: alt_svc_header_syntax (7)
+      line: 175
+  - label: alt_svc_header_syntax (6)
     section: § 3
     snippet: Note that the "quoted-string" syntax needs to be used because ":" is not an allowed character in "token".
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 235
-  - label: alt_svc_header_syntax (8)
+      line: 243
+  - label: alt_svc_header_syntax (7)
     section: § 3
     snippet: Octets in the ALPN protocol name MUST NOT be percent-encoded if they are valid token characters except "%", and
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 168
-  - label: alt_svc_header_syntax (9)
+      line: 176
+  - label: alt_svc_header_syntax (8)
     section: § 3
     snippet: Octets not allowed in tokens ([RFC7230], Section 3.2.6) MUST be percent-encoded as per Section 2.1 of [RFC3986].
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 165
+      line: 173
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 149
-  - label: alt_svc_header_syntax (10)
+  - label: alt_svc_header_syntax (9)
     section: § 3
     snippet: The "alt-authority" component consists of an OPTIONAL uri-host ("host" in Section 3.2.2 of [RFC3986]), a colon (":"), and a port number.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 234
-  - label: alt_svc_header_syntax (11)
+      line: 242
+  - label: alt_svc_header_syntax (10)
     section: § 3
     snippet: The field value consists either of a list of values, each of which indicates one alternative service, or the keyword "clear".
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 134
+      line: 142
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 28
-  - label: alt_svc_header_syntax (12)
+  - label: alt_svc_header_syntax (11)
     section: § 3
     snippet: When using percent-encoding, uppercase hex digits MUST be used.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 169
-  - label: alt_svc_header_syntax (13)
+      line: 177
+  - label: alt_svc_header_syntax (12)
     section: § 3
     snippet: With these constraints, recipients can apply simple string comparison to match protocol identifiers.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 170
-  - label: alt_svc_header_syntax (14)
+      line: 178
+  - label: alt_svc_header_syntax (13)
     section: § 3
     snippet: alt-authority = quoted-string ; containing [ uri-host ] ":" port
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 233
-  - label: alt_svc_header_syntax (15)
+      line: 241
+  - label: alt_svc_header_syntax (14)
     section: § 3
     snippet: alt-value     = alternative *( OWS ";" OWS parameter )
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 146
+      line: 154
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 393
-  - label: alt_svc_header_syntax (16)
+  - label: alt_svc_header_syntax (15)
     section: § 3
     snippet: alternative   = protocol-id "=" alt-authority
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 498
+      line: 506
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 404
-  - label: alt_svc_header_syntax (17)
+  - label: alt_svc_header_syntax (16)
     section: § 3
     snippet: protocol-id   = token ; percent-encoded ALPN protocol name
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 499
+      line: 507
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 147
-  - label: alt_svc_header_syntax (18)
+  - label: alt_svc_header_syntax (17)
     section: § 3.1
     snippet: Alternative services that are intended to be longer lived (such as those that are not specific to the client access network) can carry the "persist" parameter with a value "1" as a hint that the service is potentially useful beyond a network configuration change.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 469
-  - label: alt_svc_header_syntax (19)
+      line: 477
+  - label: alt_svc_header_syntax (18)
     section: § 3.1
     snippet: Clients MUST ignore "persist" parameters with values other than "1".
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 471
-  - label: alt_svc_header_syntax (20)
+      line: 479
+  - label: alt_svc_header_syntax (19)
     section: § 3.1
     snippet: This specification only defines a single value for "persist".
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 470
-  - label: alt_svc_header_syntax (21)
+      line: 478
+  - label: alt_svc_header_syntax (20)
     section: § 8
     snippet: An internationalized domain name that appears in either the header field (Section 3) or the HTTP/2 frame (Section 4) MUST be expressed using A-labels ([RFC5890], Section 2.3.2.1).
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 270
+      line: 278
   - label: alt_svc_protocol_registered
     section: § 2
     snippet: An Application Layer Protocol Negotiation (ALPN) protocol name, as per [RFC7301]
@@ -5373,7 +5373,7 @@ sources:
     snippet: All HTTP requirements applicable to an origin server also apply to the outbound communication of a gateway.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 668
+      line: 675
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 333
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
@@ -6791,7 +6791,7 @@ sources:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 104
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 752
+      line: 760
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
       line: 103
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
@@ -7251,7 +7251,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 340
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 147
+      line: 155
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 165
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
@@ -7305,7 +7305,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
       line: 155
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 726
+      line: 733
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 601
   - label: lint-http-rules/src/helpers/list.rs (2)
@@ -7367,7 +7367,7 @@ sources:
     - file: lint-http-rules/src/helpers/word.rs
       line: 90
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 236
+      line: 244
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 429
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -7645,7 +7645,7 @@ sources:
     - file: lint-http-rules/src/helpers/word.rs
       line: 89
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 500
+      line: 508
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 411
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
@@ -7785,7 +7785,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 215
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 701
+      line: 708
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 363
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs


### PR DESCRIPTION
`Alt-Svc` is an alternation at the top — `clear / 1#alt-value` — and a value carrying both halves derives from neither. The document does not leave that to a reader: it names the state in a parenthetical, calls it an invalid reply, and says what a client does about it, which is to invalidate every alternative for the origin including the ones written beside the keyword.

`_conflicting`, because both halves are readable and each contradicts the other. Nothing is malformed at the octet level, nothing is missing, and neither half is forbidden on its own — what fails is that one field value says two things a recipient cannot both act on.

`error`, and it is the one entry in this subject that outranks the rule reporting it. Every other defect in this field costs the sender the alternative it is written in; this one costs the sender all of them, because the recipient's defined answer is to discard the very alternatives the response was sent to advertise. That is the rule prose as the evidence for a default, not the `config_example` beside it.

RFC 7838 §3 moves out of the rule and into the subject file, where the entry quoting it lives, and the rule imports it back for `specifications()` — a reference on a def and a reference in that list are compared by value, so there is one definition or there is a silent split.

Catalogue 254, spec floor 245, citation floor 104 → 103: one site, one sentence, one entry naming it, and the finding still carries the reference.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
