### PR TITLE
Delimiters this field prints bare

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1063,12 +1063,24 @@ severity = "warn"
 # ALPN protocol name is not one this deployment serves
 severity = "warn"
 
+[violations.alt_svc_alternative_equals_missing]
+# Alt-Svc alternative has no '=' between its protocol-id and its alt-authority
+severity = "warn"
+
 [violations.alt_svc_clear_conflicting]
 # Alt-Svc carries the clear keyword beside an alternative service
 severity = "error"
 
+[violations.alt_svc_equals_whitespace_forbidden]
+# Alt-Svc writes whitespace beside an '=' its grammar prints bare
+severity = "warn"
+
 [violations.alt_svc_ma_invalid]
 # Alt-Svc states a freshness lifetime that cannot be what was meant
+severity = "warn"
+
+[violations.alt_svc_parameter_equals_missing]
+# Alt-Svc parameter has no '=' and no value
 severity = "warn"
 
 [violations.auth_scheme_character_forbidden]

--- a/lint-http-rules/src/rules/alt_svc_header_syntax.rs
+++ b/lint-http-rules/src/rules/alt_svc_header_syntax.rs
@@ -11,7 +11,10 @@ use crate::helpers::shown::{describe_char, shown_in_finding};
 use crate::helpers::word::{token_or_quoted_string, WordDefect};
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
-use crate::violations::alt_svc::{ALT_SVC_CLEAR_CONFLICTING, RFC_7838_3};
+use crate::violations::alt_svc::{
+    ALT_SVC_ALTERNATIVE_EQUALS_MISSING, ALT_SVC_CLEAR_CONFLICTING,
+    ALT_SVC_EQUALS_WHITESPACE_FORBIDDEN, ALT_SVC_PARAMETER_EQUALS_MISSING, RFC_7838_3,
+};
 use crate::violations::list::{
     LIST_MEMBER_EMPTY, LIST_MEMBER_MISSING, RFC_9110_5_6_1_1, RFC_9110_5_6_1_2,
 };
@@ -32,12 +35,12 @@ use crate::violations::uri::{
 };
 use crate::violations::ViolationDef;
 
-/// Seventeen defects over five subjects, and RFC 7838 defines one of them.
+/// Twenty defects over five subjects, and RFC 7838 defines four of them.
 ///
-/// The one is the field's own: `Alt-Svc` is an alternation at the top, and a
-/// value carrying both of its halves is a state the document names. Everything
-/// else here is imported, and the paragraph below is where each import comes
-/// from.
+/// The four are the field's own: the alternation at the top of it, the two `=`
+/// delimiters it prints and the whitespace it prints nowhere near them.
+/// Everything else here is imported, and the paragraph below is where each
+/// import comes from.
 ///
 /// § 1.1 says where the notation comes from and § 3 says where the productions
 /// do: the `#rule` extension is RFC 7230 § 7's, whose sender requirement is the
@@ -47,24 +50,24 @@ use crate::violations::ViolationDef;
 /// `port` out of RFC 3986. So an `alt-authority` of `"a]b:443"` reports the
 /// same defect a `Forwarded` `for=` and a `Warning`'s `warn-agent` do.
 ///
-/// **Fourteen findings stay this document's and are not named yet.**
-/// Six are the two `=` delimiters RFC 7838 prints and the whitespace it does
-/// *not*; two are the ALPN name's percent-encoding spelling, which is this
-/// field's alone; two are `alt-authority`'s prose, which requires the colon and
-/// the port the ABNF leaves optional; one is a port outside the sixteen-bit
-/// namespace an ALPN name implies; one is `persist`'s single literal; one is
-/// § 8's A-labels; and one is the case-sensitive spelling of `clear`. Every one
-/// is a sentence about `Alt-Svc` and no other field, so every one of them is
-/// the `alt_svc` subject's — the fifteenth was, and it went first because the
-/// document states the recipient behaviour that ranks it.
+/// **Eight findings stay this document's and are not named yet.** Two are the
+/// ALPN name's percent-encoding spelling, which is this field's alone; two are
+/// `alt-authority`'s prose, which requires the colon and the port the ABNF
+/// leaves optional; one is a port outside the sixteen-bit namespace an ALPN
+/// name implies; one is `persist`'s single literal; one is § 8's A-labels; and
+/// one is a semicolon with no parameter behind it. Every one is a sentence
+/// about `Alt-Svc` and no other field, so every one of them is the `alt_svc`
+/// subject's, as the four already there were.
 ///
 /// **`parameter_equals_missing` and `parameter_equals_whitespace_forbidden` are
-/// refused, for the second commit running.** RFC 7838 § 3's `parameter` is not
-/// § 5.6.6's: its value is mandatory where § 5.6.6's is optional, and it prints
-/// no whitespace beside its `=` at all — so where § 5.6.6 tolerates the
-/// whitespace and records the leniency at `info`, this document admits none and
-/// the rule reports it at its own level. Two sentences, two verdicts, and the
-/// rule had already written the difference down for another reason.
+/// refused, and the refusal is now written as two ids rather than as none.**
+/// RFC 7838 § 3's `parameter` is not § 5.6.6's: its value is mandatory where
+/// § 5.6.6's is optional, and it prints no whitespace beside its `=` at all —
+/// so where § 5.6.6 tolerates the whitespace and records the leniency at
+/// `info`, this document admits none and its own entry says so at `warn`. **A
+/// production of the same name in another document is another production**, and
+/// the catalogue can now hold both without either borrowing the other's
+/// sentence.
 ///
 /// **Three of the four `quoted_string_*` entries are declared and unreachable
 /// here, and the reason is a check two levels up.** The field value's quoting
@@ -78,6 +81,9 @@ use crate::violations::ViolationDef;
 /// find and is reported as that instead.
 static DECLARED: &[&ViolationDef] = &[
     &ALT_SVC_CLEAR_CONFLICTING,
+    &ALT_SVC_ALTERNATIVE_EQUALS_MISSING,
+    &ALT_SVC_PARAMETER_EQUALS_MISSING,
+    &ALT_SVC_EQUALS_WHITESPACE_FORBIDDEN,
     &LIST_MEMBER_EMPTY,
     &LIST_MEMBER_MISSING,
     &TOKEN_EMPTY,
@@ -100,8 +106,9 @@ static DECLARED: &[&ViolationDef] = &[
 /// catalogue names that defect.
 ///
 /// The shape `expect_header_valid` settled: a judge that is half converted says
-/// so in its type. Here the halves are almost even — four subjects' ids against
-/// nine sentences this document writes about its own field.
+/// so in its type. Here the halves are five subjects' ids — four imported and
+/// this field's own — against the nine sentences RFC 7838 writes about
+/// `Alt-Svc` that no entry holds yet.
 struct Defect {
     def: Option<&'static ViolationDef>,
     message: String,
@@ -395,24 +402,32 @@ fn check_parameter(shown: &str, parameter: &str) -> Option<Defect> {
     // **Not `parameter_equals_missing`.** That def carries § 5.6.6's
     // `parameter`, whose value the constructs reading it treat as optional --
     // which is the very thing the paragraph above says this production is not.
-    // A def is a sentence, and this field's is its own.
+    // A def is a sentence, and this field's is its own -- so it has one of its
+    // own, and the two ids sit beside each other in the catalogue saying which
+    // document each answers for.
     let Some((name, value)) = parameter.split_once('=') else {
-        return Some(Defect::unnamed(format!(
-            "Alt-Svc parameter '{}' in '{shown}' has no '='. A `parameter` is `token \"=\" ( token / quoted-string )`, so the value and its delimiter are not optional",
-            shown_in_finding(parameter)
-        )));
+        return Some(Defect::named(
+            &ALT_SVC_PARAMETER_EQUALS_MISSING,
+            format!(
+                "Alt-Svc parameter '{}' in '{shown}' has no '='. A `parameter` is `token \"=\" ( token / quoted-string )`, so the value and its delimiter are not optional",
+                shown_in_finding(parameter)
+            ),
+        ));
     };
     //
     // **Not `parameter_equals_whitespace_forbidden` either**, and this is the
     // sharper half of the same refusal: that def is `info`, because § 5.6.6's
     // readers trim the whitespace and publish the leniency. This document
-    // prints no whitespace here to be lenient *about*, so the rule reports it
-    // at its own level rather than at one chosen for a different production.
+    // prints no whitespace here to be lenient *about*, so the finding reports
+    // as this field's own defect at this field's own rank.
     if whitespace_beside_delimiter(name, value) {
-        return Some(Defect::unnamed(format!(
-            "Alt-Svc parameter '{}' in '{shown}' has whitespace beside its '='. `parameter` prints `token \"=\" ( token / quoted-string )` with nothing between the halves and the delimiter, and the only `OWS` this grammar writes sits around the semicolon",
-            shown_in_finding(parameter)
-        )));
+        return Some(Defect::named(
+            &ALT_SVC_EQUALS_WHITESPACE_FORBIDDEN,
+            format!(
+                "Alt-Svc parameter '{}' in '{shown}' has whitespace beside its '='. `parameter` prints `token \"=\" ( token / quoted-string )` with nothing between the halves and the delimiter, and the only `OWS` this grammar writes sits around the semicolon",
+                shown_in_finding(parameter)
+            ),
+        ));
     }
     if name.is_empty() {
         return Some(Defect::named(
@@ -509,22 +524,33 @@ fn check_alt_value(member: &str) -> Option<Defect> {
     let Some((protocol_id, authority)) = alternative.split_once('=') else {
         // `%s"clear"` is case-sensitive, so a case variant is not the
         // keyword -- it is an `alt-value` with no '=' in it, and saying so
-        // is more use to whoever wrote it than the generic verdict.
+        // is more use to whoever wrote it than the generic verdict. **The id
+        // is the same one either way**: what the value is does not change
+        // because a reader can say how its sender got there.
         // cite(RFC 7838 § 3): "clear         = %s"clear"; "clear", case-sensitive"
         if alternative.eq_ignore_ascii_case(CLEAR) {
-            return Some(Defect::unnamed(format!(
-                "Alt-Svc carries '{}' where the keyword is spelled `%s\"clear\"` -- a case-sensitive string, so this value is read as an `alt-value` instead, and an `alt-value` opens with `protocol-id \"=\" alt-authority`",
-                shown_in_finding(alternative)
-            )));
+            return Some(Defect::named(
+                &ALT_SVC_ALTERNATIVE_EQUALS_MISSING,
+                format!(
+                    "Alt-Svc carries '{}' where the keyword is spelled `%s\"clear\"` -- a case-sensitive string, so this value is read as an `alt-value` instead, and an `alt-value` opens with `protocol-id \"=\" alt-authority`",
+                    shown_in_finding(alternative)
+                ),
+            ));
         }
-        return Some(Defect::unnamed(format!(
-            "Alt-Svc alt-value '{shown}' has no '=' in its alternative. `alternative` is `protocol-id \"=\" alt-authority`, so a recipient reading this finds a protocol identifier and no alternative to reach it at"
-        )));
+        return Some(Defect::named(
+            &ALT_SVC_ALTERNATIVE_EQUALS_MISSING,
+            format!(
+                "Alt-Svc alt-value '{shown}' has no '=' in its alternative. `alternative` is `protocol-id \"=\" alt-authority`, so a recipient reading this finds a protocol identifier and no alternative to reach it at"
+            ),
+        ));
     };
     if whitespace_beside_delimiter(protocol_id, authority) {
-        return Some(Defect::unnamed(format!(
-            "Alt-Svc alt-value '{shown}' has whitespace beside the '=' of its alternative. `alternative` prints `protocol-id \"=\" alt-authority` with nothing between the halves and the delimiter, and the only `OWS` this grammar writes sits around the semicolon before a parameter"
-        )));
+        return Some(Defect::named(
+            &ALT_SVC_EQUALS_WHITESPACE_FORBIDDEN,
+            format!(
+                "Alt-Svc alt-value '{shown}' has whitespace beside the '=' of its alternative. `alternative` prints `protocol-id \"=\" alt-authority` with nothing between the halves and the delimiter, and the only `OWS` this grammar writes sits around the semicolon before a parameter"
+            ),
+        ));
     }
     if protocol_id.is_empty() {
         return Some(Defect::named(
@@ -900,7 +926,11 @@ mod tests {
     )]
     #[case("h2=\"a]b:443\"", "is not a `uri-host`", "uri_host_bracket_forbidden")]
     #[case("h2=\"a%zb:443\"", "is not a `uri-host`", "percent_encoding_malformed")]
-    #[case("h2example.com:443", "has no \'=\' in its alternative", "")]
+    #[case(
+        "h2example.com:443",
+        "has no \'=\' in its alternative",
+        "alt_svc_alternative_equals_missing"
+    )]
     #[case("h@=\":443\"", "which is no `tchar`", "token_character_forbidden")]
     #[case("=\":443\"", "empty protocol-id", "token_empty")]
     #[case("x%3dy=\":443\"", "lowercase hex digits", "")]
@@ -919,13 +949,21 @@ mod tests {
         "Percent-encoding incomplete",
         "percent_encoding_digits_missing"
     )]
-    #[case("h2 = \":443\"", "whitespace beside the \'=\'", "")]
+    #[case(
+        "h2 = \":443\"",
+        "whitespace beside the \'=\'",
+        "alt_svc_equals_whitespace_forbidden"
+    )]
     #[case("h2=\":443\"; persist=2", "sets persist to \'2\'", "")]
     #[case("h2=\":443\"; persist=\"0\"", "sets persist to \'0\'", "")]
     #[case("h2=\":443\"; ;", "semicolon with no parameter after it", "")]
-    #[case("h2=\":443\"; ma", "has no \'=\'", "")]
+    #[case("h2=\":443\"; ma", "has no \'=\'", "alt_svc_parameter_equals_missing")]
     #[case("h2=\":443\"; ma=", "has an empty value", "")]
-    #[case("h2=\":443\"; ma = 60", "whitespace beside its \'=\'", "")]
+    #[case(
+        "h2=\":443\"; ma = 60",
+        "whitespace beside its \'=\'",
+        "alt_svc_equals_whitespace_forbidden"
+    )]
     #[case(
         "h2=\":443\"; m@=60",
         "which is no `tchar`",
@@ -947,7 +985,7 @@ mod tests {
         "both the keyword `clear` and alternative services",
         "alt_svc_clear_conflicting"
     )]
-    #[case("CLEAR", "case-sensitive string", "")]
+    #[case("CLEAR", "case-sensitive string", "alt_svc_alternative_equals_missing")]
     #[case(",", "empty field value", "list_member_missing")]
     #[case("h2=\":443\",", "empty list element", "list_member_empty")]
     #[case(

--- a/lint-http-rules/src/violations/alt_svc.rs
+++ b/lint-http-rules/src/violations/alt_svc.rs
@@ -14,8 +14,8 @@
 //! value is a [`delta_seconds`](crate::violations::delta_seconds), read at both
 //! ends of that production.
 //!
-//! **What is left is what the field states above its grammar**, and the two
-//! entries below are at opposite ends of it. One is the top production's
+//! **What is left is what the field states for itself**, and two entries below
+//! are at opposite ends of it. One is the top production's
 //! alternation, where the document names the state it forbids and says what a
 //! recipient does about it. The other is what a number means: a freshness
 //! lifetime that conforms to `delta-seconds` and cannot be what the sender
@@ -27,13 +27,21 @@
 //! argument for the uncited entry; the alternation, by contrast, is a sentence,
 //! and the entry naming it is cited on every finding.
 //!
-//! **The field's own grammar is only partly written here.** The top
-//! production's alternation is, because a value holding both of its halves is
-//! a state the document names in its own words. The rest —
-//! `alt_svc_header_syntax`'s reading of an `alternative` with no `=`, a
-//! percent-encoding this field's one-spelling constraint forbids, an
-//! `alt-authority` naming no port — is this subject's too and is not written
-//! yet.
+//! **The two `=` delimiters are here too, and they are the field's rather than
+//! any production's.** `alternative` and `parameter` each print one, with
+//! nothing beside it: RFC 7838 writes `OWS` in exactly one place — around the
+//! semicolon before a parameter — and the `#rule` it imports writes it around
+//! the commas, both of them gone by the time a half is read. So a delimiter
+//! that is absent and whitespace that is present are two of this document's
+//! sentences, and neither can borrow from
+//! [`parameter`](crate::violations::parameter), whose § 5.6.6 production makes
+//! the value optional and tolerates the whitespace at `info`. **A production of
+//! the same name written in another document is another production.**
+//!
+//! **What is still not written here** is the rest of
+//! `alt_svc_header_syntax`'s reading: a percent-encoding this field's
+//! one-spelling constraint forbids, an `alt-authority` naming no port, and what
+//! `persist` means. Those are this subject's too.
 //
 // cite(RFC 7838 § 3.1): "The delta-seconds value indicates the number of seconds since the response was generated for which the alternative service is considered fresh."
 
@@ -81,6 +89,98 @@ defects! {
         spec: &[RFC_7838_3],
     }
 
+    /// An `alt-value` whose alternative holds no `=`: a protocol identifier
+    /// and nowhere to reach it.
+    ///
+    /// `alternative = protocol-id "=" alt-authority` writes three parts and
+    /// brackets none of them, so a member with no delimiter in it names a
+    /// protocol and no service. What a recipient can do with it is nothing —
+    /// the alternative is dropped, and the response advertises one fewer
+    /// service than it looks like it does.
+    ///
+    /// **A `clear` in the wrong case reports here too, with its own message.**
+    /// `%s"clear"` is RFC 7405's case-sensitive string, so `CLEAR` is not the
+    /// keyword and is read as an `alt-value` like any other — which is exactly
+    /// this defect, reached by a sender who meant something else entirely. The
+    /// message says so; the id says what the value is. **A reading that
+    /// explains how a sender got here is not a second defect**, which is the
+    /// line drawn for the comma in a `Sec-WebSocket-Protocol`.
+    ///
+    /// `warn`, with the rest of the field's grammar: one alternative is lost
+    /// and the exchange is unaffected, because a client that finds no
+    /// alternative it can use goes to the origin.
+    ///
+    // cite(RFC 7838 § 3): "alternative   = protocol-id "=" alt-authority"
+    ALT_SVC_ALTERNATIVE_EQUALS_MISSING = {
+        id: "alt_svc_alternative_equals_missing",
+        title: "Alt-Svc alternative has no '=' between its protocol-id and its alt-authority",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_7838_3],
+    }
+
+    /// A `parameter` whose value and delimiter are both absent: `; ma`.
+    ///
+    /// **Not [`parameter_equals_missing`](crate::violations::parameter), and
+    /// the reason is the whole of this entry.** That def carries RFC 9110
+    /// § 5.6.6's `parameter`, whose `= value` half the constructs reading it
+    /// treat as optional. This document prints `parameter = token "="
+    /// ( token / quoted-string )` with no brackets anywhere in it, so a name on
+    /// its own derives from nothing here and derives perfectly well there. **Two
+    /// documents, one production name, two sentences** — borrowing the id would
+    /// put § 5.6.6's requirement behind a finding § 5.6.6 does not make.
+    ///
+    /// Its own entry rather than the alternative's, for the same reason the two
+    /// are two productions: what is absent differs. An `alternative` with no
+    /// `=` names no service at all; a `parameter` with no `=` names a service
+    /// perfectly well and loses one thing said about it.
+    ///
+    /// `warn`. A recipient that cannot read a parameter drops the alternative
+    /// carrying it, since a member is read as a whole.
+    ///
+    // cite(RFC 7838 § 3): "parameter     = token "=" ( token / quoted-string )"
+    ALT_SVC_PARAMETER_EQUALS_MISSING = {
+        id: "alt_svc_parameter_equals_missing",
+        title: "Alt-Svc parameter has no '=' and no value",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_7838_3],
+    }
+
+    /// Whitespace touching one of the field's two `=` delimiters: `h2 = ":443"`
+    /// or `; ma = 60`.
+    ///
+    /// **One entry for both delimiters**, because what is forbidden is the same
+    /// octet in the same position under the same sentence, and a sender that
+    /// spaced out one of its `=` spaced out the other for the same reason. The
+    /// message says which delimiter it was. **Split where the thing that is
+    /// wrong differs, not where its container does.**
+    ///
+    /// RFC 7838 writes `OWS` in exactly one place — around the semicolon of
+    /// `*( OWS ";" OWS parameter )` — and the `#rule` it imports writes it
+    /// around the commas. Both are consumed before a half reaches a delimiter,
+    /// so whitespace still touching an `=` is admitted by no production of this
+    /// field. **This is the opposite answer to a `BWS`**, which is whitespace a
+    /// grammar prints in order to tolerate; there is none printed here to
+    /// tolerate.
+    ///
+    /// Which is also why this is not
+    /// [`parameter_equals_whitespace_forbidden`](crate::violations::parameter).
+    /// That entry is `info` because § 5.6.6's readers trim the whitespace and
+    /// the specification publishes the leniency. Nothing publishes a leniency
+    /// here, so the defect ranks with the field's other grammar defects at
+    /// `warn` — a recipient reading `h2 ` against `token` finds no `tchar` for
+    /// the space and drops the alternative.
+    ///
+    // cite(RFC 7838 § 3): "alt-value     = alternative *( OWS ";" OWS parameter )"
+    ALT_SVC_EQUALS_WHITESPACE_FORBIDDEN = {
+        id: "alt_svc_equals_whitespace_forbidden",
+        title: "Alt-Svc writes whitespace beside an '=' its grammar prints bare",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_7838_3],
+    }
+
     /// A freshness lifetime that derives from `delta-seconds` and states
     /// nothing a client can use: `ma=0`, which is stale on arrival, or a value
     /// so far above any deployment's horizon that it is a typo.
@@ -125,6 +225,39 @@ mod tests {
     fn the_uncited_entry_states_no_sentence() {
         assert!(ALT_SVC_MA_INVALID.spec.is_empty());
         assert_eq!(ALT_SVC_MA_INVALID.default_severity, Severity::Warn);
+    }
+
+    /// The two delimiters this field prints bare, measured against the
+    /// `parameter` subject they may not borrow from: same shape, different
+    /// document, and the rank is where the difference shows. § 5.6.6's readers
+    /// trim the whitespace and the specification publishes the leniency, so
+    /// that entry is `info`; nothing publishes one here.
+    #[test]
+    fn the_field_writes_its_own_delimiter_entries_rather_than_borrowing() {
+        use crate::violations::parameter::{
+            PARAMETER_EQUALS_MISSING, PARAMETER_EQUALS_WHITESPACE_FORBIDDEN,
+        };
+
+        assert_ne!(
+            ALT_SVC_PARAMETER_EQUALS_MISSING.id,
+            PARAMETER_EQUALS_MISSING.id
+        );
+        assert_eq!(
+            ALT_SVC_EQUALS_WHITESPACE_FORBIDDEN.default_severity,
+            Severity::Warn
+        );
+        assert_eq!(
+            PARAMETER_EQUALS_WHITESPACE_FORBIDDEN.default_severity,
+            Severity::Info
+        );
+        for def in [
+            &ALT_SVC_ALTERNATIVE_EQUALS_MISSING,
+            &ALT_SVC_PARAMETER_EQUALS_MISSING,
+            &ALT_SVC_EQUALS_WHITESPACE_FORBIDDEN,
+        ] {
+            assert_eq!(def.spec, [RFC_7838_3], "{}", def.id);
+            assert_eq!(def.default_severity, Severity::Warn, "{}", def.id);
+        }
     }
 
     /// The two entries are the subject's two ends, and they rank apart for a

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -436,7 +436,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 245;
+        const FLOOR: usize = 248;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1258,7 +1258,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 167
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 179
+      line: 186
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 150
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
@@ -1428,7 +1428,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1142
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 279
+      line: 286
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 356
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
@@ -1448,7 +1448,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1335
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 299
+      line: 306
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 52
     - file: lint-http-rules/src/rules/via_header_syntax.rs
@@ -2453,7 +2453,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1311
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 344
+      line: 351
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 204
   - label: lint-http-rules/src/helpers/uri.rs (2)
@@ -2463,7 +2463,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1310
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 343
+      line: 350
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 203
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
@@ -3969,7 +3969,7 @@ sources:
     snippet: A field value containing the special value "clear" indicates that the origin requests all alternatives for that origin to be invalidated (including those specified in the same response, in case of an invalid reply containing both "clear" and alternative services).
     cited_by:
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 75
+      line: 83
   - label: Alt-Svc grammar
     section: § 3
     snippet: Alt-Svc       = clear / 1#alt-value
@@ -3977,7 +3977,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 29
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 140
+      line: 147
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 27
   - label: alt_svc_h3_advertisement_valid
@@ -3987,7 +3987,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 214
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 674
+      line: 700
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 332
   - label: alt_svc_h3_advertisement_valid (2)
@@ -3997,7 +3997,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 312
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 384
+      line: 391
   - label: alt_svc_h3_advertisement_valid (3)
     section: § 3
     snippet: Unknown parameters MUST be ignored.
@@ -4005,7 +4005,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 45
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 385
+      line: 392
   - label: alt_svc_h3_advertisement_valid (4)
     section: § 3
     snippet: clear         = %s"clear"; "clear", case-sensitive
@@ -4013,9 +4013,9 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 30
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 141
+      line: 148
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 513
+      line: 530
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 372
   - label: alt_svc_h3_advertisement_valid (5)
@@ -4027,7 +4027,9 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 311
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 383
+      line: 390
+    - file: lint-http-rules/src/violations/alt_svc.rs
+      line: 141
   - label: alt_svc_h3_advertisement_valid (6)
     section: § 3.1
     snippet: The delta-seconds value indicates the number of seconds since the response was generated for which the alternative service is considered fresh.
@@ -4035,25 +4037,25 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 337
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 38
+      line: 46
   - label: alt_svc_header_syntax
     section: § 1.1
     snippet: This document uses the Augmented BNF defined in [RFC5234] and updated by [RFC7405] along with the "#rule" extension defined in Section 7 of [RFC7230].
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 759
+      line: 785
   - label: alt_svc_header_syntax (2)
     section: § 2
     snippet: Note that for the purpose of this specification, an ALPN protocol name implicitly includes TLS in the suite of protocols it identifies, unless specified otherwise in its definition.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 342
+      line: 349
   - label: alt_svc_header_syntax (3)
     section: § 3
     snippet: Alt-Svc MAY occur in any HTTP response message, regardless of the status code.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 691
+      line: 717
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 353
   - label: alt_svc_header_syntax (4)
@@ -4061,31 +4063,31 @@ sources:
     snippet: Consequently, the octet representing the percent character "%" (hex 25) MUST be percent-encoded as well.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 174
+      line: 181
   - label: alt_svc_header_syntax (5)
     section: § 3
     snippet: 'In order to have precisely one way to represent any ALPN protocol name, the following additional constraints apply:'
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 175
+      line: 182
   - label: alt_svc_header_syntax (6)
     section: § 3
     snippet: Note that the "quoted-string" syntax needs to be used because ":" is not an allowed character in "token".
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 243
+      line: 250
   - label: alt_svc_header_syntax (7)
     section: § 3
     snippet: Octets in the ALPN protocol name MUST NOT be percent-encoded if they are valid token characters except "%", and
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 176
+      line: 183
   - label: alt_svc_header_syntax (8)
     section: § 3
     snippet: Octets not allowed in tokens ([RFC7230], Section 3.2.6) MUST be percent-encoded as per Section 2.1 of [RFC3986].
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 173
+      line: 180
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 149
   - label: alt_svc_header_syntax (9)
@@ -4093,13 +4095,13 @@ sources:
     snippet: The "alt-authority" component consists of an OPTIONAL uri-host ("host" in Section 3.2.2 of [RFC3986]), a colon (":"), and a port number.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 242
+      line: 249
   - label: alt_svc_header_syntax (10)
     section: § 3
     snippet: The field value consists either of a list of values, each of which indicates one alternative service, or the keyword "clear".
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 142
+      line: 149
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 28
   - label: alt_svc_header_syntax (11)
@@ -4107,41 +4109,45 @@ sources:
     snippet: When using percent-encoding, uppercase hex digits MUST be used.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 177
+      line: 184
   - label: alt_svc_header_syntax (12)
     section: § 3
     snippet: With these constraints, recipients can apply simple string comparison to match protocol identifiers.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 178
+      line: 185
   - label: alt_svc_header_syntax (13)
     section: § 3
     snippet: alt-authority = quoted-string ; containing [ uri-host ] ":" port
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 241
+      line: 248
   - label: alt_svc_header_syntax (14)
     section: § 3
     snippet: alt-value     = alternative *( OWS ";" OWS parameter )
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 154
+      line: 161
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 393
+    - file: lint-http-rules/src/violations/alt_svc.rs
+      line: 175
   - label: alt_svc_header_syntax (15)
     section: § 3
     snippet: alternative   = protocol-id "=" alt-authority
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 506
+      line: 521
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 404
+    - file: lint-http-rules/src/violations/alt_svc.rs
+      line: 113
   - label: alt_svc_header_syntax (16)
     section: § 3
     snippet: protocol-id   = token ; percent-encoded ALPN protocol name
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 507
+      line: 522
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 147
   - label: alt_svc_header_syntax (17)
@@ -4149,25 +4155,25 @@ sources:
     snippet: Alternative services that are intended to be longer lived (such as those that are not specific to the client access network) can carry the "persist" parameter with a value "1" as a hint that the service is potentially useful beyond a network configuration change.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 477
+      line: 492
   - label: alt_svc_header_syntax (18)
     section: § 3.1
     snippet: Clients MUST ignore "persist" parameters with values other than "1".
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 479
+      line: 494
   - label: alt_svc_header_syntax (19)
     section: § 3.1
     snippet: This specification only defines a single value for "persist".
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 478
+      line: 493
   - label: alt_svc_header_syntax (20)
     section: § 8
     snippet: An internationalized domain name that appears in either the header field (Section 3) or the HTTP/2 frame (Section 4) MUST be expressed using A-labels ([RFC5890], Section 2.3.2.1).
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 278
+      line: 285
   - label: alt_svc_protocol_registered
     section: § 2
     snippet: An Application Layer Protocol Negotiation (ALPN) protocol name, as per [RFC7301]
@@ -5373,7 +5379,7 @@ sources:
     snippet: All HTTP requirements applicable to an origin server also apply to the outbound communication of a gateway.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 675
+      line: 701
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 333
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
@@ -6791,7 +6797,7 @@ sources:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 104
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 760
+      line: 786
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
       line: 103
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
@@ -7251,7 +7257,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 340
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 155
+      line: 162
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 165
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
@@ -7305,7 +7311,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
       line: 155
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 733
+      line: 759
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 601
   - label: lint-http-rules/src/helpers/list.rs (2)
@@ -7367,7 +7373,7 @@ sources:
     - file: lint-http-rules/src/helpers/word.rs
       line: 90
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 244
+      line: 251
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 429
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -7645,7 +7651,7 @@ sources:
     - file: lint-http-rules/src/helpers/word.rs
       line: 89
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 508
+      line: 523
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 411
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
@@ -7785,7 +7791,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 215
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 708
+      line: 734
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 363
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs


### PR DESCRIPTION
Three entries for the two `=` RFC 7838 writes, and the argument for all three is that a production of the same name in another document is another production.

`alt_svc_parameter_equals_missing` rather than `parameter_equals_missing`: RFC 9110 §5.6.6's `parameter` brackets its `= value` and the constructs reading it treat the value as optional, where this document brackets nothing. A name on its own derives from nothing here and derives perfectly well there, so borrowing the id would put §5.6.6's requirement behind a finding §5.6.6 does not make. Two documents, one production name, two sentences.

`alt_svc_alternative_equals_missing` is its own entry beside it, because what is absent differs: an `alternative` with no `=` names no service at all, and a `parameter` with no `=` names one perfectly well and loses one thing said about it. A `clear` in the wrong case reports here too, with its own message — `%s"clear"` is case-sensitive, so `CLEAR` is read as an `alt-value` like any other, which is exactly this defect reached by a sender who meant something else. A reading that explains how a sender got here is not a second defect.

`alt_svc_equals_whitespace_forbidden` is one entry for both delimiters, because what is forbidden is the same octet in the same position under the same sentence, and the message says which delimiter it was. Split where the thing that is wrong differs, not where its container does. It is `warn` where `parameter_equals_whitespace_forbidden` is `info`: that entry is lenient because §5.6.6's readers trim and the specification publishes the leniency, and nothing publishes one here.

Catalogue 257, spec floor 248. Nine of this rule's findings are still sentences no entry holds.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
