### PR TITLE
What a parameter can be written without

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1079,8 +1079,16 @@ severity = "warn"
 # Alt-Svc states a freshness lifetime that cannot be what was meant
 severity = "warn"
 
+[violations.alt_svc_parameter_empty]
+# Alt-Svc writes a semicolon with no parameter behind it
+severity = "warn"
+
 [violations.alt_svc_parameter_equals_missing]
 # Alt-Svc parameter has no '=' and no value
+severity = "warn"
+
+[violations.alt_svc_parameter_value_empty]
+# Alt-Svc parameter is written with no value after its '='
 severity = "warn"
 
 [violations.auth_scheme_character_forbidden]

--- a/lint-http-rules/src/rules/alt_svc_header_syntax.rs
+++ b/lint-http-rules/src/rules/alt_svc_header_syntax.rs
@@ -13,7 +13,8 @@ use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
 use crate::violations::alt_svc::{
     ALT_SVC_ALTERNATIVE_EQUALS_MISSING, ALT_SVC_CLEAR_CONFLICTING,
-    ALT_SVC_EQUALS_WHITESPACE_FORBIDDEN, ALT_SVC_PARAMETER_EQUALS_MISSING, RFC_7838_3,
+    ALT_SVC_EQUALS_WHITESPACE_FORBIDDEN, ALT_SVC_PARAMETER_EMPTY, ALT_SVC_PARAMETER_EQUALS_MISSING,
+    ALT_SVC_PARAMETER_VALUE_EMPTY, RFC_7838_3,
 };
 use crate::violations::list::{
     LIST_MEMBER_EMPTY, LIST_MEMBER_MISSING, RFC_9110_5_6_1_1, RFC_9110_5_6_1_2,
@@ -35,12 +36,12 @@ use crate::violations::uri::{
 };
 use crate::violations::ViolationDef;
 
-/// Twenty defects over five subjects, and RFC 7838 defines four of them.
+/// Twenty-two defects over five subjects, and RFC 7838 defines six of them.
 ///
-/// The four are the field's own: the alternation at the top of it, the two `=`
-/// delimiters it prints and the whitespace it prints nowhere near them.
-/// Everything else here is imported, and the paragraph below is where each
-/// import comes from.
+/// The six are the field's own: the alternation at the top of it, the two `=`
+/// delimiters it prints, the whitespace it prints nowhere near them, and the
+/// two halves a parameter can be written without. Everything else here is
+/// imported, and the paragraph below is where each import comes from.
 ///
 /// § 1.1 says where the notation comes from and § 3 says where the productions
 /// do: the `#rule` extension is RFC 7230 § 7's, whose sender requirement is the
@@ -50,24 +51,24 @@ use crate::violations::ViolationDef;
 /// `port` out of RFC 3986. So an `alt-authority` of `"a]b:443"` reports the
 /// same defect a `Forwarded` `for=` and a `Warning`'s `warn-agent` do.
 ///
-/// **Eight findings stay this document's and are not named yet.** Two are the
+/// **Seven findings stay this document's and are not named yet.** Two are the
 /// ALPN name's percent-encoding spelling, which is this field's alone; two are
 /// `alt-authority`'s prose, which requires the colon and the port the ABNF
 /// leaves optional; one is a port outside the sixteen-bit namespace an ALPN
-/// name implies; one is `persist`'s single literal; one is § 8's A-labels; and
-/// one is a semicolon with no parameter behind it. Every one is a sentence
-/// about `Alt-Svc` and no other field, so every one of them is the `alt_svc`
-/// subject's, as the four already there were.
+/// name implies; one is `persist`'s single literal; and one is § 8's A-labels.
+/// Every one is a sentence about `Alt-Svc` and no other field, so every one of
+/// them is the `alt_svc` subject's, as the six already there were.
 ///
-/// **`parameter_equals_missing` and `parameter_equals_whitespace_forbidden` are
-/// refused, and the refusal is now written as two ids rather than as none.**
-/// RFC 7838 § 3's `parameter` is not § 5.6.6's: its value is mandatory where
-/// § 5.6.6's is optional, and it prints no whitespace beside its `=` at all —
-/// so where § 5.6.6 tolerates the whitespace and records the leniency at
-/// `info`, this document admits none and its own entry says so at `warn`. **A
-/// production of the same name in another document is another production**, and
-/// the catalogue can now hold both without either borrowing the other's
-/// sentence.
+/// **Nothing here borrows from the `parameter` subject, and the reason is one
+/// sentence repeated three times.** RFC 7838 § 3's `parameter` is not
+/// § 5.6.6's: its value is mandatory where § 5.6.6's is optional, it prints no
+/// whitespace beside its `=` at all, and the repetition holding it brackets
+/// nothing where § 5.6.6 writes `[ parameter ]`. So a bare name, a spaced-out
+/// `=` and an empty repetition are three defects here and none there, and where
+/// § 5.6.6 tolerates the whitespace at `info` this document admits none and
+/// says so at `warn`. **A production of the same name in another document is
+/// another production**, and the catalogue holds both without either borrowing
+/// the other's sentence.
 ///
 /// **Three of the four `quoted_string_*` entries are declared and unreachable
 /// here, and the reason is a check two levels up.** The field value's quoting
@@ -83,6 +84,8 @@ static DECLARED: &[&ViolationDef] = &[
     &ALT_SVC_CLEAR_CONFLICTING,
     &ALT_SVC_ALTERNATIVE_EQUALS_MISSING,
     &ALT_SVC_PARAMETER_EQUALS_MISSING,
+    &ALT_SVC_PARAMETER_EMPTY,
+    &ALT_SVC_PARAMETER_VALUE_EMPTY,
     &ALT_SVC_EQUALS_WHITESPACE_FORBIDDEN,
     &LIST_MEMBER_EMPTY,
     &LIST_MEMBER_MISSING,
@@ -107,7 +110,7 @@ static DECLARED: &[&ViolationDef] = &[
 ///
 /// The shape `expect_header_valid` settled: a judge that is half converted says
 /// so in its type. Here the halves are five subjects' ids — four imported and
-/// this field's own — against the nine sentences RFC 7838 writes about
+/// this field's own — against the seven sentences RFC 7838 writes about
 /// `Alt-Svc` that no entry holds yet.
 struct Defect {
     def: Option<&'static ViolationDef>,
@@ -393,10 +396,16 @@ fn check_alt_authority(shown: &str, authority: &str) -> Option<Defect> {
 fn check_parameter(shown: &str, parameter: &str) -> Option<Defect> {
     // `*( OWS ";" OWS parameter )` repeats a group holding one parameter,
     // so two adjacent semicolons produce a repetition with nothing in it.
+    // The brackets § 5.6.6 puts around its own `[ parameter ]` are what makes
+    // that conforming there and a defect here, which is why the entry is this
+    // field's rather than that subject's.
     if parameter.is_empty() {
-        return Some(Defect::unnamed(format!(
-            "Alt-Svc alt-value '{shown}' carries a semicolon with no parameter after it. Each repetition of `*( OWS \";\" OWS parameter )` holds one `parameter`, and a `parameter` is a name, an '=' and a value"
-        )));
+        return Some(Defect::named(
+            &ALT_SVC_PARAMETER_EMPTY,
+            format!(
+                "Alt-Svc alt-value '{shown}' carries a semicolon with no parameter after it. Each repetition of `*( OWS \";\" OWS parameter )` holds one `parameter`, and a `parameter` is a name, an '=' and a value"
+            ),
+        ));
     }
     //
     // **Not `parameter_equals_missing`.** That def carries § 5.6.6's
@@ -455,13 +464,16 @@ fn check_parameter(shown: &str, parameter: &str) -> Option<Defect> {
     let unquoted = match token_or_quoted_string(value) {
         Ok(content) => content,
         // The `None` `word_defect` answers, at the third of the six fields that
-        // reach it: what an empty value means is this field's verdict, and the
-        // comment above says so in its own words.
+        // reach it: what an empty value means is this field's verdict, and this
+        // field now has an entry to say it in.
         Err(WordDefect::Empty) => {
-            return Some(Defect::unnamed(format!(
-                "Alt-Svc parameter '{}' in '{shown}' has an empty value. The value half is `token / quoted-string`, and the empty string derives from neither -- a `token` is `1*tchar` and a `quoted-string` is at least its two DQUOTEs",
-                shown_in_finding(name)
-            )))
+            return Some(Defect::named(
+                &ALT_SVC_PARAMETER_VALUE_EMPTY,
+                format!(
+                    "Alt-Svc parameter '{}' in '{shown}' has an empty value. The value half is `token / quoted-string`, and the empty string derives from neither -- a `token` is `1*tchar` and a `quoted-string` is at least its two DQUOTEs",
+                    shown_in_finding(name)
+                ),
+            ))
         }
         Err(WordDefect::NotToken(c)) => {
             return Some(Defect::named(
@@ -956,9 +968,17 @@ mod tests {
     )]
     #[case("h2=\":443\"; persist=2", "sets persist to \'2\'", "")]
     #[case("h2=\":443\"; persist=\"0\"", "sets persist to \'0\'", "")]
-    #[case("h2=\":443\"; ;", "semicolon with no parameter after it", "")]
+    #[case(
+        "h2=\":443\"; ;",
+        "semicolon with no parameter after it",
+        "alt_svc_parameter_empty"
+    )]
     #[case("h2=\":443\"; ma", "has no \'=\'", "alt_svc_parameter_equals_missing")]
-    #[case("h2=\":443\"; ma=", "has an empty value", "")]
+    #[case(
+        "h2=\":443\"; ma=",
+        "has an empty value",
+        "alt_svc_parameter_value_empty"
+    )]
     #[case(
         "h2=\":443\"; ma = 60",
         "whitespace beside its \'=\'",

--- a/lint-http-rules/src/violations/alt_svc.rs
+++ b/lint-http-rules/src/violations/alt_svc.rs
@@ -147,6 +147,64 @@ defects! {
         spec: &[RFC_7838_3],
     }
 
+    /// A repetition of the parameter group holding no parameter: `h2=":443"; ;`
+    /// or a value ending on its semicolon.
+    ///
+    /// **Not [`list_member_empty`](crate::violations::list) and not
+    /// [`parameter`](crate::violations::parameter)'s anything**, and the second
+    /// half of that is the sharper one. § 5.6.6 writes `parameters = *( OWS ";"
+    /// OWS [ parameter ] )` — the brackets are what make `text/plain;` a
+    /// conforming zero-parameter repetition — and RFC 7838 § 3 writes
+    /// `*( OWS ";" OWS parameter )` with no brackets at all. **The same
+    /// repetition written without its brackets is a different production**, so
+    /// what conforms one field over is a defect here, and the entry that would
+    /// have been borrowed does not exist because there is nothing there to
+    /// report.
+    ///
+    /// `_empty` and not `_missing`: the semicolon is the repetition's own
+    /// delimiter, so a sender that wrote one knew a parameter was due and wrote
+    /// none of it.
+    ///
+    /// `warn`, with the rest of the field's grammar — the alternative carrying
+    /// it is what a recipient drops.
+    ///
+    // cite(RFC 7838 § 3): "Each "alt-value" is followed by an OPTIONAL semicolon-separated list of additional parameters, each such "parameter" comprising a name and a value."
+    ALT_SVC_PARAMETER_EMPTY = {
+        id: "alt_svc_parameter_empty",
+        title: "Alt-Svc writes a semicolon with no parameter behind it",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_7838_3],
+    }
+
+    /// An `=` with nothing after it: `ma=`.
+    ///
+    /// The value half is `( token / quoted-string )` and neither alternative
+    /// derives the empty string — a `token` is `1*tchar` and the shortest
+    /// `quoted-string` is its two DQUOTEs. `ma=""` is a different value and
+    /// conforms to the production, whatever the parameter makes of it.
+    ///
+    /// **This entry is the answer to a `None` in a mapping.** The shared reader
+    /// of `( token / quoted-string )` returns no id for an empty value on
+    /// purpose, because what an empty value *means* is the field's to say and
+    /// six fields reach that reader. Here it means an advertisement that named
+    /// a parameter and said nothing with it, which is this document's sentence
+    /// about its own production rather than § 5.6.6's about another one.
+    ///
+    /// `warn`, and beside [`ALT_SVC_PARAMETER_EQUALS_MISSING`] rather than
+    /// folded into it: `docs/development.md` keeps `_missing` and `_empty`
+    /// apart wherever a delimiter can tell them apart, and a sender that wrote
+    /// the `=` knew a value was due.
+    ///
+    // cite(RFC 7838 § 3): "parameter     = token "=" ( token / quoted-string )"
+    ALT_SVC_PARAMETER_VALUE_EMPTY = {
+        id: "alt_svc_parameter_value_empty",
+        title: "Alt-Svc parameter is written with no value after its '='",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_7838_3],
+    }
+
     /// Whitespace touching one of the field's two `=` delimiters: `h2 = ":443"`
     /// or `; ma = 60`.
     ///
@@ -253,11 +311,24 @@ mod tests {
         for def in [
             &ALT_SVC_ALTERNATIVE_EQUALS_MISSING,
             &ALT_SVC_PARAMETER_EQUALS_MISSING,
+            &ALT_SVC_PARAMETER_EMPTY,
+            &ALT_SVC_PARAMETER_VALUE_EMPTY,
             &ALT_SVC_EQUALS_WHITESPACE_FORBIDDEN,
         ] {
             assert_eq!(def.spec, [RFC_7838_3], "{}", def.id);
             assert_eq!(def.default_severity, Severity::Warn, "{}", def.id);
         }
+    }
+
+    /// The pair `docs/development.md` keeps apart wherever a delimiter can tell
+    /// them apart, written here for both of the field's: the `;` of the
+    /// repetition and the `=` of the parameter. A sender that wrote either knew
+    /// something was due after it.
+    #[test]
+    fn each_delimiter_splits_the_absent_from_the_blank() {
+        assert!(ALT_SVC_PARAMETER_EMPTY.id.ends_with("_empty"));
+        assert!(ALT_SVC_PARAMETER_VALUE_EMPTY.id.ends_with("_empty"));
+        assert!(ALT_SVC_PARAMETER_EQUALS_MISSING.id.ends_with("_missing"));
     }
 
     /// The two entries are the subject's two ends, and they rank apart for a

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -436,7 +436,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 248;
+        const FLOOR: usize = 250;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1258,7 +1258,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 167
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 186
+      line: 189
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 150
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
@@ -1428,7 +1428,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1142
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 286
+      line: 289
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 356
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
@@ -1448,7 +1448,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1335
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 306
+      line: 309
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 52
     - file: lint-http-rules/src/rules/via_header_syntax.rs
@@ -2453,7 +2453,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1311
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 351
+      line: 354
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 204
   - label: lint-http-rules/src/helpers/uri.rs (2)
@@ -2463,7 +2463,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1310
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 350
+      line: 353
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 203
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
@@ -3977,7 +3977,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 29
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 147
+      line: 150
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 27
   - label: alt_svc_h3_advertisement_valid
@@ -3987,7 +3987,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 214
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 700
+      line: 712
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 332
   - label: alt_svc_h3_advertisement_valid (2)
@@ -3997,7 +3997,9 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 312
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 391
+      line: 394
+    - file: lint-http-rules/src/violations/alt_svc.rs
+      line: 171
   - label: alt_svc_h3_advertisement_valid (3)
     section: § 3
     snippet: Unknown parameters MUST be ignored.
@@ -4005,7 +4007,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 45
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 392
+      line: 395
   - label: alt_svc_h3_advertisement_valid (4)
     section: § 3
     snippet: clear         = %s"clear"; "clear", case-sensitive
@@ -4013,9 +4015,9 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 30
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 148
+      line: 151
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 530
+      line: 542
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 372
   - label: alt_svc_h3_advertisement_valid (5)
@@ -4027,9 +4029,11 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 311
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 390
+      line: 393
     - file: lint-http-rules/src/violations/alt_svc.rs
       line: 141
+    - file: lint-http-rules/src/violations/alt_svc.rs
+      line: 199
   - label: alt_svc_h3_advertisement_valid (6)
     section: § 3.1
     snippet: The delta-seconds value indicates the number of seconds since the response was generated for which the alternative service is considered fresh.
@@ -4043,19 +4047,19 @@ sources:
     snippet: This document uses the Augmented BNF defined in [RFC5234] and updated by [RFC7405] along with the "#rule" extension defined in Section 7 of [RFC7230].
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 785
+      line: 797
   - label: alt_svc_header_syntax (2)
     section: § 2
     snippet: Note that for the purpose of this specification, an ALPN protocol name implicitly includes TLS in the suite of protocols it identifies, unless specified otherwise in its definition.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 349
+      line: 352
   - label: alt_svc_header_syntax (3)
     section: § 3
     snippet: Alt-Svc MAY occur in any HTTP response message, regardless of the status code.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 717
+      line: 729
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 353
   - label: alt_svc_header_syntax (4)
@@ -4063,31 +4067,31 @@ sources:
     snippet: Consequently, the octet representing the percent character "%" (hex 25) MUST be percent-encoded as well.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 181
+      line: 184
   - label: alt_svc_header_syntax (5)
     section: § 3
     snippet: 'In order to have precisely one way to represent any ALPN protocol name, the following additional constraints apply:'
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 182
+      line: 185
   - label: alt_svc_header_syntax (6)
     section: § 3
     snippet: Note that the "quoted-string" syntax needs to be used because ":" is not an allowed character in "token".
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 250
+      line: 253
   - label: alt_svc_header_syntax (7)
     section: § 3
     snippet: Octets in the ALPN protocol name MUST NOT be percent-encoded if they are valid token characters except "%", and
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 183
+      line: 186
   - label: alt_svc_header_syntax (8)
     section: § 3
     snippet: Octets not allowed in tokens ([RFC7230], Section 3.2.6) MUST be percent-encoded as per Section 2.1 of [RFC3986].
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 180
+      line: 183
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 149
   - label: alt_svc_header_syntax (9)
@@ -4095,13 +4099,13 @@ sources:
     snippet: The "alt-authority" component consists of an OPTIONAL uri-host ("host" in Section 3.2.2 of [RFC3986]), a colon (":"), and a port number.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 249
+      line: 252
   - label: alt_svc_header_syntax (10)
     section: § 3
     snippet: The field value consists either of a list of values, each of which indicates one alternative service, or the keyword "clear".
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 149
+      line: 152
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 28
   - label: alt_svc_header_syntax (11)
@@ -4109,35 +4113,35 @@ sources:
     snippet: When using percent-encoding, uppercase hex digits MUST be used.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 184
+      line: 187
   - label: alt_svc_header_syntax (12)
     section: § 3
     snippet: With these constraints, recipients can apply simple string comparison to match protocol identifiers.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 185
+      line: 188
   - label: alt_svc_header_syntax (13)
     section: § 3
     snippet: alt-authority = quoted-string ; containing [ uri-host ] ":" port
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 248
+      line: 251
   - label: alt_svc_header_syntax (14)
     section: § 3
     snippet: alt-value     = alternative *( OWS ";" OWS parameter )
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 161
+      line: 164
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 393
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 175
+      line: 233
   - label: alt_svc_header_syntax (15)
     section: § 3
     snippet: alternative   = protocol-id "=" alt-authority
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 521
+      line: 533
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 404
     - file: lint-http-rules/src/violations/alt_svc.rs
@@ -4147,7 +4151,7 @@ sources:
     snippet: protocol-id   = token ; percent-encoded ALPN protocol name
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 522
+      line: 534
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 147
   - label: alt_svc_header_syntax (17)
@@ -4155,25 +4159,25 @@ sources:
     snippet: Alternative services that are intended to be longer lived (such as those that are not specific to the client access network) can carry the "persist" parameter with a value "1" as a hint that the service is potentially useful beyond a network configuration change.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 492
+      line: 504
   - label: alt_svc_header_syntax (18)
     section: § 3.1
     snippet: Clients MUST ignore "persist" parameters with values other than "1".
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 494
+      line: 506
   - label: alt_svc_header_syntax (19)
     section: § 3.1
     snippet: This specification only defines a single value for "persist".
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 493
+      line: 505
   - label: alt_svc_header_syntax (20)
     section: § 8
     snippet: An internationalized domain name that appears in either the header field (Section 3) or the HTTP/2 frame (Section 4) MUST be expressed using A-labels ([RFC5890], Section 2.3.2.1).
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 285
+      line: 288
   - label: alt_svc_protocol_registered
     section: § 2
     snippet: An Application Layer Protocol Negotiation (ALPN) protocol name, as per [RFC7301]
@@ -5379,7 +5383,7 @@ sources:
     snippet: All HTTP requirements applicable to an origin server also apply to the outbound communication of a gateway.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 701
+      line: 713
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 333
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
@@ -6797,7 +6801,7 @@ sources:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 104
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 786
+      line: 798
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
       line: 103
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
@@ -7257,7 +7261,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 340
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 162
+      line: 165
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 165
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
@@ -7311,7 +7315,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
       line: 155
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 759
+      line: 771
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 601
   - label: lint-http-rules/src/helpers/list.rs (2)
@@ -7373,7 +7377,7 @@ sources:
     - file: lint-http-rules/src/helpers/word.rs
       line: 90
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 251
+      line: 254
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 429
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -7651,7 +7655,7 @@ sources:
     - file: lint-http-rules/src/helpers/word.rs
       line: 89
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 523
+      line: 535
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 411
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
@@ -7791,7 +7795,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 215
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 734
+      line: 746
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 363
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs


### PR DESCRIPTION
Two entries for the two halves a `parameter` can be missing once its `=` is accounted for, and both of them are this field's rather than the shared subject's.

The repetition is the sharper one. RFC 9110 §5.6.6 writes `parameters = *( OWS ";" OWS [ parameter ] )` — the brackets are what make `text/plain;` a conforming zero-parameter repetition — and RFC 7838 §3 writes `*( OWS ";" OWS parameter )` with no brackets at all. The same repetition written without its brackets is a different production, so a semicolon holding nothing is a defect here and conforming there, and the entry that would have been borrowed does not exist because there is nothing there to report.

`alt_svc_parameter_value_empty` answers a `None` in a mapping. The shared reader of `( token / quoted-string )` returns no id for an empty value on purpose, because what an empty value means is the field's to say and six fields reach that reader; here it means an advertisement that named a parameter and said nothing with it.

Both are `_empty` rather than `_missing`, and the delimiter is why: the `;` of the repetition and the `=` of the parameter were each written by a sender who knew something was due after it.

Catalogue 259, spec floor 250. Seven of this rule's findings are still sentences no entry holds.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
