### PR TITLE
The one parameter with a value of its own

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1091,6 +1091,10 @@ severity = "warn"
 # Alt-Svc parameter is written with no value after its '='
 severity = "warn"
 
+[violations.alt_svc_persist_invalid]
+# Alt-Svc sets persist to a value the parameter does not define
+severity = "info"
+
 [violations.auth_scheme_character_forbidden]
 # Authentication scheme holds a character outside token
 severity = "warn"

--- a/docs/rules/alt_svc_header_syntax.md
+++ b/docs/rules/alt_svc_header_syntax.md
@@ -37,7 +37,7 @@ parameter     = token "=" ( token / quoted-string )
 ## Specifications
 
 - [RFC 7838 §3](https://www.rfc-editor.org/rfc/rfc7838.html#section-3): The Alt-Svc HTTP Header Field: `Alt-Svc = clear / 1#alt-value` and the productions under it, the case-sensitive `clear` keyword, the three percent-encoding constraints on a `protocol-id`, and the prose requiring a colon and a port inside the `alt-authority`
-- [RFC 7838 §3.1](https://www.rfc-editor.org/rfc/rfc7838.html#section-3.1): Caching Alt-Svc Header Field Values: `persist = "1"` is the whole syntax of that parameter, and clients ignore any other value
+- [RFC 7838 §3.1](https://www.rfc-editor.org/rfc/rfc7838.html#section-3.1): Caching Alt-Svc Header Field Values: the `ma` parameter's delta-seconds value states how long the alternative is considered fresh, and `persist` has exactly one defined value — `"1"` — with clients required to ignore any other
 - [RFC 7838 §1.1](https://www.rfc-editor.org/rfc/rfc7838.html#section-1.1): Notational Conventions: the field's terminals — `OWS`, `port`, `quoted-string`, `token`, `uri-host` — and the `#rule` extension are imported from RFC 7230, whose §3.2.3, §2.7, §3.2.6 and §7 are carried unchanged by RFC 9110 §5.6.3, §4.1, §5.6.4, §5.6.2 and §5.6.1
 - [RFC 7838 §8](https://www.rfc-editor.org/rfc/rfc7838.html#section-8): Internationalization Considerations: an internationalized domain name in this field is written as A-labels
 - [RFC 7838 §2](https://www.rfc-editor.org/rfc/rfc7838.html#section-2): Alternative Services Concepts: an alternative service is an ALPN protocol name, an RFC 3986 host and an RFC 3986 port, and the protocol name implies the transport the port is registered in

--- a/lint-http-rules/src/rules/alt_svc_header_syntax.rs
+++ b/lint-http-rules/src/rules/alt_svc_header_syntax.rs
@@ -14,7 +14,7 @@ use crate::rules::{Rule, RuleMeta};
 use crate::violations::alt_svc::{
     ALT_SVC_ALTERNATIVE_EQUALS_MISSING, ALT_SVC_CLEAR_CONFLICTING,
     ALT_SVC_EQUALS_WHITESPACE_FORBIDDEN, ALT_SVC_PARAMETER_EMPTY, ALT_SVC_PARAMETER_EQUALS_MISSING,
-    ALT_SVC_PARAMETER_VALUE_EMPTY, RFC_7838_3,
+    ALT_SVC_PARAMETER_VALUE_EMPTY, ALT_SVC_PERSIST_INVALID, RFC_7838_3, RFC_7838_3_1,
 };
 use crate::violations::list::{
     LIST_MEMBER_EMPTY, LIST_MEMBER_MISSING, RFC_9110_5_6_1_1, RFC_9110_5_6_1_2,
@@ -36,12 +36,13 @@ use crate::violations::uri::{
 };
 use crate::violations::ViolationDef;
 
-/// Twenty-two defects over five subjects, and RFC 7838 defines six of them.
+/// Twenty-three defects over five subjects, and RFC 7838 defines seven of them.
 ///
-/// The six are the field's own: the alternation at the top of it, the two `=`
-/// delimiters it prints, the whitespace it prints nowhere near them, and the
-/// two halves a parameter can be written without. Everything else here is
-/// imported, and the paragraph below is where each import comes from.
+/// The seven are the field's own: the alternation at the top of it, the two `=`
+/// delimiters it prints, the whitespace it prints nowhere near them, the two
+/// halves a parameter can be written without, and the one parameter this
+/// document gives a value to. Everything else here is imported, and the
+/// paragraph below is where each import comes from.
 ///
 /// § 1.1 says where the notation comes from and § 3 says where the productions
 /// do: the `#rule` extension is RFC 7230 § 7's, whose sender requirement is the
@@ -51,13 +52,13 @@ use crate::violations::ViolationDef;
 /// `port` out of RFC 3986. So an `alt-authority` of `"a]b:443"` reports the
 /// same defect a `Forwarded` `for=` and a `Warning`'s `warn-agent` do.
 ///
-/// **Seven findings stay this document's and are not named yet.** Two are the
+/// **Six findings stay this document's and are not named yet.** Two are the
 /// ALPN name's percent-encoding spelling, which is this field's alone; two are
 /// `alt-authority`'s prose, which requires the colon and the port the ABNF
 /// leaves optional; one is a port outside the sixteen-bit namespace an ALPN
-/// name implies; one is `persist`'s single literal; and one is § 8's A-labels.
-/// Every one is a sentence about `Alt-Svc` and no other field, so every one of
-/// them is the `alt_svc` subject's, as the six already there were.
+/// name implies; and one is § 8's A-labels. Every one is a sentence about
+/// `Alt-Svc` and no other field, so every one of them is the `alt_svc`
+/// subject's, as the seven already there were.
 ///
 /// **Nothing here borrows from the `parameter` subject, and the reason is one
 /// sentence repeated three times.** RFC 7838 § 3's `parameter` is not
@@ -87,6 +88,7 @@ static DECLARED: &[&ViolationDef] = &[
     &ALT_SVC_PARAMETER_EMPTY,
     &ALT_SVC_PARAMETER_VALUE_EMPTY,
     &ALT_SVC_EQUALS_WHITESPACE_FORBIDDEN,
+    &ALT_SVC_PERSIST_INVALID,
     &LIST_MEMBER_EMPTY,
     &LIST_MEMBER_MISSING,
     &TOKEN_EMPTY,
@@ -110,7 +112,7 @@ static DECLARED: &[&ViolationDef] = &[
 ///
 /// The shape `expect_header_valid` settled: a judge that is half converted says
 /// so in its type. Here the halves are five subjects' ids — four imported and
-/// this field's own — against the seven sentences RFC 7838 writes about
+/// this field's own — against the six sentences RFC 7838 writes about
 /// `Alt-Svc` that no entry holds yet.
 struct Defect {
     def: Option<&'static ViolationDef>,
@@ -500,15 +502,18 @@ fn check_parameter(shown: &str, parameter: &str) -> Option<Defect> {
     // § 3.1 prints a syntax for this parameter, and the syntax is one
     // literal. The sentence beside it is addressed to clients rather than
     // to the sender, which is what makes the finding a report of what the
-    // value will be treated as rather than of a refusal.
+    // value will be treated as rather than of a refusal -- and what puts the
+    // entry at `info`, since being ignored leaves the alternative exactly as
+    // persistent as one that never asked.
     // cite(RFC 7838 § 3.1): "Alternative services that are intended to be longer lived (such as those that are not specific to the client access network) can carry the "persist" parameter with a value "1" as a hint that the service is potentially useful beyond a network configuration change."
-    // cite(RFC 7838 § 3.1): "This specification only defines a single value for "persist"."
-    // cite(RFC 7838 § 3.1): "Clients MUST ignore "persist" parameters with values other than "1"."
     if name == "persist" && unquoted != "1" {
-        return Some(Defect::unnamed(format!(
-            "Alt-Svc alt-value '{shown}' sets persist to '{}'. The registered syntax for this parameter is the single literal \"1\", and a client is required to ignore every other value -- so this alternative carries no persistence hint at all",
-            shown_in_finding(&unquoted)
-        )));
+        return Some(Defect::named(
+            &ALT_SVC_PERSIST_INVALID,
+            format!(
+                "Alt-Svc alt-value '{shown}' sets persist to '{}'. The registered syntax for this parameter is the single literal \"1\", and a client is required to ignore every other value -- so this alternative carries no persistence hint at all",
+                shown_in_finding(&unquoted)
+            ),
+        ));
     }
     None
 }
@@ -609,12 +614,6 @@ fn check_alt_value(member: &str) -> Option<Defect> {
 /// defined in `violations/alt_svc.rs` beside that entry's quote and imported
 /// back here. A reference on a def and a reference in `specifications()` are
 /// compared by value, so there is one definition or there is a silent split.
-const RFC_7838_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 7838",
-    section: Some("3.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc7838.html#section-3.1",
-    note: "Caching Alt-Svc Header Field Values: `persist = \"1\"` is the whole syntax of that parameter, and clients ignore any other value",
-};
 const RFC_7838_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 7838",
     section: Some("1.1"),
@@ -966,8 +965,16 @@ mod tests {
         "whitespace beside the \'=\'",
         "alt_svc_equals_whitespace_forbidden"
     )]
-    #[case("h2=\":443\"; persist=2", "sets persist to \'2\'", "")]
-    #[case("h2=\":443\"; persist=\"0\"", "sets persist to \'0\'", "")]
+    #[case(
+        "h2=\":443\"; persist=2",
+        "sets persist to \'2\'",
+        "alt_svc_persist_invalid"
+    )]
+    #[case(
+        "h2=\":443\"; persist=\"0\"",
+        "sets persist to \'0\'",
+        "alt_svc_persist_invalid"
+    )]
     #[case(
         "h2=\":443\"; ;",
         "semicolon with no parameter after it",

--- a/lint-http-rules/src/violations/alt_svc.rs
+++ b/lint-http-rules/src/violations/alt_svc.rs
@@ -40,14 +40,24 @@
 //!
 //! **What is still not written here** is the rest of
 //! `alt_svc_header_syntax`'s reading: a percent-encoding this field's
-//! one-spelling constraint forbids, an `alt-authority` naming no port, and what
-//! `persist` means. Those are this subject's too.
+//! one-spelling constraint forbids, and an `alt-authority` naming no port.
+//! Those are this subject's too.
 //
 // cite(RFC 7838 § 3.1): "The delta-seconds value indicates the number of seconds since the response was generated for which the alternative service is considered fresh."
 
 use crate::lint::Severity;
 use crate::rules::SpecRef;
 use crate::violations::defects;
+
+/// What the two parameters this document defines are for: how long an
+/// advertisement stays fresh, and the one literal `persist` is allowed to
+/// carry.
+pub const RFC_7838_3_1: SpecRef = SpecRef {
+    spec: "RFC 7838",
+    section: Some("3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc7838.html#section-3.1",
+    note: "Caching Alt-Svc Header Field Values: the `ma` parameter's delta-seconds value states how long the alternative is considered fresh, and `persist` has exactly one defined value — `\"1\"` — with clients required to ignore any other",
+};
 
 /// The field: its grammar, the `clear` keyword, and what a recipient does with
 /// a value carrying that keyword beside an alternative service.
@@ -239,6 +249,37 @@ defects! {
         spec: &[RFC_7838_3],
     }
 
+    /// A `persist` parameter carrying anything but `1`.
+    ///
+    /// **The layer above a grammar**, and the second entry in this catalogue to
+    /// live there: every production in sight derives `persist=2` — the name is
+    /// a `token`, the value is a `token` — and what refuses it is the
+    /// subsection that defines the parameter. § 3.1 prints one value and one
+    /// only, and tells clients to ignore every other, so a value the grammar
+    /// admits is a value the parameter does not have. `_invalid` is exactly
+    /// that: grammatical, and refused past the grammar.
+    ///
+    /// **`info`, and the argument is the recipient's failure mode.** A client
+    /// that ignores the parameter treats the alternative as *not* persistent,
+    /// which is what an alternative with no `persist` at all is — the
+    /// conservative reading, and the one a network change re-checks. So the
+    /// sender lost a hint it wanted and nobody lost correctness, which is the
+    /// same severity argument the qualified cache directives make one field
+    /// over. It ranks below [`ALT_SVC_MA_INVALID`] for the same reason: an
+    /// implausible lifetime is an advertisement a client will not use, and an
+    /// unreadable `persist` is an advertisement it will use exactly as far as
+    /// the next network change.
+    ///
+    // cite(RFC 7838 § 3.1): "This specification only defines a single value for "persist"."
+    // cite(RFC 7838 § 3.1): "Clients MUST ignore "persist" parameters with values other than "1"."
+    ALT_SVC_PERSIST_INVALID = {
+        id: "alt_svc_persist_invalid",
+        title: "Alt-Svc sets persist to a value the parameter does not define",
+        message: "",
+        default_severity: Severity::Info,
+        spec: &[RFC_7838_3_1],
+    }
+
     /// A freshness lifetime that derives from `delta-seconds` and states
     /// nothing a client can use: `ma=0`, which is stale on arrival, or a value
     /// so far above any deployment's horizon that it is a typo.
@@ -329,6 +370,20 @@ mod tests {
         assert!(ALT_SVC_PARAMETER_EMPTY.id.ends_with("_empty"));
         assert!(ALT_SVC_PARAMETER_VALUE_EMPTY.id.ends_with("_empty"));
         assert!(ALT_SVC_PARAMETER_EQUALS_MISSING.id.ends_with("_missing"));
+    }
+
+    /// The two parameters § 3.1 defines rank apart, and the axis is what a
+    /// recipient does when the value is no use: `persist` is ignored, which
+    /// leaves the alternative exactly as persistent as one that never asked,
+    /// where an implausible `ma` is an advertisement a client will not act on
+    /// at all. Both cite the section that gives the parameters their meaning,
+    /// or would — the lifetime's ends are the entry with no sentence.
+    #[test]
+    fn the_ignored_parameter_ranks_below_the_unusable_one() {
+        assert_eq!(ALT_SVC_PERSIST_INVALID.default_severity, Severity::Info);
+        assert!(ALT_SVC_PERSIST_INVALID.default_severity < ALT_SVC_MA_INVALID.default_severity);
+        assert_eq!(ALT_SVC_PERSIST_INVALID.spec, [RFC_7838_3_1]);
+        assert!(ALT_SVC_MA_INVALID.spec.is_empty());
     }
 
     /// The two entries are the subject's two ends, and they rank apart for a

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -436,7 +436,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 250;
+        const FLOOR: usize = 251;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1258,7 +1258,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 167
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 189
+      line: 191
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 150
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
@@ -1428,7 +1428,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1142
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 289
+      line: 291
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 356
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
@@ -1448,7 +1448,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1335
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 309
+      line: 311
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 52
     - file: lint-http-rules/src/rules/via_header_syntax.rs
@@ -2453,7 +2453,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1311
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 354
+      line: 356
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 204
   - label: lint-http-rules/src/helpers/uri.rs (2)
@@ -2463,7 +2463,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1310
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 353
+      line: 355
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 203
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
@@ -3969,7 +3969,19 @@ sources:
     snippet: A field value containing the special value "clear" indicates that the origin requests all alternatives for that origin to be invalidated (including those specified in the same response, in case of an invalid reply containing both "clear" and alternative services).
     cited_by:
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 83
+      line: 93
+  - label: alt_svc (2)
+    section: § 3.1
+    snippet: Clients MUST ignore "persist" parameters with values other than "1".
+    cited_by:
+    - file: lint-http-rules/src/violations/alt_svc.rs
+      line: 274
+  - label: alt_svc (3)
+    section: § 3.1
+    snippet: This specification only defines a single value for "persist".
+    cited_by:
+    - file: lint-http-rules/src/violations/alt_svc.rs
+      line: 273
   - label: Alt-Svc grammar
     section: § 3
     snippet: Alt-Svc       = clear / 1#alt-value
@@ -3977,7 +3989,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 29
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 150
+      line: 152
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 27
   - label: alt_svc_h3_advertisement_valid
@@ -3987,7 +3999,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 214
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 712
+      line: 711
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 332
   - label: alt_svc_h3_advertisement_valid (2)
@@ -3997,9 +4009,9 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 312
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 394
+      line: 396
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 171
+      line: 181
   - label: alt_svc_h3_advertisement_valid (3)
     section: § 3
     snippet: Unknown parameters MUST be ignored.
@@ -4007,7 +4019,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 45
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 395
+      line: 397
   - label: alt_svc_h3_advertisement_valid (4)
     section: § 3
     snippet: clear         = %s"clear"; "clear", case-sensitive
@@ -4015,9 +4027,9 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 30
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 151
+      line: 153
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 542
+      line: 547
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 372
   - label: alt_svc_h3_advertisement_valid (5)
@@ -4029,11 +4041,11 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 311
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 393
+      line: 395
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 141
+      line: 151
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 199
+      line: 209
   - label: alt_svc_h3_advertisement_valid (6)
     section: § 3.1
     snippet: The delta-seconds value indicates the number of seconds since the response was generated for which the alternative service is considered fresh.
@@ -4047,19 +4059,19 @@ sources:
     snippet: This document uses the Augmented BNF defined in [RFC5234] and updated by [RFC7405] along with the "#rule" extension defined in Section 7 of [RFC7230].
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 797
+      line: 796
   - label: alt_svc_header_syntax (2)
     section: § 2
     snippet: Note that for the purpose of this specification, an ALPN protocol name implicitly includes TLS in the suite of protocols it identifies, unless specified otherwise in its definition.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 352
+      line: 354
   - label: alt_svc_header_syntax (3)
     section: § 3
     snippet: Alt-Svc MAY occur in any HTTP response message, regardless of the status code.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 729
+      line: 728
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 353
   - label: alt_svc_header_syntax (4)
@@ -4067,31 +4079,31 @@ sources:
     snippet: Consequently, the octet representing the percent character "%" (hex 25) MUST be percent-encoded as well.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 184
+      line: 186
   - label: alt_svc_header_syntax (5)
     section: § 3
     snippet: 'In order to have precisely one way to represent any ALPN protocol name, the following additional constraints apply:'
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 185
+      line: 187
   - label: alt_svc_header_syntax (6)
     section: § 3
     snippet: Note that the "quoted-string" syntax needs to be used because ":" is not an allowed character in "token".
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 253
+      line: 255
   - label: alt_svc_header_syntax (7)
     section: § 3
     snippet: Octets in the ALPN protocol name MUST NOT be percent-encoded if they are valid token characters except "%", and
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 186
+      line: 188
   - label: alt_svc_header_syntax (8)
     section: § 3
     snippet: Octets not allowed in tokens ([RFC7230], Section 3.2.6) MUST be percent-encoded as per Section 2.1 of [RFC3986].
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 183
+      line: 185
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 149
   - label: alt_svc_header_syntax (9)
@@ -4099,13 +4111,13 @@ sources:
     snippet: The "alt-authority" component consists of an OPTIONAL uri-host ("host" in Section 3.2.2 of [RFC3986]), a colon (":"), and a port number.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 252
+      line: 254
   - label: alt_svc_header_syntax (10)
     section: § 3
     snippet: The field value consists either of a list of values, each of which indicates one alternative service, or the keyword "clear".
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 152
+      line: 154
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 28
   - label: alt_svc_header_syntax (11)
@@ -4113,45 +4125,45 @@ sources:
     snippet: When using percent-encoding, uppercase hex digits MUST be used.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 187
+      line: 189
   - label: alt_svc_header_syntax (12)
     section: § 3
     snippet: With these constraints, recipients can apply simple string comparison to match protocol identifiers.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 188
+      line: 190
   - label: alt_svc_header_syntax (13)
     section: § 3
     snippet: alt-authority = quoted-string ; containing [ uri-host ] ":" port
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 251
+      line: 253
   - label: alt_svc_header_syntax (14)
     section: § 3
     snippet: alt-value     = alternative *( OWS ";" OWS parameter )
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 164
+      line: 166
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 393
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 233
+      line: 243
   - label: alt_svc_header_syntax (15)
     section: § 3
     snippet: alternative   = protocol-id "=" alt-authority
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 533
+      line: 538
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 404
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 113
+      line: 123
   - label: alt_svc_header_syntax (16)
     section: § 3
     snippet: protocol-id   = token ; percent-encoded ALPN protocol name
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 534
+      line: 539
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 147
   - label: alt_svc_header_syntax (17)
@@ -4159,25 +4171,13 @@ sources:
     snippet: Alternative services that are intended to be longer lived (such as those that are not specific to the client access network) can carry the "persist" parameter with a value "1" as a hint that the service is potentially useful beyond a network configuration change.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 504
+      line: 508
   - label: alt_svc_header_syntax (18)
-    section: § 3.1
-    snippet: Clients MUST ignore "persist" parameters with values other than "1".
-    cited_by:
-    - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 506
-  - label: alt_svc_header_syntax (19)
-    section: § 3.1
-    snippet: This specification only defines a single value for "persist".
-    cited_by:
-    - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 505
-  - label: alt_svc_header_syntax (20)
     section: § 8
     snippet: An internationalized domain name that appears in either the header field (Section 3) or the HTTP/2 frame (Section 4) MUST be expressed using A-labels ([RFC5890], Section 2.3.2.1).
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 288
+      line: 290
   - label: alt_svc_protocol_registered
     section: § 2
     snippet: An Application Layer Protocol Negotiation (ALPN) protocol name, as per [RFC7301]
@@ -5383,7 +5383,7 @@ sources:
     snippet: All HTTP requirements applicable to an origin server also apply to the outbound communication of a gateway.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 713
+      line: 712
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 333
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
@@ -6801,7 +6801,7 @@ sources:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 104
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 798
+      line: 797
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
       line: 103
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
@@ -7261,7 +7261,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 340
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 165
+      line: 167
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 165
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
@@ -7315,7 +7315,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
       line: 155
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 771
+      line: 770
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 601
   - label: lint-http-rules/src/helpers/list.rs (2)
@@ -7377,7 +7377,7 @@ sources:
     - file: lint-http-rules/src/helpers/word.rs
       line: 90
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 254
+      line: 256
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 429
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -7655,7 +7655,7 @@ sources:
     - file: lint-http-rules/src/helpers/word.rs
       line: 89
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 535
+      line: 540
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 411
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
@@ -7795,7 +7795,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 215
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 746
+      line: 745
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 363
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs


### PR DESCRIPTION
`persist=2` derives from every production in sight — the name is a `token`, the value is a `token` — and what refuses it is the subsection that defines the parameter. RFC 7838 §3.1 prints one value and one only, and tells clients to ignore every other, so a value the grammar admits is a value the parameter does not have. That is the layer above a grammar, and `_invalid` is exactly the word for it: grammatical, and refused past the grammar.

`info`, and the argument is the recipient's failure mode. A client that ignores the parameter treats the alternative as not persistent, which is what an alternative with no `persist` at all is — the conservative reading, and the one a network change re-checks. The sender lost a hint it wanted and nobody lost correctness. It ranks below the lifetime entry beside it for that reason: an implausible `ma` is an advertisement a client will not act on, and an ignored `persist` is one it acts on exactly as far as the next network change.

§3.1 moves into the subject file with the entry that cites it, and its note now covers both parameters — the section defines the meaning of each, and the file holds an entry about each.

Catalogue 260, spec floor 251. Six of this rule's findings are still sentences no entry holds.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
