### PR TITLE
Precisely one way to write a name

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1095,6 +1095,10 @@ severity = "warn"
 # Alt-Svc sets persist to a value the parameter does not define
 severity = "info"
 
+[violations.alt_svc_protocol_id_invalid]
+# Alt-Svc protocol-id is not the one spelling this field allows for its ALPN name
+severity = "warn"
+
 [violations.auth_scheme_character_forbidden]
 # Authentication scheme holds a character outside token
 severity = "warn"

--- a/lint-http-rules/src/rules/alt_svc_header_syntax.rs
+++ b/lint-http-rules/src/rules/alt_svc_header_syntax.rs
@@ -14,7 +14,8 @@ use crate::rules::{Rule, RuleMeta};
 use crate::violations::alt_svc::{
     ALT_SVC_ALTERNATIVE_EQUALS_MISSING, ALT_SVC_CLEAR_CONFLICTING,
     ALT_SVC_EQUALS_WHITESPACE_FORBIDDEN, ALT_SVC_PARAMETER_EMPTY, ALT_SVC_PARAMETER_EQUALS_MISSING,
-    ALT_SVC_PARAMETER_VALUE_EMPTY, ALT_SVC_PERSIST_INVALID, RFC_7838_3, RFC_7838_3_1,
+    ALT_SVC_PARAMETER_VALUE_EMPTY, ALT_SVC_PERSIST_INVALID, ALT_SVC_PROTOCOL_ID_INVALID,
+    RFC_7838_3, RFC_7838_3_1,
 };
 use crate::violations::list::{
     LIST_MEMBER_EMPTY, LIST_MEMBER_MISSING, RFC_9110_5_6_1_1, RFC_9110_5_6_1_2,
@@ -36,13 +37,14 @@ use crate::violations::uri::{
 };
 use crate::violations::ViolationDef;
 
-/// Twenty-three defects over five subjects, and RFC 7838 defines seven of them.
+/// Twenty-four defects over five subjects, and RFC 7838 defines eight of them.
 ///
-/// The seven are the field's own: the alternation at the top of it, the two `=`
+/// The eight are the field's own: the alternation at the top of it, the two `=`
 /// delimiters it prints, the whitespace it prints nowhere near them, the two
-/// halves a parameter can be written without, and the one parameter this
-/// document gives a value to. Everything else here is imported, and the
-/// paragraph below is where each import comes from.
+/// halves a parameter can be written without, the one parameter this document
+/// gives a value to, and the single spelling it allows an ALPN protocol name.
+/// Everything else here is imported, and the paragraph below is where each
+/// import comes from.
 ///
 /// § 1.1 says where the notation comes from and § 3 says where the productions
 /// do: the `#rule` extension is RFC 7230 § 7's, whose sender requirement is the
@@ -52,13 +54,12 @@ use crate::violations::ViolationDef;
 /// `port` out of RFC 3986. So an `alt-authority` of `"a]b:443"` reports the
 /// same defect a `Forwarded` `for=` and a `Warning`'s `warn-agent` do.
 ///
-/// **Six findings stay this document's and are not named yet.** Two are the
-/// ALPN name's percent-encoding spelling, which is this field's alone; two are
-/// `alt-authority`'s prose, which requires the colon and the port the ABNF
-/// leaves optional; one is a port outside the sixteen-bit namespace an ALPN
-/// name implies; and one is § 8's A-labels. Every one is a sentence about
-/// `Alt-Svc` and no other field, so every one of them is the `alt_svc`
-/// subject's, as the seven already there were.
+/// **Four findings stay this document's and are not named yet**, and all four
+/// are the `alt-authority`'s: the prose requiring the colon and the port the
+/// ABNF leaves optional, a port outside the sixteen-bit namespace an ALPN name
+/// implies, and § 8's A-labels. Every one is a sentence about `Alt-Svc` and no
+/// other field, so every one of them is the `alt_svc` subject's, as the eight
+/// already there were.
 ///
 /// **Nothing here borrows from the `parameter` subject, and the reason is one
 /// sentence repeated three times.** RFC 7838 § 3's `parameter` is not
@@ -89,6 +90,7 @@ static DECLARED: &[&ViolationDef] = &[
     &ALT_SVC_PARAMETER_VALUE_EMPTY,
     &ALT_SVC_EQUALS_WHITESPACE_FORBIDDEN,
     &ALT_SVC_PERSIST_INVALID,
+    &ALT_SVC_PROTOCOL_ID_INVALID,
     &LIST_MEMBER_EMPTY,
     &LIST_MEMBER_MISSING,
     &TOKEN_EMPTY,
@@ -112,7 +114,7 @@ static DECLARED: &[&ViolationDef] = &[
 ///
 /// The shape `expect_header_valid` settled: a judge that is half converted says
 /// so in its type. Here the halves are five subjects' ids — four imported and
-/// this field's own — against the six sentences RFC 7838 writes about
+/// this field's own — against the four sentences RFC 7838 writes about
 /// `Alt-Svc` that no entry holds yet.
 struct Defect {
     def: Option<&'static ViolationDef>,
@@ -172,10 +174,10 @@ fn whitespace_beside_delimiter(left: &str, right: &str) -> bool {
 /// The three sentences RFC 7838 § 3 adds on top of `protocol-id = token`.
 ///
 /// A `token` admits `%`, so the character scan cannot see any of them. Each is
-/// a MUST or a MUST NOT addressed to whoever writes the field, and together
-/// they are what the section's closing sentence rests on -- *"With these
-/// constraints, recipients can apply simple string comparison to match protocol
-/// identifiers."* A protocol-id spelled two ways is two protocols to every
+/// a MUST or a MUST NOT addressed to whoever writes the field, and all three
+/// are one requirement: the purpose they are stated for and the comparison they
+/// buy live on `alt_svc_protocol_id_invalid`, which is the one entry all three
+/// report as. A protocol-id spelled two ways is two protocols to every
 /// recipient reading it that way.
 ///
 /// `helpers::uri::check_percent_encoding` declines the uppercase question on
@@ -184,10 +186,8 @@ fn whitespace_beside_delimiter(left: &str, right: &str) -> bool {
 /// here, because this document states it as a MUST for this one production.
 // cite(RFC 7838 § 3): "Octets not allowed in tokens ([RFC7230], Section 3.2.6) MUST be percent-encoded as per Section 2.1 of [RFC3986]."
 // cite(RFC 7838 § 3): "Consequently, the octet representing the percent character "%" (hex 25) MUST be percent-encoded as well."
-// cite(RFC 7838 § 3): "In order to have precisely one way to represent any ALPN protocol name, the following additional constraints apply:"
 // cite(RFC 7838 § 3): "Octets in the ALPN protocol name MUST NOT be percent-encoded if they are valid token characters except "%", and"
 // cite(RFC 7838 § 3): "When using percent-encoding, uppercase hex digits MUST be used."
-// cite(RFC 7838 § 3): "With these constraints, recipients can apply simple string comparison to match protocol identifiers."
 // cite(RFC 3986 § 2.1): "pct-encoded = "%" HEXDIG HEXDIG"
 fn protocol_id_encoding_defect(protocol_id: &str) -> Option<Defect> {
     // The triplet's *shape* is `helpers::uri::percent_encoding_defect`'s, and it
@@ -218,19 +218,25 @@ fn protocol_id_encoding_defect(protocol_id: &str) -> Option<Defect> {
         // Both are `HEXDIG`; the scan above returned `None`.
         let (hi, lo) = (bytes[i + 1] as char, bytes[i + 2] as char);
         if hi.is_ascii_lowercase() || lo.is_ascii_lowercase() {
-            return Some(Defect::unnamed(format!(
-                "the triplet '%{hi}{lo}' at offset {i} uses lowercase hex digits, and this field requires uppercase ones so that two spellings of one ALPN protocol name cannot exist"
-            )));
+            return Some(Defect::named(
+                &ALT_SVC_PROTOCOL_ID_INVALID,
+                format!(
+                    "the triplet '%{hi}{lo}' at offset {i} uses lowercase hex digits, and this field requires uppercase ones so that two spellings of one ALPN protocol name cannot exist"
+                ),
+            ));
         }
         // The escaping table's third row is why `%25` is exempt: `%` is a
         // `tchar`, and it is the one `tchar` this document requires to be
         // encoded rather than forbids.
         let octet = (hi.to_digit(16)? * 16 + lo.to_digit(16)?) as u8;
         if octet != b'%' && crate::helpers::token::is_tchar_byte(octet) {
-            return Some(Defect::unnamed(format!(
-                "the triplet '%{hi}{lo}' at offset {i} encodes {}, which is a `tchar` and so must appear as itself -- this field admits exactly one spelling per ALPN protocol name",
-                describe_char(octet as char)
-            )));
+            return Some(Defect::named(
+                &ALT_SVC_PROTOCOL_ID_INVALID,
+                format!(
+                    "the triplet '%{hi}{lo}' at offset {i} encodes {}, which is a `tchar` and so must appear as itself -- this field admits exactly one spelling per ALPN protocol name",
+                    describe_char(octet as char)
+                ),
+            ));
         }
         i += 3;
     }
@@ -944,11 +950,15 @@ mod tests {
     )]
     #[case("h@=\":443\"", "which is no `tchar`", "token_character_forbidden")]
     #[case("=\":443\"", "empty protocol-id", "token_empty")]
-    #[case("x%3dy=\":443\"", "lowercase hex digits", "")]
+    #[case(
+        "x%3dy=\":443\"",
+        "lowercase hex digits",
+        "alt_svc_protocol_id_invalid"
+    )]
     #[case(
         "%68%32=\":443\"",
         "which is a `tchar` and so must appear as itself",
-        ""
+        "alt_svc_protocol_id_invalid"
     )]
     #[case(
         "x%zzy=\":443\"",

--- a/lint-http-rules/src/violations/alt_svc.rs
+++ b/lint-http-rules/src/violations/alt_svc.rs
@@ -38,10 +38,17 @@
 //! the value optional and tolerates the whitespace at `info`. **A production of
 //! the same name written in another document is another production.**
 //!
+//! **The `protocol-id`'s spelling is here as well, and it is one entry for
+//! three sentences.** § 3 constrains the percent-encoding of an ALPN protocol
+//! name three ways and says what for — *precisely one way to represent* it —
+//! and every one of the three ends in the same place: two spellings of one name
+//! where the recipient does simple string comparison. The name itself, once the
+//! spelling is undone, is [`alpn`](crate::violations::alpn)'s.
+//!
 //! **What is still not written here** is the rest of
-//! `alt_svc_header_syntax`'s reading: a percent-encoding this field's
-//! one-spelling constraint forbids, and an `alt-authority` naming no port.
-//! Those are this subject's too.
+//! `alt_svc_header_syntax`'s reading: the `alt-authority`'s prose, which asks
+//! for a colon and a port the ABNF leaves optional, and the A-labels § 8 asks
+//! an internationalized name to be written as. Those are this subject's too.
 //
 // cite(RFC 7838 § 3.1): "The delta-seconds value indicates the number of seconds since the response was generated for which the alternative service is considered fresh."
 
@@ -249,6 +256,42 @@ defects! {
         spec: &[RFC_7838_3],
     }
 
+    /// A `protocol-id` that is a well-formed `token` of well-formed triplets
+    /// and is not the one spelling this field allows for the name it stands
+    /// for: `x%3dy` for `x%3Dy`, or `%68%32` for `h2`.
+    ///
+    /// § 3 states three constraints and states them for one declared purpose —
+    /// *"In order to have precisely one way to represent any ALPN protocol
+    /// name"*. Octets no `token` admits are percent-encoded, `%` itself is
+    /// written `%25`, octets that *are* `tchar`s are not encoded at all, and
+    /// the hex digits are uppercase. **A `token` admits `%`, so no character
+    /// scan can see any of this**: every value reaching this entry has already
+    /// derived from the production.
+    ///
+    /// **One entry for the constraints, because they are one requirement and
+    /// the defect they describe is one defect.** Both spellings decode to the
+    /// right name — that is what makes them spellings rather than errors — and
+    /// what breaks is the closing sentence they exist for: *"recipients can
+    /// apply simple string comparison to match protocol identifiers"*. A
+    /// recipient comparing `%68%32` against `h2` finds two protocols where the
+    /// sender meant one, whichever constraint was broken. The message says
+    /// which triplet and why; the id says the name has more than one spelling.
+    ///
+    /// `_invalid`, on the same line `persist` is: every octet derives and what
+    /// fails is one level past the grammar. `warn` — the alternative is
+    /// advertised for a protocol no recipient will match, so it is lost the way
+    /// an unreadable member is.
+    ///
+    // cite(RFC 7838 § 3): "In order to have precisely one way to represent any ALPN protocol name, the following additional constraints apply:"
+    // cite(RFC 7838 § 3): "With these constraints, recipients can apply simple string comparison to match protocol identifiers."
+    ALT_SVC_PROTOCOL_ID_INVALID = {
+        id: "alt_svc_protocol_id_invalid",
+        title: "Alt-Svc protocol-id is not the one spelling this field allows for its ALPN name",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_7838_3],
+    }
+
     /// A `persist` parameter carrying anything but `1`.
     ///
     /// **The layer above a grammar**, and the second entry in this catalogue to
@@ -370,6 +413,20 @@ mod tests {
         assert!(ALT_SVC_PARAMETER_EMPTY.id.ends_with("_empty"));
         assert!(ALT_SVC_PARAMETER_VALUE_EMPTY.id.ends_with("_empty"));
         assert!(ALT_SVC_PARAMETER_EQUALS_MISSING.id.ends_with("_missing"));
+    }
+
+    /// The two entries about a value that derives perfectly and is still wrong
+    /// are the two `_invalid` ones, and they rank apart: a spelling nobody will
+    /// match costs the alternative, and a `persist` nobody will read costs a
+    /// hint. Neither is `_malformed`, which is the word for a value that does
+    /// not derive at all.
+    #[test]
+    fn the_entries_past_the_grammar_are_the_invalid_ones() {
+        assert_eq!(ALT_SVC_PROTOCOL_ID_INVALID.default_severity, Severity::Warn);
+        assert!(
+            ALT_SVC_PERSIST_INVALID.default_severity < ALT_SVC_PROTOCOL_ID_INVALID.default_severity
+        );
+        assert_eq!(ALT_SVC_PROTOCOL_ID_INVALID.spec, [RFC_7838_3]);
     }
 
     /// The two parameters § 3.1 defines rank apart, and the axis is what a

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -436,7 +436,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 251;
+        const FLOOR: usize = 252;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1428,7 +1428,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1142
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 291
+      line: 297
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 356
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
@@ -1448,7 +1448,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1335
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 311
+      line: 317
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 52
     - file: lint-http-rules/src/rules/via_header_syntax.rs
@@ -2453,7 +2453,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1311
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 356
+      line: 362
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 204
   - label: lint-http-rules/src/helpers/uri.rs (2)
@@ -2463,7 +2463,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1310
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 355
+      line: 361
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 203
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
@@ -3969,19 +3969,31 @@ sources:
     snippet: A field value containing the special value "clear" indicates that the origin requests all alternatives for that origin to be invalidated (including those specified in the same response, in case of an invalid reply containing both "clear" and alternative services).
     cited_by:
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 93
+      line: 100
   - label: alt_svc (2)
+    section: § 3
+    snippet: 'In order to have precisely one way to represent any ALPN protocol name, the following additional constraints apply:'
+    cited_by:
+    - file: lint-http-rules/src/violations/alt_svc.rs
+      line: 285
+  - label: alt_svc (3)
+    section: § 3
+    snippet: With these constraints, recipients can apply simple string comparison to match protocol identifiers.
+    cited_by:
+    - file: lint-http-rules/src/violations/alt_svc.rs
+      line: 286
+  - label: alt_svc (4)
     section: § 3.1
     snippet: Clients MUST ignore "persist" parameters with values other than "1".
     cited_by:
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 274
-  - label: alt_svc (3)
+      line: 317
+  - label: alt_svc (5)
     section: § 3.1
     snippet: This specification only defines a single value for "persist".
     cited_by:
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 273
+      line: 316
   - label: Alt-Svc grammar
     section: § 3
     snippet: Alt-Svc       = clear / 1#alt-value
@@ -3989,7 +4001,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 29
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 152
+      line: 154
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 27
   - label: alt_svc_h3_advertisement_valid
@@ -3999,7 +4011,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 214
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 711
+      line: 717
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 332
   - label: alt_svc_h3_advertisement_valid (2)
@@ -4009,9 +4021,9 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 312
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 396
+      line: 402
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 181
+      line: 188
   - label: alt_svc_h3_advertisement_valid (3)
     section: § 3
     snippet: Unknown parameters MUST be ignored.
@@ -4019,7 +4031,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 45
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 397
+      line: 403
   - label: alt_svc_h3_advertisement_valid (4)
     section: § 3
     snippet: clear         = %s"clear"; "clear", case-sensitive
@@ -4027,9 +4039,9 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 30
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 153
+      line: 155
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 547
+      line: 553
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 372
   - label: alt_svc_h3_advertisement_valid (5)
@@ -4041,11 +4053,11 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 311
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 395
+      line: 401
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 151
+      line: 158
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 209
+      line: 216
   - label: alt_svc_h3_advertisement_valid (6)
     section: § 3.1
     snippet: The delta-seconds value indicates the number of seconds since the response was generated for which the alternative service is considered fresh.
@@ -4053,25 +4065,25 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 337
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 46
+      line: 53
   - label: alt_svc_header_syntax
     section: § 1.1
     snippet: This document uses the Augmented BNF defined in [RFC5234] and updated by [RFC7405] along with the "#rule" extension defined in Section 7 of [RFC7230].
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 796
+      line: 802
   - label: alt_svc_header_syntax (2)
     section: § 2
     snippet: Note that for the purpose of this specification, an ALPN protocol name implicitly includes TLS in the suite of protocols it identifies, unless specified otherwise in its definition.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 354
+      line: 360
   - label: alt_svc_header_syntax (3)
     section: § 3
     snippet: Alt-Svc MAY occur in any HTTP response message, regardless of the status code.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 728
+      line: 734
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 353
   - label: alt_svc_header_syntax (4)
@@ -4079,105 +4091,93 @@ sources:
     snippet: Consequently, the octet representing the percent character "%" (hex 25) MUST be percent-encoded as well.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 186
+      line: 188
   - label: alt_svc_header_syntax (5)
-    section: § 3
-    snippet: 'In order to have precisely one way to represent any ALPN protocol name, the following additional constraints apply:'
-    cited_by:
-    - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 187
-  - label: alt_svc_header_syntax (6)
     section: § 3
     snippet: Note that the "quoted-string" syntax needs to be used because ":" is not an allowed character in "token".
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 255
-  - label: alt_svc_header_syntax (7)
+      line: 261
+  - label: alt_svc_header_syntax (6)
     section: § 3
     snippet: Octets in the ALPN protocol name MUST NOT be percent-encoded if they are valid token characters except "%", and
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 188
-  - label: alt_svc_header_syntax (8)
+      line: 189
+  - label: alt_svc_header_syntax (7)
     section: § 3
     snippet: Octets not allowed in tokens ([RFC7230], Section 3.2.6) MUST be percent-encoded as per Section 2.1 of [RFC3986].
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 185
+      line: 187
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 149
-  - label: alt_svc_header_syntax (9)
+  - label: alt_svc_header_syntax (8)
     section: § 3
     snippet: The "alt-authority" component consists of an OPTIONAL uri-host ("host" in Section 3.2.2 of [RFC3986]), a colon (":"), and a port number.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 254
-  - label: alt_svc_header_syntax (10)
+      line: 260
+  - label: alt_svc_header_syntax (9)
     section: § 3
     snippet: The field value consists either of a list of values, each of which indicates one alternative service, or the keyword "clear".
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 154
+      line: 156
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 28
-  - label: alt_svc_header_syntax (11)
+  - label: alt_svc_header_syntax (10)
     section: § 3
     snippet: When using percent-encoding, uppercase hex digits MUST be used.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 189
-  - label: alt_svc_header_syntax (12)
-    section: § 3
-    snippet: With these constraints, recipients can apply simple string comparison to match protocol identifiers.
-    cited_by:
-    - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 190
-  - label: alt_svc_header_syntax (13)
+  - label: alt_svc_header_syntax (11)
     section: § 3
     snippet: alt-authority = quoted-string ; containing [ uri-host ] ":" port
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 253
-  - label: alt_svc_header_syntax (14)
+      line: 259
+  - label: alt_svc_header_syntax (12)
     section: § 3
     snippet: alt-value     = alternative *( OWS ";" OWS parameter )
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 166
+      line: 168
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 393
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 243
-  - label: alt_svc_header_syntax (15)
+      line: 250
+  - label: alt_svc_header_syntax (13)
     section: § 3
     snippet: alternative   = protocol-id "=" alt-authority
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 538
+      line: 544
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 404
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 123
-  - label: alt_svc_header_syntax (16)
+      line: 130
+  - label: alt_svc_header_syntax (14)
     section: § 3
     snippet: protocol-id   = token ; percent-encoded ALPN protocol name
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 539
+      line: 545
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 147
-  - label: alt_svc_header_syntax (17)
+  - label: alt_svc_header_syntax (15)
     section: § 3.1
     snippet: Alternative services that are intended to be longer lived (such as those that are not specific to the client access network) can carry the "persist" parameter with a value "1" as a hint that the service is potentially useful beyond a network configuration change.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 508
-  - label: alt_svc_header_syntax (18)
+      line: 514
+  - label: alt_svc_header_syntax (16)
     section: § 8
     snippet: An internationalized domain name that appears in either the header field (Section 3) or the HTTP/2 frame (Section 4) MUST be expressed using A-labels ([RFC5890], Section 2.3.2.1).
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 290
+      line: 296
   - label: alt_svc_protocol_registered
     section: § 2
     snippet: An Application Layer Protocol Negotiation (ALPN) protocol name, as per [RFC7301]
@@ -5383,7 +5383,7 @@ sources:
     snippet: All HTTP requirements applicable to an origin server also apply to the outbound communication of a gateway.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 712
+      line: 718
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 333
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
@@ -6801,7 +6801,7 @@ sources:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 104
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 797
+      line: 803
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
       line: 103
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
@@ -7261,7 +7261,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 340
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 167
+      line: 169
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 165
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
@@ -7315,7 +7315,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
       line: 155
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 770
+      line: 776
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 601
   - label: lint-http-rules/src/helpers/list.rs (2)
@@ -7377,7 +7377,7 @@ sources:
     - file: lint-http-rules/src/helpers/word.rs
       line: 90
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 256
+      line: 262
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 429
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -7655,7 +7655,7 @@ sources:
     - file: lint-http-rules/src/helpers/word.rs
       line: 89
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 540
+      line: 546
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 411
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
@@ -7795,7 +7795,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 215
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 745
+      line: 751
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 363
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs


### PR DESCRIPTION
RFC 7838 §3 constrains the percent-encoding of an ALPN protocol name three ways — octets no `token` admits are encoded, `%` itself is written `%25`, octets that are `tchar`s are not encoded at all, and the hex digits are uppercase — and states what all of it is for: precisely one way to represent any name.

One entry for the three, because they are one requirement and what they describe is one defect. Both `x%3dy` and `%68%32` decode to the right name — that is what makes them spellings rather than errors — and what breaks is the closing sentence the constraints exist for: recipients can apply simple string comparison to match protocol identifiers. A recipient comparing `%68%32` against `h2` finds two protocols where the sender meant one, whichever constraint was broken. The message says which triplet and why; the id says the name has more than one spelling.

`_invalid` on the same line `persist` is: every octet derives and what fails is one level past the grammar. `warn`, because the alternative is advertised for a protocol no recipient will match and is lost the way an unreadable member is.

The `alpn` subject said where this belonged before it was written: its entries are about the name after the spelling is undone, and how it was spelled is the carrying field's.

Catalogue 261, spec floor 252. The four findings left in this rule are all the alt-authority's.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
