### PR TITLE
Three ways to name no port

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1095,6 +1095,18 @@ severity = "warn"
 # Alt-Svc sets persist to a value the parameter does not define
 severity = "info"
 
+[violations.alt_svc_port_empty]
+# Alt-Svc alt-authority ends at the colon with no port
+severity = "warn"
+
+[violations.alt_svc_port_invalid]
+# Alt-Svc alt-authority names a port no transport has
+severity = "warn"
+
+[violations.alt_svc_port_missing]
+# Alt-Svc alt-authority names no port
+severity = "warn"
+
 [violations.alt_svc_protocol_id_invalid]
 # Alt-Svc protocol-id is not the one spelling this field allows for its ALPN name
 severity = "warn"

--- a/lint-http-rules/src/rules/alt_svc_header_syntax.rs
+++ b/lint-http-rules/src/rules/alt_svc_header_syntax.rs
@@ -14,8 +14,9 @@ use crate::rules::{Rule, RuleMeta};
 use crate::violations::alt_svc::{
     ALT_SVC_ALTERNATIVE_EQUALS_MISSING, ALT_SVC_CLEAR_CONFLICTING,
     ALT_SVC_EQUALS_WHITESPACE_FORBIDDEN, ALT_SVC_PARAMETER_EMPTY, ALT_SVC_PARAMETER_EQUALS_MISSING,
-    ALT_SVC_PARAMETER_VALUE_EMPTY, ALT_SVC_PERSIST_INVALID, ALT_SVC_PROTOCOL_ID_INVALID,
-    RFC_7838_3, RFC_7838_3_1,
+    ALT_SVC_PARAMETER_VALUE_EMPTY, ALT_SVC_PERSIST_INVALID, ALT_SVC_PORT_EMPTY,
+    ALT_SVC_PORT_INVALID, ALT_SVC_PORT_MISSING, ALT_SVC_PROTOCOL_ID_INVALID, RFC_7838_3,
+    RFC_7838_3_1,
 };
 use crate::violations::list::{
     LIST_MEMBER_EMPTY, LIST_MEMBER_MISSING, RFC_9110_5_6_1_1, RFC_9110_5_6_1_2,
@@ -37,14 +38,14 @@ use crate::violations::uri::{
 };
 use crate::violations::ViolationDef;
 
-/// Twenty-four defects over five subjects, and RFC 7838 defines eight of them.
+/// Twenty-seven defects over five subjects, and RFC 7838 defines eleven of them.
 ///
-/// The eight are the field's own: the alternation at the top of it, the two `=`
+/// The eleven are the field's own: the alternation at the top of it, the two `=`
 /// delimiters it prints, the whitespace it prints nowhere near them, the two
 /// halves a parameter can be written without, the one parameter this document
-/// gives a value to, and the single spelling it allows an ALPN protocol name.
-/// Everything else here is imported, and the paragraph below is where each
-/// import comes from.
+/// gives a value to, the single spelling it allows an ALPN protocol name, and
+/// the three ways an `alt-authority` can name no port. Everything else here is
+/// imported, and the paragraph below is where each import comes from.
 ///
 /// § 1.1 says where the notation comes from and § 3 says where the productions
 /// do: the `#rule` extension is RFC 7230 § 7's, whose sender requirement is the
@@ -54,12 +55,10 @@ use crate::violations::ViolationDef;
 /// `port` out of RFC 3986. So an `alt-authority` of `"a]b:443"` reports the
 /// same defect a `Forwarded` `for=` and a `Warning`'s `warn-agent` do.
 ///
-/// **Four findings stay this document's and are not named yet**, and all four
-/// are the `alt-authority`'s: the prose requiring the colon and the port the
-/// ABNF leaves optional, a port outside the sixteen-bit namespace an ALPN name
-/// implies, and § 8's A-labels. Every one is a sentence about `Alt-Svc` and no
-/// other field, so every one of them is the `alt_svc` subject's, as the eight
-/// already there were.
+/// **One finding stays this document's and is not named yet**: § 8's A-labels,
+/// which is an octet at or above %x80 anywhere inside an `alt-authority`. It is
+/// a sentence about `Alt-Svc` and no other field, so it is the `alt_svc`
+/// subject's, as the eleven already there are.
 ///
 /// **Nothing here borrows from the `parameter` subject, and the reason is one
 /// sentence repeated three times.** RFC 7838 § 3's `parameter` is not
@@ -91,6 +90,9 @@ static DECLARED: &[&ViolationDef] = &[
     &ALT_SVC_EQUALS_WHITESPACE_FORBIDDEN,
     &ALT_SVC_PERSIST_INVALID,
     &ALT_SVC_PROTOCOL_ID_INVALID,
+    &ALT_SVC_PORT_MISSING,
+    &ALT_SVC_PORT_EMPTY,
+    &ALT_SVC_PORT_INVALID,
     &LIST_MEMBER_EMPTY,
     &LIST_MEMBER_MISSING,
     &TOKEN_EMPTY,
@@ -114,8 +116,8 @@ static DECLARED: &[&ViolationDef] = &[
 ///
 /// The shape `expect_header_valid` settled: a judge that is half converted says
 /// so in its type. Here the halves are five subjects' ids — four imported and
-/// this field's own — against the four sentences RFC 7838 writes about
-/// `Alt-Svc` that no entry holds yet.
+/// this field's own — against the one sentence RFC 7838 writes about `Alt-Svc`
+/// that no entry holds yet.
 struct Defect {
     def: Option<&'static ViolationDef>,
     message: String,
@@ -319,10 +321,13 @@ fn check_alt_authority(shown: &str, authority: &str) -> Option<Defect> {
     let Some(port) = port else {
         // The prose beside the production, and it is this document's: the two
         // halves are RFC 3986's and which of them is optional is § 3's.
-        return Some(Defect::unnamed(format!(
-            "Alt-Svc alternative '{shown}' has an alt-authority with no ':' in it. The host is optional and the colon and the port number are not, so '{}' names no port for a client to open the alternative on",
-            shown_in_finding(&inner)
-        )));
+        return Some(Defect::named(
+            &ALT_SVC_PORT_MISSING,
+            format!(
+                "Alt-Svc alternative '{shown}' has an alt-authority with no ':' in it. The host is optional and the colon and the port number are not, so '{}' names no port for a client to open the alternative on",
+                shown_in_finding(&inner)
+            ),
+        ));
     };
     if !host.is_empty() {
         if let Err(defect) = crate::helpers::uri::validate_uri_host(host) {
@@ -339,9 +344,12 @@ fn check_alt_authority(shown: &str, authority: &str) -> Option<Defect> {
         // Said in the finding itself: `port = *DIGIT` generates this, so no
         // production is broken and there is no defect of one to report. What is
         // wrong is § 3's prose asking for a port number.
-        return Some(Defect::unnamed(format!(
-            "Alt-Svc alternative '{shown}' carries the port's delimiter and no port. `port` is `*DIGIT`, so the grammar admits this, and the sentence beside it asks for a port number -- a client reading this has a host and no number to reach it on"
-        )));
+        return Some(Defect::named(
+            &ALT_SVC_PORT_EMPTY,
+            format!(
+                "Alt-Svc alternative '{shown}' carries the port's delimiter and no port. `port` is `*DIGIT`, so the grammar admits this, and the sentence beside it asks for a port number -- a client reading this has a host and no number to reach it on"
+            ),
+        ));
     }
     if let Some(c) = port.chars().find(|c| !c.is_ascii_digit()) {
         return Some(Defect::named(
@@ -361,14 +369,18 @@ fn check_alt_authority(shown: &str, authority: &str) -> Option<Defect> {
     // cite(RFC 6335 § 6): "TCP, UDP, UDP-Lite, SCTP, and DCCP use 16-bit namespaces for their port number registries."
     // cite(RFC 6335 § 6): "Reserved port numbers include values at the edges of each range, e.g., 0, 1023, 1024, etc., which may be used to extend these ranges or the overall port number space in the future."
     if crate::helpers::uri::port_number(port).is_none() {
-        // A well-formed `port` naming a number no transport has. The def above
-        // is about the octets and says in its own doc that a port outside a
-        // transport's range is not its finding, because `port = *DIGIT` bounds
-        // nothing -- so the sentence answering this one is RFC 6335's, and the
-        // subject that would hold it does not exist.
-        return Some(Defect::unnamed(format!(
-            "Alt-Svc alternative '{shown}' names port {port}, which designates no port: the transports an ALPN protocol name is carried over register theirs in a sixteen-bit namespace"
-        )));
+        // A well-formed `port` naming a number no transport has. The `uri` def
+        // above is about the octets and says in its own doc that a port outside
+        // a transport's range is not its finding, because `port = *DIGIT` bounds
+        // nothing -- so the sentence answering this one is § 3's prose asking
+        // for a port *number*, and the width is measured by the two references
+        // this rule declares beside it.
+        return Some(Defect::named(
+            &ALT_SVC_PORT_INVALID,
+            format!(
+                "Alt-Svc alternative '{shown}' names port {port}, which designates no port: the transports an ALPN protocol name is carried over register theirs in a sixteen-bit namespace"
+            ),
+        ));
     }
     None
 }
@@ -914,14 +926,22 @@ mod tests {
         "unquoted alt-authority",
         "quoted_string_delimiter_missing"
     )]
-    #[case("h2=\"example.com\"", "no \':\' in it", "")]
-    #[case("h2=\"example.com:\"", "carries the port\'s delimiter and no port", "")]
+    #[case("h2=\"example.com\"", "no \':\' in it", "alt_svc_port_missing")]
+    #[case(
+        "h2=\"example.com:\"",
+        "carries the port\'s delimiter and no port",
+        "alt_svc_port_empty"
+    )]
     #[case(
         "h2=\"example.com:notaport\"",
         "in its port",
         "uri_port_character_forbidden"
     )]
-    #[case("h2=\"example.com:65536\"", "sixteen-bit namespace", "")]
+    #[case(
+        "h2=\"example.com:65536\"",
+        "sixteen-bit namespace",
+        "alt_svc_port_invalid"
+    )]
     #[case(
         "h2=\"exam ple.com:443\"",
         "is not a `uri-host`",

--- a/lint-http-rules/src/violations/alt_svc.rs
+++ b/lint-http-rules/src/violations/alt_svc.rs
@@ -45,10 +45,17 @@
 //! where the recipient does simple string comparison. The name itself, once the
 //! spelling is undone, is [`alpn`](crate::violations::alpn)'s.
 //!
-//! **What is still not written here** is the rest of
-//! `alt_svc_header_syntax`'s reading: the `alt-authority`'s prose, which asks
-//! for a colon and a port the ABNF leaves optional, and the A-labels § 8 asks
-//! an internationalized name to be written as. Those are this subject's too.
+//! **The `alt-authority`'s three port entries are the prose rather than the
+//! ABNF**, which is what makes them this subject's at all: the production is
+//! `quoted-string` and a comment, and the sentence beside it asks for an
+//! OPTIONAL host, a colon and a port number. Two of the three are not optional,
+//! so a value with no colon, a value ending on one, and a value naming a number
+//! no transport has are three senders with three fixes and one sentence between
+//! them.
+//!
+//! **What is still not written here** is the last of
+//! `alt_svc_header_syntax`'s reading: the A-labels § 8 asks an internationalized
+//! name to be written as. That is this subject's too.
 //
 // cite(RFC 7838 § 3.1): "The delta-seconds value indicates the number of seconds since the response was generated for which the alternative service is considered fresh."
 
@@ -256,6 +263,83 @@ defects! {
         spec: &[RFC_7838_3],
     }
 
+    /// An `alt-authority` with no colon in it: `h2="example.com"`.
+    ///
+    /// **The ABNF is not the requirement here, and that is the whole of these
+    /// three entries.** `alt-authority = quoted-string` is followed by a
+    /// comment, and the prose beside it is what states the shape: an OPTIONAL
+    /// `uri-host`, a colon, and a port number. Two of the three are not
+    /// optional, so a value naming a host and stopping names nothing a client
+    /// can open a connection to — the same shape `authority-form` has, where
+    /// the quantifiers demand nothing and the sentence beside them demands two
+    /// halves.
+    ///
+    /// `_missing` and not `_empty`: no colon was written, so there is no port
+    /// to be blank. [`ALT_SVC_PORT_EMPTY`] is the other side of that line.
+    ///
+    /// `warn`. The alternative is unusable and the origin still is not — a
+    /// client with nowhere to reach the alternative uses the origin it already
+    /// has.
+    ///
+    // cite(RFC 7838 § 3): "The "alt-authority" component consists of an OPTIONAL uri-host ("host" in Section 3.2.2 of [RFC3986]), a colon (":"), and a port number."
+    ALT_SVC_PORT_MISSING = {
+        id: "alt_svc_port_missing",
+        title: "Alt-Svc alt-authority names no port",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_7838_3],
+    }
+
+    /// An `alt-authority` that carries the colon and no digits after it:
+    /// `h2="example.com:"`.
+    ///
+    /// `port` is `*DIGIT`, so the grammar derives this and there is no
+    /// production to have broken; what asks for a number is § 3's prose. **The
+    /// delimiter is what splits this from [`ALT_SVC_PORT_MISSING`]** — a sender
+    /// that wrote the colon knew the component was there and wrote none of it,
+    /// which is a different sender from one that stopped at the host.
+    ///
+    /// `warn`, with its sibling and for the same reason.
+    ///
+    // cite(RFC 7838 § 3): "The "alt-authority" component consists of an OPTIONAL uri-host ("host" in Section 3.2.2 of [RFC3986]), a colon (":"), and a port number."
+    ALT_SVC_PORT_EMPTY = {
+        id: "alt_svc_port_empty",
+        title: "Alt-Svc alt-authority ends at the colon with no port",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_7838_3],
+    }
+
+    /// An `alt-authority` naming a number no transport has: `h2=":65536"`.
+    ///
+    /// `port` is `*DIGIT` and bounds nothing at either end, so every digit here
+    /// derives from the production and what fails is that the result is not a
+    /// port number. **The sentence that makes it a defect is § 3's prose and
+    /// the width comes from somewhere else** — § 2 says an ALPN protocol name
+    /// implicitly identifies a suite carried over a transport, and those
+    /// transports register their ports in a sixteen-bit namespace (RFC 6335
+    /// § 6). So this entry names the requirement and the rule declaring it
+    /// names the two references that supply the measurement: **a bound reached
+    /// through a transport is still the requirement's defect, not the
+    /// transport's**, which is the line the CONNECT destination's port drew one
+    /// subject over.
+    ///
+    /// **`0` is not reported.** It sits inside the namespace as a reserved edge
+    /// value, held back for extending the ranges later, and no sentence here
+    /// makes a reserved port an invalid one.
+    ///
+    /// `_invalid` rather than `_malformed`, with this subject's other two: every
+    /// octet is a DIGIT and the production is satisfied.
+    ///
+    // cite(RFC 7838 § 3): "The "alt-authority" component consists of an OPTIONAL uri-host ("host" in Section 3.2.2 of [RFC3986]), a colon (":"), and a port number."
+    ALT_SVC_PORT_INVALID = {
+        id: "alt_svc_port_invalid",
+        title: "Alt-Svc alt-authority names a port no transport has",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_7838_3],
+    }
+
     /// A `protocol-id` that is a well-formed `token` of well-formed triplets
     /// and is not the one spelling this field allows for the name it stands
     /// for: `x%3dy` for `x%3Dy`, or `%68%32` for `h2`.
@@ -413,6 +497,30 @@ mod tests {
         assert!(ALT_SVC_PARAMETER_EMPTY.id.ends_with("_empty"));
         assert!(ALT_SVC_PARAMETER_VALUE_EMPTY.id.ends_with("_empty"));
         assert!(ALT_SVC_PARAMETER_EQUALS_MISSING.id.ends_with("_missing"));
+    }
+
+    /// One sentence, three entries, and the reason they are three: a value with
+    /// no colon, a value ending on one, and a value naming a number no
+    /// transport has are three senders with three fixes. The delimiter is what
+    /// splits the first two, exactly as it does for a CONNECT's destination —
+    /// and the ranks are this field's rather than that one's, because an
+    /// unusable alternative costs a client nothing it did not already have.
+    #[test]
+    fn the_alt_authoritys_prose_is_three_entries_of_one_rank() {
+        use crate::violations::authority::AUTHORITY_TUNNEL_PORT_INVALID;
+
+        for def in [
+            &ALT_SVC_PORT_MISSING,
+            &ALT_SVC_PORT_EMPTY,
+            &ALT_SVC_PORT_INVALID,
+        ] {
+            assert_eq!(def.spec, [RFC_7838_3], "{}", def.id);
+            assert_eq!(def.default_severity, Severity::Warn, "{}", def.id);
+        }
+        assert_eq!(
+            AUTHORITY_TUNNEL_PORT_INVALID.default_severity,
+            Severity::Error
+        );
     }
 
     /// The two entries about a value that derives perfectly and is still wrong

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -436,7 +436,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 252;
+        const FLOOR: usize = 255;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1258,7 +1258,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 167
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 191
+      line: 193
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 150
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
@@ -1428,7 +1428,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1142
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 297
+      line: 299
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 356
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
@@ -1448,7 +1448,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1335
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 317
+      line: 319
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 52
     - file: lint-http-rules/src/rules/via_header_syntax.rs
@@ -2453,7 +2453,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1311
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 362
+      line: 370
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 204
   - label: lint-http-rules/src/helpers/uri.rs (2)
@@ -2463,7 +2463,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1310
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 361
+      line: 369
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 203
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
@@ -3969,31 +3969,31 @@ sources:
     snippet: A field value containing the special value "clear" indicates that the origin requests all alternatives for that origin to be invalidated (including those specified in the same response, in case of an invalid reply containing both "clear" and alternative services).
     cited_by:
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 100
+      line: 107
   - label: alt_svc (2)
     section: § 3
     snippet: 'In order to have precisely one way to represent any ALPN protocol name, the following additional constraints apply:'
     cited_by:
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 285
+      line: 369
   - label: alt_svc (3)
     section: § 3
     snippet: With these constraints, recipients can apply simple string comparison to match protocol identifiers.
     cited_by:
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 286
+      line: 370
   - label: alt_svc (4)
     section: § 3.1
     snippet: Clients MUST ignore "persist" parameters with values other than "1".
     cited_by:
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 317
+      line: 401
   - label: alt_svc (5)
     section: § 3.1
     snippet: This specification only defines a single value for "persist".
     cited_by:
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 316
+      line: 400
   - label: Alt-Svc grammar
     section: § 3
     snippet: Alt-Svc       = clear / 1#alt-value
@@ -4001,7 +4001,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 29
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 154
+      line: 156
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 27
   - label: alt_svc_h3_advertisement_valid
@@ -4011,7 +4011,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 214
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 717
+      line: 729
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 332
   - label: alt_svc_h3_advertisement_valid (2)
@@ -4021,9 +4021,9 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 312
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 402
+      line: 414
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 188
+      line: 195
   - label: alt_svc_h3_advertisement_valid (3)
     section: § 3
     snippet: Unknown parameters MUST be ignored.
@@ -4031,7 +4031,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 45
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 403
+      line: 415
   - label: alt_svc_h3_advertisement_valid (4)
     section: § 3
     snippet: clear         = %s"clear"; "clear", case-sensitive
@@ -4039,9 +4039,9 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 30
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 155
+      line: 157
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 553
+      line: 565
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 372
   - label: alt_svc_h3_advertisement_valid (5)
@@ -4053,11 +4053,11 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 311
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 401
+      line: 413
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 158
+      line: 165
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 216
+      line: 223
   - label: alt_svc_h3_advertisement_valid (6)
     section: § 3.1
     snippet: The delta-seconds value indicates the number of seconds since the response was generated for which the alternative service is considered fresh.
@@ -4065,25 +4065,25 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 337
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 53
+      line: 60
   - label: alt_svc_header_syntax
     section: § 1.1
     snippet: This document uses the Augmented BNF defined in [RFC5234] and updated by [RFC7405] along with the "#rule" extension defined in Section 7 of [RFC7230].
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 802
+      line: 814
   - label: alt_svc_header_syntax (2)
     section: § 2
     snippet: Note that for the purpose of this specification, an ALPN protocol name implicitly includes TLS in the suite of protocols it identifies, unless specified otherwise in its definition.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 360
+      line: 368
   - label: alt_svc_header_syntax (3)
     section: § 3
     snippet: Alt-Svc MAY occur in any HTTP response message, regardless of the status code.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 734
+      line: 746
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 353
   - label: alt_svc_header_syntax (4)
@@ -4091,25 +4091,25 @@ sources:
     snippet: Consequently, the octet representing the percent character "%" (hex 25) MUST be percent-encoded as well.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 188
+      line: 190
   - label: alt_svc_header_syntax (5)
     section: § 3
     snippet: Note that the "quoted-string" syntax needs to be used because ":" is not an allowed character in "token".
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 261
+      line: 263
   - label: alt_svc_header_syntax (6)
     section: § 3
     snippet: Octets in the ALPN protocol name MUST NOT be percent-encoded if they are valid token characters except "%", and
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 189
+      line: 191
   - label: alt_svc_header_syntax (7)
     section: § 3
     snippet: Octets not allowed in tokens ([RFC7230], Section 3.2.6) MUST be percent-encoded as per Section 2.1 of [RFC3986].
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 187
+      line: 189
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 149
   - label: alt_svc_header_syntax (8)
@@ -4117,13 +4117,19 @@ sources:
     snippet: The "alt-authority" component consists of an OPTIONAL uri-host ("host" in Section 3.2.2 of [RFC3986]), a colon (":"), and a port number.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 260
+      line: 262
+    - file: lint-http-rules/src/violations/alt_svc.rs
+      line: 284
+    - file: lint-http-rules/src/violations/alt_svc.rs
+      line: 304
+    - file: lint-http-rules/src/violations/alt_svc.rs
+      line: 334
   - label: alt_svc_header_syntax (9)
     section: § 3
     snippet: The field value consists either of a list of values, each of which indicates one alternative service, or the keyword "clear".
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 156
+      line: 158
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 28
   - label: alt_svc_header_syntax (10)
@@ -4131,39 +4137,39 @@ sources:
     snippet: When using percent-encoding, uppercase hex digits MUST be used.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 190
+      line: 192
   - label: alt_svc_header_syntax (11)
     section: § 3
     snippet: alt-authority = quoted-string ; containing [ uri-host ] ":" port
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 259
+      line: 261
   - label: alt_svc_header_syntax (12)
     section: § 3
     snippet: alt-value     = alternative *( OWS ";" OWS parameter )
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 168
+      line: 170
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 393
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 250
+      line: 257
   - label: alt_svc_header_syntax (13)
     section: § 3
     snippet: alternative   = protocol-id "=" alt-authority
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 544
+      line: 556
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 404
     - file: lint-http-rules/src/violations/alt_svc.rs
-      line: 130
+      line: 137
   - label: alt_svc_header_syntax (14)
     section: § 3
     snippet: protocol-id   = token ; percent-encoded ALPN protocol name
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 545
+      line: 557
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 147
   - label: alt_svc_header_syntax (15)
@@ -4171,13 +4177,13 @@ sources:
     snippet: Alternative services that are intended to be longer lived (such as those that are not specific to the client access network) can carry the "persist" parameter with a value "1" as a hint that the service is potentially useful beyond a network configuration change.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 514
+      line: 526
   - label: alt_svc_header_syntax (16)
     section: § 8
     snippet: An internationalized domain name that appears in either the header field (Section 3) or the HTTP/2 frame (Section 4) MUST be expressed using A-labels ([RFC5890], Section 2.3.2.1).
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 296
+      line: 298
   - label: alt_svc_protocol_registered
     section: § 2
     snippet: An Application Layer Protocol Negotiation (ALPN) protocol name, as per [RFC7301]
@@ -5383,7 +5389,7 @@ sources:
     snippet: All HTTP requirements applicable to an origin server also apply to the outbound communication of a gateway.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 718
+      line: 730
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 333
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
@@ -6801,7 +6807,7 @@ sources:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 104
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 803
+      line: 815
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
       line: 103
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
@@ -7261,7 +7267,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 340
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 169
+      line: 171
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 165
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
@@ -7315,7 +7321,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
       line: 155
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 776
+      line: 788
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 601
   - label: lint-http-rules/src/helpers/list.rs (2)
@@ -7377,7 +7383,7 @@ sources:
     - file: lint-http-rules/src/helpers/word.rs
       line: 90
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 262
+      line: 264
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 429
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -7655,7 +7661,7 @@ sources:
     - file: lint-http-rules/src/helpers/word.rs
       line: 89
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 546
+      line: 558
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 411
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
@@ -7795,7 +7801,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 215
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 751
+      line: 763
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 363
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs


### PR DESCRIPTION
`alt-authority = quoted-string` is a production and a comment, and the requirement is the prose beside it: an OPTIONAL uri-host, a colon, and a port number. Two of the three are not optional, so one sentence answers for three entries.

Three and not one, because the senders differ and so do the fixes. A value with no colon stopped at the host; a value ending on the colon knew the component was there and wrote none of it — the delimiter line a CONNECT's destination already drew — and a value naming 65536 wrote a number that is not a port.

The last of those is the shape where the sentence and the measurement come from different places. §3's prose is what makes it a defect, and the width comes from §2 — an ALPN protocol name implicitly identifies a suite carried over a transport — and from RFC 6335 §6, where those transports register their ports in a sixteen-bit namespace. So the entry names the requirement and the rule names the two references that measure it: a bound reached through a transport is still the requirement's defect. `0` stays unreported, a reserved value inside the namespace rather than outside it.

All three are `warn` where the CONNECT destination's are `error`, and the difference is what a recipient loses: a tunnel that cannot be opened is the request, and an alternative that cannot be opened is a hint the client did not need.

Catalogue 264, spec floor 255. One finding is left in this rule.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
