### PR TITLE
The one sentence written to a server

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1895,6 +1895,10 @@ severity = "error"
 # WebSocket handshake carries no Sec-WebSocket-Version
 severity = "error"
 
+[violations.server_timing_param_duplicated]
+# Server-Timing metric names one parameter more than once
+severity = "warn"
+
 [violations.server_timing_param_empty]
 # Server-Timing writes a semicolon with no parameter behind it
 severity = "warn"

--- a/lint-http-rules/src/rules/server_timing_header_syntax.rs
+++ b/lint-http-rules/src/rules/server_timing_header_syntax.rs
@@ -19,8 +19,9 @@ use crate::violations::quoted_string::{
     QUOTED_STRING_DELIMITER_MISSING, QUOTED_STRING_QUOTE_ESCAPE_MISSING, RFC_9110_5_6_4,
 };
 use crate::violations::server_timing::{
-    SERVER_TIMING_2, SERVER_TIMING_PARAM_EMPTY, SERVER_TIMING_PARAM_EQUALS_MISSING,
-    SERVER_TIMING_PARAM_VALUE_EMPTY, SERVER_TIMING_PARAM_VALUE_MALFORMED,
+    SERVER_TIMING_2, SERVER_TIMING_PARAM_DUPLICATED, SERVER_TIMING_PARAM_EMPTY,
+    SERVER_TIMING_PARAM_EQUALS_MISSING, SERVER_TIMING_PARAM_VALUE_EMPTY,
+    SERVER_TIMING_PARAM_VALUE_MALFORMED,
 };
 use crate::violations::token::{
     token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN, TOKEN_EMPTY,
@@ -144,8 +145,8 @@ fn is_valid_floating_point_number(s: &str) -> bool {
 /// § 2 prints.
 pub struct ServerTimingHeaderSyntax;
 
-/// Twelve defects over four subjects, and the field's own document defines four
-/// of them.
+/// Thirteen defects over four subjects, and the field's own document defines
+/// five of them.
 ///
 /// § 2 prints `Server-Timing = #server-timing-metric` and then a sentence
 /// naming where the notation comes from: *See [RFC7230] for definitions of #,
@@ -162,10 +163,12 @@ pub struct ServerTimingHeaderSyntax;
 /// alternative it started in. That is the residue a borrowed construct leaves,
 /// for the fourth and fifth time.
 ///
-/// **Three sentences stay unnamed**: a parameter named twice, which is § 2's
-/// SHOULD NOT and the only sentence in the document measuring a server, and the
-/// two the getters supply — a `dur` that is not a valid floating-point number,
-/// and a name spelled in a case that surfaces nothing.
+/// **The fifth is § 2's SHOULD NOT**, the only sentence in the document
+/// measuring a server, and it is the one entry here that is not assembly.
+///
+/// **Two sentences stay unnamed**, both of them the getters': a `dur` that is
+/// not a valid floating-point number, and a name spelled in a case that
+/// surfaces nothing.
 ///
 /// **`parameter_equals_missing` is deliberately not among these**, and the
 /// reason is written at the site: this parameter is not § 5.6.6's. Its value is
@@ -193,6 +196,7 @@ static DECLARED: &[&ViolationDef] = &[
     &SERVER_TIMING_PARAM_EQUALS_MISSING,
     &SERVER_TIMING_PARAM_VALUE_EMPTY,
     &SERVER_TIMING_PARAM_VALUE_MALFORMED,
+    &SERVER_TIMING_PARAM_DUPLICATED,
     &LIST_MEMBER_EMPTY,
     &TOKEN_EMPTY,
     &TOKEN_CHARACTER_FORBIDDEN,
@@ -662,15 +666,18 @@ fn check_param<'a>(metric: &str, param: &'a str, seen: &mut Vec<&'a str>) -> Opt
     // cite(Server Timing § 2): "All subsequent occurrences MUST be ignored without signaling an error or otherwise altering the processing of the server-timing-metric."
     if seen.contains(&name) {
         // The document's own sentence, and the only one it addresses to a
-        // server. `parameter_duplicated` is the def a subject would hold for
-        // this, and no subject holds one yet — three fields report a repeated
-        // parameter over three different productions, and nothing has read them
-        // together.
-        return Some(Defect::unnamed(format!(
+        // server. It is *this field's* entry rather than a shared
+        // `parameter_duplicated`: the four fields reporting a repeated
+        // parameter were read together and no two of them share a production, a
+        // document or a modal, which the def records.
+        return Some(Defect::named(
+            &SERVER_TIMING_PARAM_DUPLICATED,
+            format!(
             "Server-Timing metric '{}' names the server-timing-param '{}' more than once; a user agent takes the first occurrence and ignores the rest without signalling anything, so the later values are silently discarded (advice: the specification says SHOULD NOT, to avoid any possible ambiguity)",
-            shown_in_finding(metric),
-            shown_in_finding(name)
-        )));
+                shown_in_finding(metric),
+                shown_in_finding(name)
+            ),
+        ));
     }
     seen.push(name);
 
@@ -968,8 +975,16 @@ mod tests {
         "server_timing_param_value_malformed"
     )]
     // Advice, and every one of these was silence before.
-    #[case::repeated_param(b"db;dur=50;dur=51", "more than once", "")]
-    #[case::repeated_param_second_invalid(b"db;dur=50;dur=abc", "more than once", "")]
+    #[case::repeated_param(
+        b"db;dur=50;dur=51",
+        "more than once",
+        "server_timing_param_duplicated"
+    )]
+    #[case::repeated_param_second_invalid(
+        b"db;dur=50;dur=abc",
+        "more than once",
+        "server_timing_param_duplicated"
+    )]
     // Which spellings the production admits is the table at the bottom of this
     // module; these two cases are here for the wiring -- that the branch is
     // reached, and that it is reached through the quoted alternative too, where

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -437,7 +437,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 260;
+        const FLOOR: usize = 261;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/server_timing.rs
+++ b/lint-http-rules/src/violations/server_timing.rs
@@ -25,6 +25,12 @@
 //! document is another production**, which is the line `Alt-Svc` drew one field
 //! over and this document draws at a publisher that is not the IETF.
 //!
+//! **One entry is not the assembly**: § 2's SHOULD NOT about a parameter name
+//! written twice, which is the only sentence the document addresses to a
+//! server. Everything else it says about repetition is the user agent's
+//! recovery — take the first, ignore the rest, signal nothing — so nothing but
+//! that entry will ever tell a server the later values were discarded.
+//!
 //! **Every entry here names the section that prints the production, and none
 //! names the modal.** The Server Timing specification holds nine BCP 14
 //! keywords and eight of them are addressed to the user agent; the one that
@@ -127,6 +133,42 @@ defects! {
         spec: &[SERVER_TIMING_2],
     }
 
+    /// One `server-timing-param-name` written twice in one metric:
+    /// `db;dur=50;dur=51`.
+    ///
+    /// **The only sentence in the document addressed to a server**, which is
+    /// what makes this entry different in kind from the four around it. The
+    /// other three of its four modals about repetition are the user agent's:
+    /// take the first occurrence, ignore every later one, signal no error. So
+    /// nothing but this will ever tell a server it wrote an ambiguity, and the
+    /// later values are discarded where no one can see it happen.
+    ///
+    /// `warn` rather than the `info` the two advisory entries carry, and the
+    /// consequence is the reason rather than the modal: a SHOULD NOT is weaker
+    /// than the MUST NOT holding up the grammar entries, and what a recipient
+    /// does about it is worse — it keeps a value the server did not mean and
+    /// says nothing.
+    ///
+    /// **Not a shared `parameter_duplicated`, and the four fields were read
+    /// together before that was decided.** `Forwarded` states a MUST NOT per
+    /// field value (RFC 7239 § 4), `Link` states one per parameter with the
+    /// parser's ignore-after-first beside it (RFC 8288 § 3.3, § 3.4.1),
+    /// `Prefer` says only the first instance is considered (RFC 7240 § 2), and
+    /// this document says SHOULD NOT to avoid ambiguity. Four productions, four
+    /// documents, four modals — **an identical defect under a different
+    /// sentence is a different entry**, so a shared one would name whichever
+    /// document was written first and cite it on three fields it does not
+    /// govern.
+    ///
+    // cite(Server Timing § 2): "To avoid any possible ambiguity, individual server-timing-param-names SHOULD NOT appear multiple times within a server-timing-metric."
+    SERVER_TIMING_PARAM_DUPLICATED = {
+        id: "server_timing_param_duplicated",
+        title: "Server-Timing metric names one parameter more than once",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[SERVER_TIMING_2],
+    }
+
     /// Content after the closing DQUOTE of a quoted value: `db;desc="abc"x`.
     ///
     /// The `quoted-string` is well formed and closed where it says; what
@@ -173,6 +215,7 @@ mod tests {
             &SERVER_TIMING_PARAM_EQUALS_MISSING,
             &SERVER_TIMING_PARAM_VALUE_EMPTY,
             &SERVER_TIMING_PARAM_VALUE_MALFORMED,
+            &SERVER_TIMING_PARAM_DUPLICATED,
         ] {
             assert_eq!(def.spec, [SERVER_TIMING_2], "{}", def.id);
             assert_eq!(def.default_severity, Severity::Warn, "{}", def.id);

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -312,25 +312,25 @@ sources:
     snippet: 'A string is a valid floating-point number if it consists of:'
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 77
+      line: 78
   - label: server_timing_header_syntax (2)
     section: § 2.3.4.3
     snippet: Advance position to the next character. (The "+" is ignored, but it is not conforming.)
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 88
+      line: 89
   - label: server_timing_header_syntax (3)
     section: § 2.3.4.3
     snippet: The Infinity and Not-a-Number (NaN) values are not valid floating-point numbers.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 78
+      line: 79
   - label: server_timing_header_syntax (4)
     section: § 2.3.4.3
     snippet: The valid floating-point number concept is typically only used to restrict what is allowed for authors, while the user agent requirements use the rules for parsing floating-point number values below
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 79
+      line: 80
 - label: HTML Document Lifecycle
   url: https://html.spec.whatwg.org/multipage/document-lifecycle.html
   type: text/html
@@ -589,113 +589,115 @@ sources:
     snippet: '*( OWS ";" OWS server-timing-param ) metric-name = token'
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 502
+      line: 506
   - label: server_timing_header_syntax
     section: § 2
     snippet: A user agent that does not recognize particular server-timing-param-name in the Server-Timing header field of a response MUST ignore those tokens and continue processing instead of signaling an error.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 46
+      line: 47
   - label: server_timing_header_syntax (2)
     section: § 2
     snippet: All subsequent occurrences MUST be ignored without signaling an error or otherwise altering the processing of the server-timing-metric.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 662
+      line: 666
   - label: server_timing_header_syntax (3)
     section: § 2
     snippet: If any server-timing-param-name is specified more than once, only the first instance is to be considered, even if the server-timing-param is incomplete or invalid.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 661
+      line: 665
   - label: server_timing_header_syntax (4)
     section: § 2
     snippet: 'See [RFC7230] for definitions of #, *, OWS, token, and quoted-string.'
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 470
+      line: 474
   - label: Server-Timing grammar
     section: § 2
     snippet: 'Server-Timing = #server-timing-metric'
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 469
+      line: 473
   - label: server_timing_header_syntax (5)
     section: § 2
     snippet: The Server-Timing header field is used to communicate one or more metrics and descriptions for the given request-response cycle.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 364
+      line: 368
   - label: server_timing_header_syntax (6)
     section: § 2
     snippet: This specification establishes the server-timing-params for server-timing-param-names "dur" for duration and "desc" for description, both optional.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 45
+      line: 46
   - label: server_timing_header_syntax (7)
     section: § 2
     snippet: To avoid any possible ambiguity, individual server-timing-param-names SHOULD NOT appear multiple times within a server-timing-metric.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 660
+      line: 664
+    - file: lint-http-rules/src/violations/server_timing.rs
+      line: 163
   - label: server_timing_header_syntax (8)
     section: § 2
     snippet: User agents MUST ignore extraneous characters found after a server-timing-param-value but before the next server-timing-param and before the end of the current server-timing-metric.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 686
+      line: 693
   - label: server-timing-metric grammar
     section: § 2
     snippet: server-timing-metric = metric-name *( OWS ";" OWS server-timing-param )
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 501
+      line: 505
     - file: lint-http-rules/src/violations/server_timing.rs
-      line: 39
+      line: 45
     - file: lint-http-rules/src/violations/server_timing.rs
-      line: 71
+      line: 77
   - label: server-timing-param grammar
     section: § 2
     snippet: server-timing-param = server-timing-param-name OWS "=" OWS server-timing-param-value
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 580
+      line: 584
     - file: lint-http-rules/src/violations/server_timing.rs
-      line: 96
+      line: 102
   - label: server-timing-param-name grammar
     section: § 2
     snippet: server-timing-param-name = token
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 581
+      line: 585
   - label: server-timing-param-value grammar
     section: § 2
     snippet: server-timing-param-value = token / quoted-string
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 724
+      line: 731
     - file: lint-http-rules/src/violations/server_timing.rs
-      line: 121
+      line: 127
     - file: lint-http-rules/src/violations/server_timing.rs
-      line: 149
+      line: 191
   - label: server_timing_header_syntax (9)
     section: § 3.2
     snippet: If dur is an error, return 0; Otherwise return dur.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 806
+      line: 813
   - label: server_timing_header_syntax (10)
     section: § 3.2
     snippet: Let dur be the result of parsing this’s params["dur"] using the rules for parsing floating-point number values.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 805
+      line: 812
   - label: server_timing_header_syntax (11)
     section: § 3.3
     snippet: The description getter steps are to return this’s params["desc"] if it exists, otherwise the empty string.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 789
+      line: 796
 - label: Permissions Policy
   url: https://w3c.github.io/webappsec-permissions-policy/
   type: text/html
@@ -5403,7 +5405,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 333
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 365
+      line: 369
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
       line: 188
   - label: auth_scheme
@@ -6839,7 +6841,7 @@ sources:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 315
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 481
+      line: 485
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
       line: 183
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
@@ -7061,7 +7063,7 @@ sources:
     - file: lint-http-rules/src/rules/refresh_header_syntax.rs
       line: 324
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 464
+      line: 468
     - file: lint-http-rules/src/rules/trace_method_echo.rs
       line: 46
     - file: lint-http-rules/src/rules/via_header_syntax.rs
@@ -7107,7 +7109,7 @@ sources:
     - file: lint-http-rules/src/rules/server_header_product_valid.rs
       line: 160
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 397
+      line: 401
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
       line: 240
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
@@ -7225,7 +7227,7 @@ sources:
     - file: lint-http-rules/src/rules/server_header_product_valid.rs
       line: 174
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 408
+      line: 412
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
       line: 187
   - label: lint-http-rules/src/helpers/headers.rs (6)
@@ -7293,7 +7295,7 @@ sources:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 307
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 626
+      line: 630
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 251
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
@@ -7395,7 +7397,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 257
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 440
+      line: 444
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 423
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
@@ -7679,7 +7681,7 @@ sources:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
       line: 245
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 517
+      line: 521
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 276
     - file: lint-http-rules/src/rules/via_header_syntax.rs
@@ -7815,7 +7817,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 363
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 407
+      line: 411
   - label: lint-http-rules/src/helpers/word.rs
     section: § 5.6.3
     snippet: The BWS rule is used where the grammar allows optional whitespace only for historical reasons.
@@ -8829,7 +8831,7 @@ sources:
     snippet: '#element => [ 1#element ]'
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 463
+      line: 467
   - label: singleton_fields_not_repeated
     section: § 10.1.5
     snippet: User-Agent = product *( RWS ( product / comment ) )


### PR DESCRIPTION
Server Timing holds nine BCP 14 keywords and eight of them are the user agent's. The ninth is a SHOULD NOT about writing one parameter name twice in a metric, and it is the only thing in the document that measures what a server sent.

Everything else the specification says about repetition is recovery: take the first occurrence, ignore every later one, signal no error. So nothing but this entry will ever tell a server it wrote an ambiguity, and the values it discarded are discarded where no one can see it happen. That is the argument for `warn` rather than the `info` the advisory entries will carry — the modal is weaker than the grammar's and the consequence is worse.

Not a shared `parameter_duplicated`, and the four fields were read together before that was settled. `Forwarded` states a MUST NOT per field value, `Link` states one per parameter with the parser's ignore-after-first beside it, `Prefer` says only the first instance is considered, and this document says SHOULD NOT to avoid ambiguity. Four productions, four documents, four modals: an identical defect under a different sentence is a different entry, and a shared one would cite whichever document was written first on three fields it does not govern.

Catalogue 270, spec floor 261. Two of this rule's findings are left, both of them the getters'.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
