### PR TITLE
What the two getters will not find

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1895,6 +1895,10 @@ severity = "error"
 # WebSocket handshake carries no Sec-WebSocket-Version
 severity = "error"
 
+[violations.server_timing_dur_invalid]
+# Server-Timing writes a dur that is not a valid floating-point number
+severity = "info"
+
 [violations.server_timing_param_duplicated]
 # Server-Timing metric names one parameter more than once
 severity = "warn"
@@ -1906,6 +1910,10 @@ severity = "warn"
 [violations.server_timing_param_equals_missing]
 # Server-Timing parameter has no '=' and no value
 severity = "warn"
+
+[violations.server_timing_param_name_invalid]
+# Server-Timing names an established parameter in a case no getter matches
+severity = "info"
 
 [violations.server_timing_param_value_empty]
 # Server-Timing parameter is written with no value after its '='

--- a/lint-http-rules/src/rules/server_timing_header_syntax.rs
+++ b/lint-http-rules/src/rules/server_timing_header_syntax.rs
@@ -19,8 +19,9 @@ use crate::violations::quoted_string::{
     QUOTED_STRING_DELIMITER_MISSING, QUOTED_STRING_QUOTE_ESCAPE_MISSING, RFC_9110_5_6_4,
 };
 use crate::violations::server_timing::{
-    SERVER_TIMING_2, SERVER_TIMING_PARAM_DUPLICATED, SERVER_TIMING_PARAM_EMPTY,
-    SERVER_TIMING_PARAM_EQUALS_MISSING, SERVER_TIMING_PARAM_VALUE_EMPTY,
+    SERVER_TIMING_2, SERVER_TIMING_DUR_INVALID, SERVER_TIMING_PARAM_DUPLICATED,
+    SERVER_TIMING_PARAM_EMPTY, SERVER_TIMING_PARAM_EQUALS_MISSING,
+    SERVER_TIMING_PARAM_NAME_INVALID, SERVER_TIMING_PARAM_VALUE_EMPTY,
     SERVER_TIMING_PARAM_VALUE_MALFORMED,
 };
 use crate::violations::token::{
@@ -145,8 +146,8 @@ fn is_valid_floating_point_number(s: &str) -> bool {
 /// § 2 prints.
 pub struct ServerTimingHeaderSyntax;
 
-/// Thirteen defects over four subjects, and the field's own document defines
-/// five of them.
+/// Fifteen defects over four subjects, and the field's own document defines
+/// seven of them.
 ///
 /// § 2 prints `Server-Timing = #server-timing-metric` and then a sentence
 /// naming where the notation comes from: *See [RFC7230] for definitions of #,
@@ -166,9 +167,12 @@ pub struct ServerTimingHeaderSyntax;
 /// **The fifth is § 2's SHOULD NOT**, the only sentence in the document
 /// measuring a server, and it is the one entry here that is not assembly.
 ///
-/// **Two sentences stay unnamed**, both of them the getters': a `dur` that is
-/// not a valid floating-point number, and a name spelled in a case that
-/// surfaces nothing.
+/// **The last two are the getters', and they are the two entries here that name
+/// no sentence**: a `dur` that is not a valid floating-point number, and a name
+/// spelled in a case that surfaces nothing. § 3.2 and § 3.3 state what an
+/// attribute returns, which is a consequence and not a requirement, so a
+/// reference on either entry would dress the one as the other. Both are `info`
+/// for the same reason — a diagnostic reading zero costs nobody a request.
 ///
 /// **`parameter_equals_missing` is deliberately not among these**, and the
 /// reason is written at the site: this parameter is not § 5.6.6's. Its value is
@@ -197,6 +201,8 @@ static DECLARED: &[&ViolationDef] = &[
     &SERVER_TIMING_PARAM_VALUE_EMPTY,
     &SERVER_TIMING_PARAM_VALUE_MALFORMED,
     &SERVER_TIMING_PARAM_DUPLICATED,
+    &SERVER_TIMING_PARAM_NAME_INVALID,
+    &SERVER_TIMING_DUR_INVALID,
     &LIST_MEMBER_EMPTY,
     &TOKEN_EMPTY,
     &TOKEN_CHARACTER_FORBIDDEN,
@@ -207,31 +213,21 @@ static DECLARED: &[&ViolationDef] = &[
     &QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
 ];
 
-/// One finding from the reading, and the defect it reports as where the
-/// catalogue names that defect.
+/// One finding from the reading, and the entry it reports as.
 ///
 /// The shape `expect_header_valid` settled and `warning_header_syntax`
-/// generalised: four nested judges that returned `Option<String>` return this
-/// instead, and [`Defect::in_context`] is where the section's name goes on the
-/// front, so the wording is byte-identical to what it was.
+/// generalised — **without the `Option` now**, since every arm of the four
+/// nested judges names an entry. [`Defect::in_context`] is where the section's
+/// name goes on the front, so the wording is byte-identical to what it was.
 struct Defect {
-    def: Option<&'static ViolationDef>,
+    def: &'static ViolationDef,
     message: String,
 }
 
 impl Defect {
     /// A defect the catalogue names.
     fn named(def: &'static ViolationDef, message: String) -> Self {
-        Self {
-            def: Some(def),
-            message,
-        }
-    }
-
-    /// A defect no subject has claimed, reported at the rule's severity the way
-    /// every finding here was before the catalogue existed.
-    fn unnamed(message: String) -> Self {
-        Self { def: None, message }
+        Self { def, message }
     }
 
     /// The same defect with its message read from further out — which field
@@ -420,10 +416,7 @@ impl Rule for ServerTimingHeaderSyntax {
                 if let Some(defect) = check_field_value(&value) {
                     let defect = defect
                         .in_context(|message| format!("In the response {section}: {message}"));
-                    return Some(match defect.def {
-                        Some(def) => ctx.report_with(def, defect.message),
-                        None => self.violation(ctx.severity, defect.message),
-                    });
+                    return Some(ctx.report_with(defect.def, defect.message));
                 }
             }
 
@@ -795,12 +788,15 @@ fn established_param_advice(metric: &str, name: &str, value: &str) -> Option<Def
     //
     // cite(Server Timing § 3.3): "The description getter steps are to return this’s params["desc"] if it exists, otherwise the empty string."
     if name != *established {
-        return Some(Defect::unnamed(format!(
+        return Some(Defect::named(
+            &SERVER_TIMING_PARAM_NAME_INVALID,
+            format!(
             "Server-Timing metric '{}' names a server-timing-param '{}', which is '{}' in another case; the attribute that would surface it looks the name up as written, so this parameter is one no user agent recognises and every one of them ignores without error (advice: nothing forbids the name)",
-            shown_in_finding(metric),
-            shown_in_finding(name),
-            established
-        )));
+                shown_in_finding(metric),
+                shown_in_finding(name),
+                established
+            ),
+        ));
     }
 
     // `desc` is whatever the server wrote and § 3.3 returns it unexamined, so
@@ -812,11 +808,14 @@ fn established_param_advice(metric: &str, name: &str, value: &str) -> Option<Def
     // cite(Server Timing § 3.2): "Let dur be the result of parsing this’s params["dur"] using the rules for parsing floating-point number values."
     // cite(Server Timing § 3.2): "If dur is an error, return 0; Otherwise return dur."
     if *established == "dur" && !is_valid_floating_point_number(value) {
-        return Some(Defect::unnamed(format!(
+        return Some(Defect::named(
+            &SERVER_TIMING_DUR_INVALID,
+            format!(
             "Server-Timing metric '{}' has a 'dur' of '{}', which is not a valid floating-point number; the parsing rules return an error for a value that does not begin with one — surfaced as a duration of 0 — and otherwise stop at the first character that is not part of the number, so neither reading is what this metric says (advice: no sentence requires 'dur' to be a number)",
-            shown_in_finding(metric),
-            shown_in_finding(value)
-        )));
+                shown_in_finding(metric),
+                shown_in_finding(value)
+            ),
+        ));
     }
 
     None
@@ -917,14 +916,15 @@ mod tests {
     /// Every finding this rule makes, with the sentence it says it in and the
     /// defect it reports as.
     ///
-    /// The third column splits the table in three. Most ids name a production
-    /// the field borrowed — the list around the metrics, the `token` three
-    /// positions are, the `quoted-string` a value may be — and an operator
-    /// tunes those once for every field in this catalogue written out of the
-    /// same production. Four name this document's own assembly, which no
-    /// borrowed production can fail. An empty one is what is left: § 2's SHOULD
-    /// NOT, and what the two getters do with what they are handed. There is
-    /// nothing in the middle, which is the claim.
+    /// The third column splits the table in three, and no cell in it is empty
+    /// any more. Most ids name a production the field borrowed — the list
+    /// around the metrics, the `token` three positions are, the `quoted-string`
+    /// a value may be — and an operator tunes those once for every field in
+    /// this catalogue written out of the same production. Four name this
+    /// document's own assembly, which no borrowed production can fail. Three
+    /// name what only this field can say: § 2's SHOULD NOT, and the two things
+    /// the getters do with what they are handed. There is nothing in the
+    /// middle, which is the claim.
     #[rstest]
     #[case::leading_comma(b",miss", "empty list element", "list_member_empty")]
     #[case::trailing_comma(b"miss,", "empty list element", "list_member_empty")]
@@ -989,11 +989,31 @@ mod tests {
     // module; these two cases are here for the wiring -- that the branch is
     // reached, and that it is reached through the quoted alternative too, where
     // `""` is a value the empty-value branch above cannot see.
-    #[case::dur_not_a_number(b"db;dur=abc", "not a valid floating-point number", "")]
-    #[case::dur_quoted_empty(b"db;dur=\"\"", "not a valid floating-point number", "")]
-    #[case::dur_quoted_not_a_number(b"db;dur=\"abc\"", "not a valid floating-point number", "")]
-    #[case::dur_wrong_case(b"db;DUR=53", "which is 'dur' in another case", "")]
-    #[case::desc_wrong_case(b"db;Desc=x", "which is 'desc' in another case", "")]
+    #[case::dur_not_a_number(
+        b"db;dur=abc",
+        "not a valid floating-point number",
+        "server_timing_dur_invalid"
+    )]
+    #[case::dur_quoted_empty(
+        b"db;dur=\"\"",
+        "not a valid floating-point number",
+        "server_timing_dur_invalid"
+    )]
+    #[case::dur_quoted_not_a_number(
+        b"db;dur=\"abc\"",
+        "not a valid floating-point number",
+        "server_timing_dur_invalid"
+    )]
+    #[case::dur_wrong_case(
+        b"db;DUR=53",
+        "which is 'dur' in another case",
+        "server_timing_param_name_invalid"
+    )]
+    #[case::desc_wrong_case(
+        b"db;Desc=x",
+        "which is 'desc' in another case",
+        "server_timing_param_name_invalid"
+    )]
     fn reported(#[case] line: &[u8], #[case] expected: &str, #[case] violation: &str) {
         let v = header(line).unwrap_or_else(|| panic!("expected a finding for {line:?}"));
         assert!(

--- a/lint-http-rules/src/violations/server_timing.rs
+++ b/lint-http-rules/src/violations/server_timing.rs
@@ -31,7 +31,15 @@
 //! recovery — take the first, ignore the rest, signal nothing — so nothing but
 //! that entry will ever tell a server the later values were discarded.
 //!
-//! **Every entry here names the section that prints the production, and none
+//! **Two entries name no sentence at all**, and they are the two the getters
+//! supply: a `dur` that is not a *valid floating-point number* and a name
+//! spelled in a case the exact-string lookup will not match. § 3.2 and § 3.3
+//! say what an attribute returns — zero, and the empty string — which is a
+//! consequence rather than a requirement, and the production measuring the
+//! first is HTML's rather than this document's. **A measurement borrowed from
+//! another document does not make that document the requirement.**
+//!
+//! **Every other entry names the section that prints the production, and none
 //! names the modal.** The Server Timing specification holds nine BCP 14
 //! keywords and eight of them are addressed to the user agent; the one that
 //! measures a server is § 2's SHOULD NOT about a repeated parameter name. So
@@ -133,6 +141,71 @@ defects! {
         spec: &[SERVER_TIMING_2],
     }
 
+    /// A parameter named `DUR` or `Desc`: one of the two established names in
+    /// every respect but case.
+    ///
+    /// `params` is an ordered map keyed by the name as the sender wrote it, and
+    /// the two getters index it with a literal — `params["dur"]`,
+    /// `params["desc"]` — so a name differing only in case is a name neither of
+    /// them finds. Nothing forbids it: the document has a user agent ignore a
+    /// name it does not recognise, without signalling an error. What is wrong
+    /// is that the server almost certainly meant the one it did not write.
+    ///
+    /// **`_invalid` for a value nothing refuses**, which is the reading
+    /// `Alt-Svc`'s `protocol-id` settled: a spelling that a recipient's exact
+    /// comparison will not match is grammatical and unusable as meant, one
+    /// level past the grammar. An id built on the *lookup* would have named
+    /// what the user agent did, which is correct behaviour and not a defect.
+    ///
+    /// **Uncited, and the reason is the first of the three**: no sentence
+    /// states this. § 3.3 defines what the getter returns and § 2 tells a
+    /// recipient to ignore what it does not know — a meaning and a recovery,
+    /// neither of them a requirement on the name — so a reference here would
+    /// dress a consequence as a rule. The same argument `Alt-Svc`'s freshness
+    /// lifetime carries, at a document whose every modal is the reader's.
+    ///
+    /// `info`. Nothing is unreadable, nothing else is affected, and one
+    /// parameter of one metric is invisible to the API that would have shown
+    /// it.
+    SERVER_TIMING_PARAM_NAME_INVALID = {
+        id: "server_timing_param_name_invalid",
+        title: "Server-Timing names an established parameter in a case no getter matches",
+        message: "",
+        default_severity: Severity::Info,
+        spec: &[],
+    }
+
+    /// A `dur` whose value is not a *valid floating-point number*: `dur=abc`,
+    /// `dur=+5`, `dur=NaN`, `dur=5.`.
+    ///
+    /// **No sentence requires `dur` to be a number**, which is the whole shape
+    /// of this entry. § 3.2 parses the value with HTML's *rules for parsing
+    /// floating-point number values* and returns 0 if that is an error — a
+    /// consequence rather than a requirement — so what the finding reports is
+    /// that the metric arrives saying a duration of zero, or a duration that
+    /// stops at the first character the parser cannot use.
+    ///
+    /// **The production measuring it is the rule's reference, not this
+    /// entry's.** HTML keeps two definitions deliberately apart: the *valid
+    /// floating-point number* a conforming author writes, and the parsing rules
+    /// a user agent runs over whatever arrived. A rule measuring a sender wants
+    /// the first, and neither of them is `f64::from_str`, which admits
+    /// Infinity, NaN and a leading `+` and refuses `53abc` that the parser
+    /// reads as 53. **A measurement borrowed from another document does not
+    /// make that document the requirement** — the requirement does not exist,
+    /// so the entry names nothing.
+    ///
+    /// `_invalid`: every octet derives from `token`, and what fails is what the
+    /// value means. `info`, with its sibling — the metric is a diagnostic, and
+    /// a diagnostic that reads zero costs nobody a request.
+    SERVER_TIMING_DUR_INVALID = {
+        id: "server_timing_dur_invalid",
+        title: "Server-Timing writes a dur that is not a valid floating-point number",
+        message: "",
+        default_severity: Severity::Info,
+        spec: &[],
+    }
+
     /// One `server-timing-param-name` written twice in one metric:
     /// `db;dur=50;dur=51`.
     ///
@@ -219,6 +292,22 @@ mod tests {
         ] {
             assert_eq!(def.spec, [SERVER_TIMING_2], "{}", def.id);
             assert_eq!(def.default_severity, Severity::Warn, "{}", def.id);
+        }
+    }
+
+    /// The two entries the getters supply are the two with no sentence, and
+    /// they rank below everything the grammar answers for: an attribute
+    /// returning zero or an empty string is a consequence the document
+    /// describes, not a requirement it states.
+    #[test]
+    fn what_the_getters_do_is_uncited_and_ranks_lowest() {
+        for def in [
+            &SERVER_TIMING_PARAM_NAME_INVALID,
+            &SERVER_TIMING_DUR_INVALID,
+        ] {
+            assert!(def.spec.is_empty(), "{}", def.id);
+            assert_eq!(def.default_severity, Severity::Info, "{}", def.id);
+            assert!(def.default_severity < SERVER_TIMING_PARAM_DUPLICATED.default_severity);
         }
     }
 

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -312,25 +312,25 @@ sources:
     snippet: 'A string is a valid floating-point number if it consists of:'
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 78
+      line: 79
   - label: server_timing_header_syntax (2)
     section: § 2.3.4.3
     snippet: Advance position to the next character. (The "+" is ignored, but it is not conforming.)
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 89
+      line: 90
   - label: server_timing_header_syntax (3)
     section: § 2.3.4.3
     snippet: The Infinity and Not-a-Number (NaN) values are not valid floating-point numbers.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 79
+      line: 80
   - label: server_timing_header_syntax (4)
     section: § 2.3.4.3
     snippet: The valid floating-point number concept is typically only used to restrict what is allowed for authors, while the user agent requirements use the rules for parsing floating-point number values below
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 80
+      line: 81
 - label: HTML Document Lifecycle
   url: https://html.spec.whatwg.org/multipage/document-lifecycle.html
   type: text/html
@@ -589,115 +589,115 @@ sources:
     snippet: '*( OWS ";" OWS server-timing-param ) metric-name = token'
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 506
+      line: 499
   - label: server_timing_header_syntax
     section: § 2
     snippet: A user agent that does not recognize particular server-timing-param-name in the Server-Timing header field of a response MUST ignore those tokens and continue processing instead of signaling an error.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 47
+      line: 48
   - label: server_timing_header_syntax (2)
     section: § 2
     snippet: All subsequent occurrences MUST be ignored without signaling an error or otherwise altering the processing of the server-timing-metric.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 666
+      line: 659
   - label: server_timing_header_syntax (3)
     section: § 2
     snippet: If any server-timing-param-name is specified more than once, only the first instance is to be considered, even if the server-timing-param is incomplete or invalid.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 665
+      line: 658
   - label: server_timing_header_syntax (4)
     section: § 2
     snippet: 'See [RFC7230] for definitions of #, *, OWS, token, and quoted-string.'
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 474
+      line: 467
   - label: Server-Timing grammar
     section: § 2
     snippet: 'Server-Timing = #server-timing-metric'
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 473
+      line: 466
   - label: server_timing_header_syntax (5)
     section: § 2
     snippet: The Server-Timing header field is used to communicate one or more metrics and descriptions for the given request-response cycle.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 368
+      line: 364
   - label: server_timing_header_syntax (6)
     section: § 2
     snippet: This specification establishes the server-timing-params for server-timing-param-names "dur" for duration and "desc" for description, both optional.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 46
+      line: 47
   - label: server_timing_header_syntax (7)
     section: § 2
     snippet: To avoid any possible ambiguity, individual server-timing-param-names SHOULD NOT appear multiple times within a server-timing-metric.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 664
+      line: 657
     - file: lint-http-rules/src/violations/server_timing.rs
-      line: 163
+      line: 236
   - label: server_timing_header_syntax (8)
     section: § 2
     snippet: User agents MUST ignore extraneous characters found after a server-timing-param-value but before the next server-timing-param and before the end of the current server-timing-metric.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 693
+      line: 686
   - label: server-timing-metric grammar
     section: § 2
     snippet: server-timing-metric = metric-name *( OWS ";" OWS server-timing-param )
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 505
+      line: 498
     - file: lint-http-rules/src/violations/server_timing.rs
-      line: 45
+      line: 53
     - file: lint-http-rules/src/violations/server_timing.rs
-      line: 77
+      line: 85
   - label: server-timing-param grammar
     section: § 2
     snippet: server-timing-param = server-timing-param-name OWS "=" OWS server-timing-param-value
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 584
+      line: 577
     - file: lint-http-rules/src/violations/server_timing.rs
-      line: 102
+      line: 110
   - label: server-timing-param-name grammar
     section: § 2
     snippet: server-timing-param-name = token
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 585
+      line: 578
   - label: server-timing-param-value grammar
     section: § 2
     snippet: server-timing-param-value = token / quoted-string
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 731
+      line: 724
     - file: lint-http-rules/src/violations/server_timing.rs
-      line: 127
+      line: 135
     - file: lint-http-rules/src/violations/server_timing.rs
-      line: 191
+      line: 264
   - label: server_timing_header_syntax (9)
     section: § 3.2
     snippet: If dur is an error, return 0; Otherwise return dur.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 813
+      line: 809
   - label: server_timing_header_syntax (10)
     section: § 3.2
     snippet: Let dur be the result of parsing this’s params["dur"] using the rules for parsing floating-point number values.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 812
+      line: 808
   - label: server_timing_header_syntax (11)
     section: § 3.3
     snippet: The description getter steps are to return this’s params["desc"] if it exists, otherwise the empty string.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 796
+      line: 789
 - label: Permissions Policy
   url: https://w3c.github.io/webappsec-permissions-policy/
   type: text/html
@@ -5405,7 +5405,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 333
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 369
+      line: 365
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
       line: 188
   - label: auth_scheme
@@ -6841,7 +6841,7 @@ sources:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 315
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 485
+      line: 478
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
       line: 183
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
@@ -7063,7 +7063,7 @@ sources:
     - file: lint-http-rules/src/rules/refresh_header_syntax.rs
       line: 324
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 468
+      line: 461
     - file: lint-http-rules/src/rules/trace_method_echo.rs
       line: 46
     - file: lint-http-rules/src/rules/via_header_syntax.rs
@@ -7109,7 +7109,7 @@ sources:
     - file: lint-http-rules/src/rules/server_header_product_valid.rs
       line: 160
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 401
+      line: 397
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
       line: 240
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
@@ -7227,7 +7227,7 @@ sources:
     - file: lint-http-rules/src/rules/server_header_product_valid.rs
       line: 174
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 412
+      line: 408
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
       line: 187
   - label: lint-http-rules/src/helpers/headers.rs (6)
@@ -7295,7 +7295,7 @@ sources:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 307
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 630
+      line: 623
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 251
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
@@ -7397,7 +7397,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 257
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 444
+      line: 437
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 423
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
@@ -7681,7 +7681,7 @@ sources:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
       line: 245
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 521
+      line: 514
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 276
     - file: lint-http-rules/src/rules/via_header_syntax.rs
@@ -7817,7 +7817,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 363
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 411
+      line: 407
   - label: lint-http-rules/src/helpers/word.rs
     section: § 5.6.3
     snippet: The BWS rule is used where the grammar allows optional whitespace only for historical reasons.
@@ -8831,7 +8831,7 @@ sources:
     snippet: '#element => [ 1#element ]'
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 467
+      line: 460
   - label: singleton_fields_not_repeated
     section: § 10.1.5
     snippet: User-Agent = product *( RWS ( product / comment ) )


### PR DESCRIPTION
The last two findings in this rule, and the two entries in the subject that name no sentence.

A parameter named `DUR` is one of the two established names in every respect but case, and `params` is keyed by the name as the sender wrote it while the getters index it with a literal. Nothing forbids the name — the document has a user agent ignore what it does not recognise, without error — so what is wrong is that the server almost certainly meant the one it did not write. `_invalid` for a value nothing refuses, which is the reading `Alt-Svc`'s `protocol-id` settled: a spelling an exact comparison will not match is grammatical and unusable as meant.

A `dur` that is not a valid floating-point number is the same shape with the measurement borrowed. §3.2 parses the value with HTML's rules and returns 0 if that is an error, which is a consequence and not a requirement, and the production a conforming author writes against is HTML's rather than this document's. A measurement borrowed from another document does not make that document the requirement — the requirement does not exist, so the entry names nothing and the rule keeps the reference that measures.

Both `info`, below everything the grammar answers for: a diagnostic reading zero costs nobody a request.

With them `server_timing_header_syntax` converts whole — the `Defect` drops its `Option`, `unnamed` goes with it, and the table of every finding this rule makes has no empty cell left.

Catalogue 272, spec floor unchanged.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
