### PR TITLE
How four parts of a warning go together

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -2139,6 +2139,22 @@ severity = "warn"
 # Via received-by is spelled as a uri-host
 severity = "warn"
 
+[violations.warning_agent_missing]
+# Warning member names no warn-agent
+severity = "warn"
+
+[violations.warning_code_malformed]
+# Warning member's warn-code is not three digits
+severity = "warn"
+
+[violations.warning_member_malformed]
+# Warning member does not derive where the production continues it
+severity = "warn"
+
+[violations.warning_text_missing]
+# Warning member carries no warn-text
+severity = "warn"
+
 [violations.weight_equals_whitespace_forbidden]
 # Whitespace is written beside the weight's '='
 severity = "warn"

--- a/lint-http-rules/src/rules/warning_header_syntax.rs
+++ b/lint-http-rules/src/rules/warning_header_syntax.rs
@@ -28,6 +28,10 @@ use crate::violations::uri::{
     RFC_3986_3_2_2, RFC_3986_3_2_3, URI_HOST_BRACKET_FORBIDDEN, URI_HOST_CHARACTER_FORBIDDEN,
     URI_HOST_CLOSING_BRACKET_MISSING, URI_HOST_IP_LITERAL_MALFORMED, URI_PORT_CHARACTER_FORBIDDEN,
 };
+use crate::violations::warning::{
+    RFC_7234_5_5, WARNING_AGENT_MISSING, WARNING_CODE_MALFORMED, WARNING_MEMBER_MALFORMED,
+    WARNING_TEXT_MISSING,
+};
 use crate::violations::ViolationDef;
 
 pub struct WarningHeaderSyntax;
@@ -45,12 +49,17 @@ pub struct WarningHeaderSyntax;
 /// inside the value, and the three rules that convert an `HTTP-date` off a
 /// field line declare that def without being able to reach it.
 ///
-/// What stays on the older API is `warning-value` itself: the three digits of a
-/// `warn-code`, the `SP` at each seam, the parts arriving in the order the
-/// production writes them, and a `1#` list with no member in it. Those are RFC
-/// 7234 § 5.5's own, and the subject holding them would have this rule as its
-/// only reader.
+/// **`warning-value` itself is the last four**, and they are the only entries
+/// in the catalogue this rule is the sole reader of: the three digits of a
+/// `warn-code`, a member that stops before its agent or before its text, and a
+/// member whose parts do not go together the way the production writes them.
+/// Those are RFC 7234 § 5.5's own and nobody else's, which is what a subject
+/// with one declarer is for.
 static DECLARED: &[&ViolationDef] = &[
+    &WARNING_CODE_MALFORMED,
+    &WARNING_AGENT_MISSING,
+    &WARNING_TEXT_MISSING,
+    &WARNING_MEMBER_MALFORMED,
     &LIST_MEMBER_EMPTY,
     &LIST_MEMBER_MISSING,
     &QUOTED_STRING_DELIMITER_MISSING,
@@ -69,33 +78,20 @@ static DECLARED: &[&ViolationDef] = &[
     &HTTP_DATE_WHITESPACE_FORBIDDEN,
 ];
 
-/// One finding from the reading, and the defect it reports as where the
-/// catalogue names that defect.
+/// One finding from the reading, and the entry it reports as.
 ///
-/// The same shape `expect_header_valid` settled: a judge that is half converted
-/// says so in its type rather than being split in two. Here the unnamed half is
-/// `warning-value`'s own structure, which no subject holds.
+/// The same shape `expect_header_valid` settled — **without the `Option`
+/// now**, since `warning-value`'s own structure has a subject and every arm of
+/// the reading names an entry.
 struct Defect {
-    def: Option<&'static ViolationDef>,
+    def: &'static ViolationDef,
     message: String,
 }
 
 impl Defect {
     /// A defect the catalogue names.
     fn named(def: &'static ViolationDef, message: String) -> Self {
-        Self {
-            def: Some(def),
-            message,
-        }
-    }
-
-    /// A defect belonging to `warning-value` itself, reported at the rule's
-    /// severity the way every finding here was before the catalogue existed.
-    fn unnamed(message: impl Into<String>) -> Self {
-        Self {
-            def: None,
-            message: message.into(),
-        }
+        Self { def, message }
     }
 
     /// The same defect with its message read from further out — the member
@@ -112,16 +108,6 @@ impl Defect {
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_7234_5_5: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 7234",
-    section: Some("5.5"),
-    url: "https://www.rfc-editor.org/rfc/rfc7234.html#section-5.5",
-    note: "The last statement of the `Warning` grammar, and the requirements about \
-           warn-codes and warn-dates that go with it. Obsoleted by RFC 9111, which \
-           removed the field rather than restating it — so this is where the \
-           productions are read from, and RFC 9111 §5.5 is where the field's status \
-           is read from",
-};
 const RFC_9111_5_5: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9111",
     section: Some("5.5"),
@@ -348,13 +334,7 @@ impl Rule for WarningHeaderSyntax {
                     .and_then(|resp| judge(&resp.headers, "Response"))
             })?;
 
-            // Two APIs behind one site: a defect the catalogue names resolves the
-            // severity configured for it, and `warning-value`'s own structure
-            // still emits at the rule's.
-            Some(match defect.def {
-                Some(def) => ctx.report_with(def, defect.message),
-                None => self.violation(ctx.severity, defect.message),
-            })
+            Some(ctx.report_with(defect.def, defect.message))
         };
         Vec::from_iter(finding())
     }
@@ -459,28 +439,41 @@ fn validate_warning_value(member: &str) -> Result<(), Defect> {
         match chars.next() {
             Some((_, c)) if c.is_ascii_digit() => {}
             Some((_, c)) => {
-                return Err(Defect::unnamed(format!(
-                    "has {} in its warn-code, and a warn-code is three digits",
-                    describe_char(c)
-                )))
+                return Err(Defect::named(
+                    &WARNING_CODE_MALFORMED,
+                    format!(
+                        "has {} in its warn-code, and a warn-code is three digits",
+                        describe_char(c)
+                    ),
+                ))
             }
             None => {
-                return Err(Defect::unnamed(
-                    "is shorter than the three digits of a warn-code",
+                return Err(Defect::named(
+                    &WARNING_CODE_MALFORMED,
+                    "is shorter than the three digits of a warn-code".into(),
                 ))
             }
         }
     }
 
     let Some((sp, c)) = chars.next() else {
-        return Err(Defect::unnamed("is a warn-code and nothing else"));
+        return Err(Defect::named(
+            &WARNING_AGENT_MISSING,
+            "is a warn-code and nothing else".into(),
+        ));
     };
     if c != ' ' {
-        return Err(Defect::unnamed(format!(
-            "has {} where the SP after its warn-code goes, so either the warn-code runs longer \
-             than three digits or the parts are unseparated",
-            describe_char(c)
-        )));
+        // Two senders and one finding: a fourth digit is a `warn-code` too long
+        // and anything else is a seam that is not a SP, and neither the
+        // catalogue nor a recipient can say which was meant.
+        return Err(Defect::named(
+            &WARNING_MEMBER_MALFORMED,
+            format!(
+                "has {} where the SP after its warn-code goes, so either the warn-code runs longer \
+                 than three digits or the parts are unseparated",
+                describe_char(c)
+            ),
+        ));
     }
 
     // The SP is one octet, so the offset just past it is a character boundary.
@@ -489,19 +482,27 @@ fn validate_warning_value(member: &str) -> Result<(), Defect> {
     // Neither alternative of `warn-agent` admits a space, so the next one ends
     // it — and a member with none of them left has no `warn-text` behind it.
     let Some(agent_end) = rest.find(' ') else {
-        return Err(Defect::unnamed(
-            "has a warn-code and a warn-agent and no warn-text",
+        return Err(Defect::named(
+            &WARNING_TEXT_MISSING,
+            "has a warn-code and a warn-agent and no warn-text".into(),
         ));
     };
     validate_warn_agent(&rest[..agent_end])?;
     let after = &rest[agent_end + 1..];
 
     // cite(RFC 7234 § 5.5): "warn-text = quoted-string"
+    // The production is its two DQUOTEs and what they enclose, so a value with
+    // neither is a `quoted-string` missing a delimiter rather than a badly
+    // written `warn-text` -- the answer an unquoted `alt-authority` gets, one
+    // field over.
     if !after.starts_with('"') {
-        return Err(Defect::unnamed(format!(
-            "has a warn-text beginning {}, and a warn-text is a quoted-string",
-            first_octet(after)
-        )));
+        return Err(Defect::named(
+            &QUOTED_STRING_DELIMITER_MISSING,
+            format!(
+                "has a warn-text beginning {}, and a warn-text is a quoted-string",
+                first_octet(after)
+            ),
+        ));
     }
     let Some(text_end) = quoted_string_end(after) else {
         return Err(Defect::named(
@@ -533,17 +534,26 @@ fn validate_warning_value(member: &str) -> Result<(), Defect> {
 
     // cite(RFC 7234 § 5.5): "warn-date = DQUOTE HTTP-date DQUOTE"
     let Some(date) = tail.strip_prefix(' ') else {
-        return Err(Defect::unnamed(format!(
-            "has {} after its warn-text, where the production writes either nothing or one SP and \
-             a warn-date",
-            first_octet(tail)
-        )));
+        return Err(Defect::named(
+            &WARNING_MEMBER_MALFORMED,
+            format!(
+                "has {} after its warn-text, where the production writes either nothing or one SP \
+                 and a warn-date",
+                first_octet(tail)
+            ),
+        ));
     };
+    // The same borrowing as the `warn-text`'s: the wrapper is a
+    // `quoted-string`, and a value that does not open with a DQUOTE is missing
+    // the delimiter rather than holding a bad date.
     if !date.starts_with('"') {
-        return Err(Defect::unnamed(format!(
-            "has a warn-date beginning {}, and a warn-date is an HTTP-date between two DQUOTEs",
-            first_octet(date)
-        )));
+        return Err(Defect::named(
+            &QUOTED_STRING_DELIMITER_MISSING,
+            format!(
+                "has a warn-date beginning {}, and a warn-date is an HTTP-date between two DQUOTEs",
+                first_octet(date)
+            ),
+        ));
     }
     let Some(date_end) = quoted_string_end(date) else {
         return Err(Defect::named(
@@ -553,10 +563,13 @@ fn validate_warning_value(member: &str) -> Result<(), Defect> {
     };
     let remainder = &date[date_end + 1..];
     if let Some(c) = remainder.chars().next() {
-        return Err(Defect::unnamed(format!(
-            "has {} after its warn-date, which is the last part a member has",
-            describe_char(c)
-        )));
+        return Err(Defect::named(
+            &WARNING_MEMBER_MALFORMED,
+            format!(
+                "has {} after its warn-date, which is the last part a member has",
+                describe_char(c)
+            ),
+        ));
     }
 
     validate_warn_date(&date[..=date_end])
@@ -580,11 +593,18 @@ fn validate_warn_agent(agent: &str) -> Result<(), Defect> {
     // Reported here rather than left to the host reading below, because the
     // finding is about one octet and neither alternative admits any of them:
     // `obs-text` is outside `tchar` and outside every `uri-host` character set.
+    // The id is the host reading's, because that is the alternative this
+    // function commits to: an alternation owns no defect, and a `warn-agent`
+    // failing both halves is read against the one carrying a port. The message
+    // names both halves, which is what the reading actually found.
     if let Some(c) = agent.chars().find(|c| !c.is_ascii()) {
-        return Err(Defect::unnamed(format!(
-            "has a warn-agent holding {}, which no uri-host admits and is not a tchar",
-            describe_char(c)
-        )));
+        return Err(Defect::named(
+            &URI_HOST_CHARACTER_FORBIDDEN,
+            format!(
+                "has a warn-agent holding {}, which no uri-host admits and is not a tchar",
+                describe_char(c)
+            ),
+        ));
     }
 
     // `reg-name` is `*( ... )`, so a host of no characters is a host and the
@@ -859,7 +879,7 @@ mod tests {
             "got {:?}",
             found.message
         );
-        assert_eq!(found.def.map(|d| d.id), Some("list_member_empty"));
+        assert_eq!(found.def.id, "list_member_empty");
     }
 
     /// The three ways a `warn-date` fails are the three `HTTP-date` ids, and
@@ -893,6 +913,43 @@ mod tests {
             id_for(" Wed, 21 Oct 2015 07:28:00 GMT"),
             "http_date_whitespace_forbidden",
         );
+    }
+
+    /// Which entry each of `warning-value`'s own findings reports as, and which
+    /// of them are borrowed. The split is the claim: an id beginning
+    /// `warning_` is a statement about how the four parts go together, and
+    /// every other id here belongs to a production the field imported and is
+    /// tuned once for every field written out of it.
+    #[rstest]
+    #[case("21a host \"text\"", "warning_code_malformed")]
+    #[case("1", "warning_code_malformed")]
+    #[case("214", "warning_agent_missing")]
+    #[case("214 host", "warning_text_missing")]
+    #[case("2140 host \"x\"", "warning_member_malformed")]
+    #[case("110-\"bad\"", "warning_member_malformed")]
+    #[case("214 host \"x\"x", "warning_member_malformed")]
+    #[case(
+        "214 host \"x\" \"Wed, 21 Oct 2015 07:28:00 GMT\"x",
+        "warning_member_malformed"
+    )]
+    // Borrowed: the wrapper is a `quoted-string` at both places it appears, so
+    // a value that does not open with a DQUOTE is missing the delimiter.
+    #[case("214 host text", "quoted_string_delimiter_missing")]
+    #[case("214 host \"x\" nodate", "quoted_string_delimiter_missing")]
+    // Borrowed: an alternation owns no defect, and the `warn-agent` reading
+    // commits to the host — the alternative that carries a port.
+    #[case("214 h\u{e9}st \"x\"", "uri_host_character_forbidden")]
+    fn each_finding_reports_as_the_entry_that_owns_it(#[case] value: &str, #[case] id: &str) {
+        let tx =
+            crate::test_helpers::make_test_transaction_with_response(200, &[("Warning", value)]);
+        let found = crate::test_helpers::run_rule(
+            &WarningHeaderSyntax,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["warning_header_syntax"]),
+        )
+        .unwrap_or_else(|| panic!("accepted {value:?}"));
+        assert_eq!(found.violation, id, "for {value:?}: {}", found.message);
     }
 
     /// Both obsolete formats parse as an `HTTP-date`, and §5.6.7's MUST is what

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -83,6 +83,7 @@ pub mod transfer_encoding;
 pub mod upgrade;
 pub mod uri;
 pub mod via;
+pub mod warning;
 
 /// One reportable defect.
 ///
@@ -437,7 +438,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 261;
+        const FLOOR: usize = 265;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/warning.rs
+++ b/lint-http-rules/src/violations/warning.rs
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `Warning` defects — how a `warning-value`'s four parts go together.
+//!
+//! `warning-value = warn-code SP warn-agent SP warn-text [ SP warn-date ]`
+//! names four things and defines one of them. The list is
+//! [`list`](crate::violations::list)'s, the `warn-agent` is a
+//! [`uri`](crate::violations::uri) host with a port or a
+//! [`token`](crate::violations::token), the `warn-text` and the `warn-date`'s
+//! wrapper are [`quoted_string`](crate::violations::quoted_string)s, and what
+//! sits inside that wrapper is an
+//! [`http_date`](crate::violations::http_date). Only `warn-code = 3DIGIT` is
+//! written here and nowhere else.
+//!
+//! **So this subject is the assembly and one terminal**, which is the shape
+//! [`via`](crate::violations::via) has: a member whose parts arrive in the
+//! order the production writes them, separated by the single SPs it prints,
+//! ending where it ends. What is left over is not a defect of any part.
+//!
+//! **Two readings were borrowed rather than written, and both are worth
+//! knowing.** A `warn-text` or a `warn-date` that does not open with a DQUOTE
+//! is `quoted_string_delimiter_missing` — the production *is* its two
+//! delimiters and what they enclose, which is the same answer an unquoted
+//! `alt-authority` gets. And a `warn-agent` holding an octet at or above %x80
+//! is `uri_host_character_forbidden`: the octet derives from neither
+//! alternative, and this rule's own policy is that a `warn-agent` failing both
+//! is read against the host, which is the alternative carrying a port. **An
+//! alternation owns no defect, so the id is whichever alternative the reading
+//! committed to** — the message still names both.
+//!
+//! **Flat at `warn`, for the reason `Via`'s subject is.** A `Warning` is
+//! advisory in the first place and obsolete in the second — RFC 9111 § 5.5
+//! removed the field rather than restating it — so no member of it can cost an
+//! exchange anything, which rules out `error`. And none of these is `info`
+//! either: each leaves a member a strict recipient cannot split, so what stops
+//! being readable is the warning itself.
+//
+// cite(RFC 7234 § 5.5, label: warning-value assembly): "warning-value = warn-code SP warn-agent SP warn-text [ SP warn-date ]"
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// The last statement of the `Warning` grammar, which is where every entry
+/// here is read from.
+pub const RFC_7234_5_5: SpecRef = SpecRef {
+    spec: "RFC 7234",
+    section: Some("5.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc7234.html#section-5.5",
+    note: "The last statement of the `Warning` grammar, and the requirements about \
+           warn-codes and warn-dates that go with it. Obsoleted by RFC 9111, which \
+           removed the field rather than restating it — so this is where the \
+           productions are read from, and RFC 9111 §5.5 is where the field's status \
+           is read from",
+};
+
+defects! {
+    /// A `warn-code` that is not three digits: `Warning: 11x agent "text"`, or
+    /// a member shorter than the code itself.
+    ///
+    /// `warn-code = 3DIGIT` is the one production a `warning-value` writes for
+    /// itself, and it is exact in both directions — a digit missing and a
+    /// non-digit present are the same three characters failing to derive, which
+    /// is why they are one entry and the message says which happened.
+    ///
+    /// **A fourth digit is not this entry**, and the reason is where the
+    /// evidence stops: what follows a three-digit code is a SP, so `1104` is
+    /// either a code with a digit too many or a code and an agent with no
+    /// separator between them. The catalogue cannot tell those apart and
+    /// neither can a recipient, so it reports as
+    /// [`WARNING_MEMBER_MALFORMED`] — the same line `Via` draws where a member
+    /// stops deriving and the sender's intent is unrecoverable.
+    ///
+    // cite(RFC 7234 § 5.5, label: warn-code grammar): "warn-code = 3DIGIT warn-agent = ( uri-host [ ":" port ] ) / pseudonym"
+    WARNING_CODE_MALFORMED = {
+        id: "warning_code_malformed",
+        title: "Warning member's warn-code is not three digits",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_7234_5_5],
+    }
+
+    /// A member that is a `warn-code` and nothing else: `Warning: 110`.
+    ///
+    /// The production writes three mandatory parts and brackets only the
+    /// fourth, so a member ending after its code names no one — and a warning
+    /// with no agent is a warning whose origin a recipient cannot record. **The
+    /// entry names the first part that is absent**, not every part after the
+    /// code: a sender that wrote nothing made one mistake, and the fix is the
+    /// rest of the member.
+    ///
+    // cite(RFC 7234 § 5.5, label: warn-agent position): "warning-value = warn-code SP warn-agent SP warn-text [ SP warn-date ]"
+    WARNING_AGENT_MISSING = {
+        id: "warning_agent_missing",
+        title: "Warning member names no warn-agent",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_7234_5_5],
+    }
+
+    /// A member that ends after its `warn-agent`: `Warning: 110 example.com`.
+    ///
+    /// The `warn-text` is the part a human reads — the whole reason the field
+    /// exists — and nothing brackets it. A member reaching this entry has an
+    /// agent and a code and says nothing about what it is warning of.
+    ///
+    /// Separate from [`WARNING_AGENT_MISSING`] because the senders differ and
+    /// so do the fixes: one stopped at the code and the other wrote everything
+    /// but the message.
+    ///
+    // cite(RFC 7234 § 5.5, label: warn-text position): "warn-text = quoted-string"
+    WARNING_TEXT_MISSING = {
+        id: "warning_text_missing",
+        title: "Warning member carries no warn-text",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_7234_5_5],
+    }
+
+    /// A member whose parts do not go together the way the production writes
+    /// them: something other than a SP at a seam, or content after the part
+    /// that ends the member.
+    ///
+    /// Three readings arrive here and they share the only claim the finding
+    /// makes — from this point on, the member does not derive. A `1104` is a
+    /// code with a digit too many or a code and an agent unseparated; a
+    /// `"text"x` is a `warn-text` with a typo behind it or a member missing its
+    /// comma; a member with content after its `warn-date` has run past the last
+    /// part it is allowed to have. **The catalogue does not guess between two
+    /// senders where a recipient cannot**, which is `via_member_malformed`'s
+    /// line and the reason this entry exists at all rather than being three.
+    ///
+    // cite(RFC 7234 § 5.5, label: warning-value seams): "warning-value = warn-code SP warn-agent SP warn-text [ SP warn-date ]"
+    WARNING_MEMBER_MALFORMED = {
+        id: "warning_member_malformed",
+        title: "Warning member does not derive where the production continues it",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_7234_5_5],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::violations::via::VIA_MEMBER_MALFORMED;
+
+    /// The subject is flat, and the argument is the field's: advisory in the
+    /// first place, obsolete in the second, and never `info` because each of
+    /// these leaves a member a strict recipient cannot split.
+    #[test]
+    fn every_entry_ranks_with_its_siblings_and_names_the_same_section() {
+        for def in [
+            &WARNING_CODE_MALFORMED,
+            &WARNING_AGENT_MISSING,
+            &WARNING_TEXT_MISSING,
+            &WARNING_MEMBER_MALFORMED,
+        ] {
+            assert_eq!(def.default_severity, Severity::Warn, "{}", def.id);
+            assert_eq!(def.spec, [RFC_7234_5_5], "{}", def.id);
+        }
+    }
+
+    /// The member that stops deriving is the same defect `Via` names, in a
+    /// field whose parts are separated by a SP instead of by `RWS` — two
+    /// entries because the two documents write two productions, one rank
+    /// because a trace and a warning cost a recipient the same thing.
+    #[test]
+    fn the_member_that_stops_deriving_is_two_entries_of_one_rank() {
+        assert_ne!(WARNING_MEMBER_MALFORMED.id, VIA_MEMBER_MALFORMED.id);
+        assert_eq!(
+            WARNING_MEMBER_MALFORMED.default_severity,
+            VIA_MEMBER_MALFORMED.default_severity
+        );
+    }
+}

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1446,7 +1446,7 @@ sources:
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
       line: 219
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 599
+      line: 619
     - file: lint-http-rules/src/violations/uri.rs
       line: 245
   - label: lint-http-rules/src/helpers/uri.rs (23)
@@ -3323,51 +3323,61 @@ sources:
     snippet: Warning = 1#warning-value
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 411
+      line: 391
   - label: warning_header_syntax (2)
     section: § 5.5
     snippet: Warning header fields can in general be applied to any message, however some warn-codes are specific to caches and can only be applied to response messages.
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 331
+      line: 317
   - label: warning_header_syntax (3)
     section: § 5.5
     snippet: Warnings are assigned three digit warn-codes.
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 456
+      line: 436
   - label: warning_header_syntax (4)
     section: § 5.5
     snippet: warn-agent = ( uri-host [ ":" port ] ) / pseudonym
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 578
-  - label: warning_header_syntax (5)
+      line: 591
+  - label: warn-code grammar
     section: § 5.5
     snippet: warn-code = 3DIGIT warn-agent = ( uri-host [ ":" port ] ) / pseudonym
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 455
-  - label: warning_header_syntax (6)
+      line: 435
+    - file: lint-http-rules/src/violations/warning.rs
+      line: 76
+  - label: warning_header_syntax (5)
     section: § 5.5
     snippet: warn-date = DQUOTE HTTP-date DQUOTE
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 534
+      line: 535
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 629
-  - label: warning_header_syntax (7)
+      line: 649
+  - label: warn-text position
     section: § 5.5
     snippet: warn-text = quoted-string
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 499
-  - label: warning_header_syntax (8)
+      line: 493
+    - file: lint-http-rules/src/violations/warning.rs
+      line: 113
+  - label: warning-value assembly
     section: § 5.5
     snippet: warning-value = warn-code SP warn-agent SP warn-text [ SP warn-date ]
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 449
+      line: 429
+    - file: lint-http-rules/src/violations/warning.rs
+      line: 40
+    - file: lint-http-rules/src/violations/warning.rs
+      line: 94
+    - file: lint-http-rules/src/violations/warning.rs
+      line: 135
 - label: RFC 7239
   url: https://www.rfc-editor.org/rfc/rfc7239.html
   fragments:
@@ -5101,7 +5111,7 @@ sources:
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
       line: 289
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 412
+      line: 392
     - file: lint-http-rules/src/violations/list.rs
       line: 99
   - label: accept_patch_header_valid (6)
@@ -5373,7 +5383,7 @@ sources:
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
       line: 179
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 398
+      line: 378
     - file: lint-http-rules/src/violations/request_target.rs
       line: 305
     - file: lint-http-rules/src/violations/request_target.rs
@@ -6477,7 +6487,7 @@ sources:
     - file: lint-http-core/src/http_date.rs
       line: 98
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 653
+      line: 673
     - file: lint-http-rules/src/violations/http_date.rs
       line: 101
   - label: lint-http-core/src/http_date.rs (3)
@@ -6507,7 +6517,7 @@ sources:
     - file: lint-http-rules/src/rules/last_modified_rfc1123_syntax.rs
       line: 116
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 681
+      line: 701
     - file: lint-http-rules/src/violations/http_date.rs
       line: 73
   - label: lint-http-core/src/http_date.rs (6)
@@ -7069,7 +7079,7 @@ sources:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
       line: 300
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 400
+      line: 380
   - label: lint-http-rules/src/helpers/field_placement.rs
     section: § 11.6.3
     snippet: Authentication-Info can be sent as a trailer field (Section 6.5) when the authentication scheme explicitly allows this.
@@ -7639,7 +7649,7 @@ sources:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 424
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 654
+      line: 674
     - file: lint-http-rules/src/violations/quoted_string.rs
       line: 58
     - file: lint-http-rules/src/violations/quoted_string.rs
@@ -9465,7 +9475,7 @@ sources:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
       line: 448
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 604
+      line: 624
   - label: via_header_syntax (13)
     section: § 7.6.3
     snippet: received-protocol = [ protocol-name "/" ] protocol-version
@@ -9497,7 +9507,7 @@ sources:
     snippet: Prior to 1995, there were three different formats commonly used by servers to communicate timestamps.
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 680
+      line: 700
 - label: RFC 9111
   url: https://www.rfc-editor.org/rfc/rfc9111.html
   fragments:


### PR DESCRIPTION
`warning-value = warn-code SP warn-agent SP warn-text [ SP warn-date ]` names four things and defines one. The list, the host and port, the two quoted-strings and the timestamp inside the second of them are all borrowed already; what was left is the assembly and the one terminal — which is the shape `Via`'s subject has, in a field whose seams are a SP instead of an `RWS`.

Four entries. A `warn-code` that is not three digits, counted in both directions because a digit missing and a non-digit present are the same three characters failing to derive. A member that stops after its code, and one that stops after its agent — two entries, since one sender wrote nothing and the other wrote everything but the message. And a member whose parts do not go together: a fourth digit is either a code too long or a seam that is not a SP, and the catalogue does not guess between two senders where a recipient cannot.

Two readings were borrowed instead of written. A `warn-text` or a `warn-date` that does not open with a DQUOTE is `quoted_string_delimiter_missing` — the production is its two delimiters and what they enclose, the answer an unquoted `alt-authority` already gets. And an octet at or above %x80 in a `warn-agent` is `uri_host_character_forbidden`: an alternation owns no defect, and this reading commits to the host, which is the alternative that carries a port. The message still names both halves.

Flat at `warn`, for `Via`'s reason: a warning is advisory and its field is obsolete, so nothing here can cost an exchange anything — and nothing is `info` either, because each leaves a member a strict recipient cannot split.

The rule converts whole; its `Defect` drops the `Option`.

Catalogue 276, spec floor 265.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
