### PR TITLE
A key no parser will read

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1987,6 +1987,10 @@ severity = "warn"
 # The policy states no max-age
 severity = "warn"
 
+[violations.structured_field_key_malformed]
+# Structured field key is not a key production
+severity = "warn"
+
 [violations.te_chunked_forbidden]
 # TE names the chunked coding, which cannot be declined
 severity = "warn"

--- a/docs/rules/digest_header_syntax.md
+++ b/docs/rules/digest_header_syntax.md
@@ -25,6 +25,7 @@ Algorithm names in the RFC 9530 fields are structured-field Dictionary keys and 
 - [RFC 3230 §4.1.1](https://www.rfc-editor.org/rfc/rfc3230.html#section-4.1.1): Historical `Digest` / `Want-Digest`, obsoleted by RFC 9530: `digest-algorithm = token`, case-insensitive — which is why uppercase is valid there and not in the structured fields
 - [RFC 7231 §Appendix B](https://www.rfc-editor.org/rfc/rfc7231.html#appendix-B): Where `Content-MD5` was removed from HTTP — RFC 9530 does not mention the field at all
 - [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
+- [RFC 9651 §4.2.3.3](https://www.rfc-editor.org/rfc/rfc9651.html#section-4.2.3.3): Parsing a Key: a `key` opens with `lcalpha` or `*` and continues with `lcalpha`, DIGIT, `_`, `-`, `.` or `*` — the production every Dictionary member name and every parameter name is written in, and the one an uppercase letter fails
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/digest_header_syntax.rs
+++ b/lint-http-rules/src/rules/digest_header_syntax.rs
@@ -4,6 +4,7 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::structured_fields::{RFC_9651_4_2_3_3, STRUCTURED_FIELD_KEY_MALFORMED};
 use crate::violations::token::{
     token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
     TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
@@ -13,8 +14,8 @@ use base64::Engine;
 
 pub struct DigestHeaderSyntax;
 
-/// Two defects, and both are the one production the *legacy* half of this rule
-/// borrows.
+/// Three defects, two of them the one production the *legacy* half of this rule
+/// borrows and one the production the structured half is written in.
 ///
 /// RFC 3230 § 4.1.1 writes `digest-algorithm = token` and takes `token` from
 /// RFC 2616, whose character set is § 5.6.2's — the fourth reading of that
@@ -22,14 +23,17 @@ pub struct DigestHeaderSyntax;
 /// or a `Want-Digest` naming an algorithm no `tchar` admits reports what a
 /// `Vary` member and a method do.
 ///
-/// **The RFC 9530 half borrows nothing, and that is the interesting half.**
+/// **The RFC 9530 half borrows one thing, and it is the interesting half.**
 /// `Content-Digest` and its three siblings are Structured Field Dictionaries,
 /// not `#rule` lists: an algorithm is a `key` — lowercase, and the helper that
-/// owns that grammar says so — and a value is a Byte Sequence or an Integer.
-/// None of those productions has a subject here, and a Dictionary key is
-/// emphatically not a `token`: the whole point of the finding is that carrying
-/// RFC 3230's `SHA-256` spelling across produces a field no structured-field
-/// parser will read.
+/// owns that grammar says so — and a value is a Byte Sequence or an Integer. A
+/// Dictionary key is emphatically not a `token`, which is the whole point of
+/// the finding: carrying RFC 3230's `SHA-256` spelling across produces a field
+/// no structured-field parser will read. That defect belongs to RFC 9651's
+/// `key` rather than to any of these fields, so it is
+/// [`structured_fields`](crate::violations::structured_fields)' — a subject
+/// shared by construction, the way `token` is, and one whose second declarer is
+/// already visible in `permissions_policy_directives_valid`.
 ///
 /// **The empty member is refused on both halves, for two different reasons.**
 /// On the legacy side the list is RFC 2616's `#rule`, which *permits* null
@@ -38,6 +42,7 @@ pub struct DigestHeaderSyntax;
 /// the structured side there is no `#rule` at all. Both findings are this
 /// rule's own strictness and stay at its severity.
 static DECLARED: &[&ViolationDef] = &[
+    &STRUCTURED_FIELD_KEY_MALFORMED,
     &TOKEN_CHARACTER_FORBIDDEN,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
 ];
@@ -437,11 +442,14 @@ fn structured_digest_defect(value: &str) -> Option<Defect> {
         // itself is owned by the structured-fields helper.
         // cite(RFC 9530 § 2): "key conveys the hashing algorithm (see Section 5) used to compute the digest;"
         if !crate::helpers::structured_fields::is_valid_sf_key(&algorithm) {
-            return Some(Defect::unnamed(format!(
-                "Digest algorithm key '{}' is not a valid structured-field key (keys are lowercase: try '{}')",
-                algorithm,
-                algorithm.to_ascii_lowercase()
-            )));
+            return Some(Defect::named(
+                &STRUCTURED_FIELD_KEY_MALFORMED,
+                format!(
+                    "Digest algorithm key '{}' is not a valid structured-field key (keys are lowercase: try '{}')",
+                    algorithm,
+                    algorithm.to_ascii_lowercase()
+                ),
+            ));
         }
 
         // The `:`-delimited base64 form, whose grammar the structured-fields
@@ -497,11 +505,14 @@ fn want_preference_defect(value: &str) -> Option<Defect> {
     for (algorithm, weight) in members {
         // Same Dictionary-key rule as the digest fields above.
         if !crate::helpers::structured_fields::is_valid_sf_key(&algorithm) {
-            return Some(Defect::unnamed(format!(
-                "Want-* algorithm key '{}' is not a valid structured-field key (keys are lowercase: try '{}')",
-                algorithm,
-                algorithm.to_ascii_lowercase()
-            )));
+            return Some(Defect::named(
+                &STRUCTURED_FIELD_KEY_MALFORMED,
+                format!(
+                    "Want-* algorithm key '{}' is not a valid structured-field key (keys are lowercase: try '{}')",
+                    algorithm,
+                    algorithm.to_ascii_lowercase()
+                ),
+            ));
         }
 
         // The bound is the spec's own, not a chosen tolerance, and the type is
@@ -546,6 +557,7 @@ severity = "warn"
             RFC_3230_4_1_1,
             RFC_7231_APPENDIX_B,
             RFC_9110_5_6_2,
+            RFC_9651_4_2_3_3,
         ]
     }
 
@@ -667,17 +679,24 @@ mod tests {
         tx
     }
 
-    /// The two findings that belong to a production this rule borrows, and a
-    /// sample of the nineteen that do not. The line the table draws is between
-    /// RFC 3230's legacy fields — whose algorithm is a `token` — and RFC 9530's,
-    /// which are Structured Field Dictionaries and share nothing with a `#rule`
-    /// list or a `token`.
+    /// The findings that belong to a production this rule borrows, and a sample
+    /// of the ones that do not. The line the table draws is between the
+    /// productions and the fields: RFC 3230's legacy algorithm is a `token`,
+    /// RFC 9530's Dictionary key is RFC 9651's `key` — the spelling a
+    /// deployment carries across from the older registry and the one no
+    /// structured-field parser will read — and everything else is a statement
+    /// one of the two documents makes about its own members.
     #[rstest]
     #[case::legacy_digest_algorithm("digest", "sha@1=YWJj", "token_character_forbidden")]
     #[case::legacy_want_digest_algorithm("want-digest", "sha@1", "token_character_forbidden")]
     #[case::legacy_empty_member("digest", "sha-256=YWJj,", "")]
     #[case::legacy_no_equals("digest", "sha-256", "")]
-    #[case::structured_key_case("content-digest", "SHA-256=:YWJj:", "")]
+    #[case::structured_key_case(
+        "content-digest",
+        "SHA-256=:YWJj:",
+        "structured_field_key_malformed"
+    )]
+    #[case::want_key_case("want-content-digest", "SHA-256=5", "structured_field_key_malformed")]
     #[case::structured_not_a_byte_sequence("content-digest", "sha-256=YWJj", "")]
     #[case::structured_empty_member("content-digest", "sha-256=:YWJj:,", "")]
     fn only_the_legacy_algorithm_is_a_borrowed_production(

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -75,6 +75,7 @@ pub mod sec_websocket_version;
 pub mod server_timing;
 pub mod status;
 pub mod strict_transport_security;
+pub mod structured_fields;
 pub mod te;
 pub mod token;
 pub mod token68;
@@ -438,7 +439,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 265;
+        const FLOOR: usize = 266;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/structured_fields.rs
+++ b/lint-http-rules/src/violations/structured_fields.rs
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! Structured Fields defects — the productions RFC 9651 defines for every
+//! field written in it.
+//!
+//! This is a subject of the same kind as [`token`](crate::violations::token)
+//! and [`quoted_string`](crate::violations::quoted_string): nothing here
+//! belongs to a field, and every entry answers for whichever field imported the
+//! production. What makes it worth opening is that a Structured Field's
+//! grammar is *shared by construction* — a document that says "this field is a
+//! Dictionary" has said everything about its shape, and what is left for the
+//! field to state is what its keys mean and what its values must be.
+//!
+//! **A parse failure costs the field, not the member.** RFC 9651 gives a
+//! recipient two answers and no third: ignore the whole field value as though
+//! it were not in the section, or treat the entire message as malformed. So a
+//! single bad key does not degrade a Dictionary — it deletes it, together with
+//! every member the sender wrote correctly, and the strict reading is worse
+//! than that. That is what the entry below ranks on, and it is why the finding
+//! is worth making at all where a lenient parser would have found the other
+//! members.
+//
+// cite(RFC 9651 § 4.2): "If parsing fails, either the entire field value MUST be ignored (i.e., treated as if the field were not present in the section), or alternatively the complete HTTP message MUST be treated as malformed."
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// The `key` production, and the parsing algorithm that reads one.
+pub const RFC_9651_4_2_3_3: SpecRef = SpecRef {
+    spec: "RFC 9651",
+    section: Some("4.2.3.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9651.html#section-4.2.3.3",
+    note: "Parsing a Key: a `key` opens with `lcalpha` or `*` and continues with `lcalpha`, DIGIT, `_`, `-`, `.` or `*` — the production every Dictionary member name and every parameter name is written in, and the one an uppercase letter fails",
+};
+
+defects! {
+    /// A Dictionary member name or a parameter name that is not a `key`:
+    /// `SHA-256`, `Report-To`, `2fa`.
+    ///
+    /// **The uppercase letter is the case worth knowing**, because it is the
+    /// one a working deployment produces. A field defined in RFC 9651 that
+    /// replaces an older `token`-based one inherits the older field's registry
+    /// spellings, and those registries are full of names like `SHA-256` and
+    /// `MD5`; carried across unchanged they make a field no structured-field
+    /// parser will read. A `key` has no uppercase in it at all — § 3.1.2 says
+    /// so in a note, in as many words — so this is not a value that will be
+    /// matched case-insensitively somewhere later.
+    ///
+    /// `_malformed`: the name derives from no `key`, which is a grammar
+    /// failure and not a name outside some registry.
+    ///
+    /// **`warn`, and the ceiling is what keeps it there.** What a bad key costs
+    /// is the whole field — § 4.2 has a recipient ignore a field it cannot
+    /// parse, so the members written correctly go with the one that was not —
+    /// and that is more than any octet-level entry costs. It is still not the
+    /// exchange: a request or a response missing a field it meant to send is
+    /// answerable, so `error` would claim something the finding cannot show.
+    ///
+    // cite(RFC 9651 § 3.1.2): "Note that parameters are ordered, and parameter keys cannot contain uppercase letters."
+    STRUCTURED_FIELD_KEY_MALFORMED = {
+        id: "structured_field_key_malformed",
+        title: "Structured field key is not a key production",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_9651_4_2_3_3],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The entry is the production's rather than any field's, which is what
+    /// lets two documents' fields report it with one id — and the rank is the
+    /// subject's, argued from what a parse failure costs.
+    #[test]
+    fn the_key_entry_belongs_to_the_production() {
+        assert_eq!(STRUCTURED_FIELD_KEY_MALFORMED.spec, [RFC_9651_4_2_3_3]);
+        assert_eq!(
+            STRUCTURED_FIELD_KEY_MALFORMED.default_severity,
+            Severity::Warn
+        );
+    }
+}

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1163,15 +1163,15 @@ sources:
     snippet: All digest-algorithm values are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 397
+      line: 402
   - label: digest_header_syntax (2)
     section: § 4.1.1
     snippet: digest-algorithm = token
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 360
+      line: 365
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 396
+      line: 401
 - label: RFC 3986
   url: https://www.rfc-editor.org/rfc/rfc3986.html
   fragments:
@@ -3314,7 +3314,7 @@ sources:
     - file: lint-http-rules/src/rules/content_md5_vs_digest_preference.rs
       line: 103
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 196
+      line: 201
 - label: RFC 7234
   url: https://www.rfc-editor.org/rfc/rfc7234.html
   fragments:
@@ -11284,37 +11284,37 @@ sources:
     snippet: This document obsoletes RFC 3230 and the Digest and Want-Digest HTTP fields.
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 184
+      line: 189
   - label: digest_header_syntax (2)
     section: § 2
     snippet: 'It is a Dictionary (see Section 3.2 of [STRUCTURED-FIELDS]), where each:'
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 143
+      line: 148
   - label: digest_header_syntax (3)
     section: § 2
     snippet: key conveys the hashing algorithm (see Section 5) used to compute the digest;
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 438
+      line: 443
   - label: digest_header_syntax (4)
     section: § 2
     snippet: value is a Byte Sequence (Section 3.3.5 of [STRUCTURED-FIELDS]) that conveys an encoded version of the byte output produced by the digest calculation.
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 450
+      line: 458
   - label: digest_header_syntax (5)
     section: § 4
     snippet: 'Want-Content-Digest and Want-Repr-Digest are of type Dictionary where each:'
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 147
+      line: 152
   - label: digest_header_syntax (6)
     section: § 4
     snippet: value is an Integer (Section 3.3.1 of [STRUCTURED-FIELDS]) that conveys an ascending, relative, weighted preference. It must be in the range 0 to 10 inclusive.
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 509
+      line: 520
 - label: RFC 9651
   url: https://www.rfc-editor.org/rfc/rfc9651.html
   fragments:
@@ -11332,6 +11332,8 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 228
+    - file: lint-http-rules/src/violations/structured_fields.rs
+      line: 62
   - label: lint-http-rules/src/helpers/structured_fields.rs (2)
     section: § 3.1.2
     snippet: The keys are unique within the scope of the Parameters they occur within, and the values are bare items (i.e., they themselves cannot be parameterized; see Section 3.3).
@@ -11718,6 +11720,8 @@ sources:
       line: 282
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
       line: 65
+    - file: lint-http-rules/src/violations/structured_fields.rs
+      line: 25
   - label: permissions_policy_directives_valid (4)
     section: § 4.2
     snippet: When generating input_bytes, parsers MUST combine all field lines in the same section (header or trailer) that case-insensitively match the field name into one comma-separated field-value, as per Section 5.2 of [HTTP]; this assures that the entire field value is processed correctly.


### PR DESCRIPTION
RFC 9651's `key` is a production, not a field: every Dictionary member name and every parameter name in every Structured Field is one, and a name that is not a `key` is the same defect wherever it is written. So it opens a subject of the same kind as `token` — shared by construction, since a document that says "this field is a Dictionary" has said everything about its shape.

The uppercase letter is the case worth having an id for, because it is the one a working deployment produces. A field defined in RFC 9651 that replaces an older `token`-based one inherits the older field's registry spellings, and those registries are full of `SHA-256` and `MD5`; carried across unchanged they make a `Content-Digest` no structured-field parser will read. A `key` has no uppercase in it at all — §3.1.2 says so in a note — so this is not a name that gets matched case-insensitively somewhere later.

`warn`, and the ceiling is what keeps it there. What a bad key costs is the whole field: §4.2 has a recipient treat a field it cannot parse as though the field were not present, so the members written correctly go with the one that was not. That is more than any octet-level entry costs and less than the exchange, which is what `error` would claim.

Two sites in `digest_header_syntax` report it. A third and fourth are already visible in `permissions_policy_directives_valid`, which validates parameter names with the same predicate and calls the outcome FieldDiscarded.

Catalogue 277, spec floor 266.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
