### PR TITLE
One digest under two generations of field

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1459,6 +1459,22 @@ severity = "warn"
 # A time in seconds is stated with no digits
 severity = "warn"
 
+[violations.digest_preference_invalid]
+# Want-Digest preference is outside the range 0 to 10
+severity = "info"
+
+[violations.digest_preference_malformed]
+# Want-Digest preference is not an Integer
+severity = "warn"
+
+[violations.digest_value_empty]
+# Digest field member carries no digest
+severity = "warn"
+
+[violations.digest_value_malformed]
+# Digest field member's value is not a Byte Sequence
+severity = "warn"
+
 [violations.domain_label_character_forbidden]
 # Domain label holds a character outside letters, digits and hyphen
 severity = "warn"

--- a/docs/rules/digest_header_syntax.md
+++ b/docs/rules/digest_header_syntax.md
@@ -26,6 +26,7 @@ Algorithm names in the RFC 9530 fields are structured-field Dictionary keys and 
 - [RFC 7231 §Appendix B](https://www.rfc-editor.org/rfc/rfc7231.html#appendix-B): Where `Content-MD5` was removed from HTTP — RFC 9530 does not mention the field at all
 - [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 - [RFC 9651 §4.2.3.3](https://www.rfc-editor.org/rfc/rfc9651.html#section-4.2.3.3): Parsing a Key: a `key` opens with `lcalpha` or `*` and continues with `lcalpha`, DIGIT, `_`, `-`, `.` or `*` — the production every Dictionary member name and every parameter name is written in, and the one an uppercase letter fails
+- [RFC 4648 §3.3](https://www.rfc-editor.org/rfc/rfc4648.html#section-3.3): Interpretation of non-alphabet characters — a MUST to reject data outside the base alphabet, unless the referring specification says otherwise
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/digest_header_syntax.rs
+++ b/lint-http-rules/src/rules/digest_header_syntax.rs
@@ -4,6 +4,11 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::base64::{BASE64_MALFORMED, RFC_4648_3_3};
+use crate::violations::digest::{
+    DIGEST_PREFERENCE_INVALID, DIGEST_PREFERENCE_MALFORMED, DIGEST_VALUE_EMPTY,
+    DIGEST_VALUE_MALFORMED, RFC_9530_2, RFC_9530_4,
+};
 use crate::violations::structured_fields::{RFC_9651_4_2_3_3, STRUCTURED_FIELD_KEY_MALFORMED};
 use crate::violations::token::{
     token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
@@ -14,8 +19,8 @@ use base64::Engine;
 
 pub struct DigestHeaderSyntax;
 
-/// Three defects, two of them the one production the *legacy* half of this rule
-/// borrows and one the production the structured half is written in.
+/// Nine defects, four of them productions this rule borrows and five statements
+/// the two digest documents make about their own members.
 ///
 /// RFC 3230 § 4.1.1 writes `digest-algorithm = token` and takes `token` from
 /// RFC 2616, whose character set is § 5.6.2's — the fourth reading of that
@@ -35,6 +40,14 @@ pub struct DigestHeaderSyntax;
 /// shared by construction, the way `token` is, and one whose second declarer is
 /// already visible in `permissions_policy_directives_valid`.
 ///
+/// **The value half of a member is a subject now**, and it is one subject over
+/// both generations: what a `Digest` and a `Content-Digest` carry is the same
+/// thing — an algorithm and the digest it produced — so a member with no digest
+/// in it is one entry whichever field wrote it, and the encoding under both is
+/// [`base64`](crate::violations::base64)'s. What differs is the type the
+/// document gives the value, which is why the Byte Sequence and the preference
+/// entries name RFC 9530's sections and the empty one names nothing.
+///
 /// **The empty member is refused on both halves, for two different reasons.**
 /// On the legacy side the list is RFC 2616's `#rule`, which *permits* null
 /// elements — the judgment `Sec-WebSocket-Extensions` settled — so
@@ -42,6 +55,11 @@ pub struct DigestHeaderSyntax;
 /// the structured side there is no `#rule` at all. Both findings are this
 /// rule's own strictness and stay at its severity.
 static DECLARED: &[&ViolationDef] = &[
+    &DIGEST_VALUE_MALFORMED,
+    &DIGEST_VALUE_EMPTY,
+    &DIGEST_PREFERENCE_MALFORMED,
+    &DIGEST_PREFERENCE_INVALID,
+    &BASE64_MALFORMED,
     &STRUCTURED_FIELD_KEY_MALFORMED,
     &TOKEN_CHARACTER_FORBIDDEN,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
@@ -85,24 +103,11 @@ impl Defect {
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_9530_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9530",
-    section: Some("2"),
-    url: "https://www.rfc-editor.org/rfc/rfc9530.html#section-2",
-    note:
-        "`Content-Digest`: a Dictionary keyed by hashing algorithm whose values are Byte Sequences",
-};
 const RFC_9530_3: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9530",
     section: Some("3"),
     url: "https://www.rfc-editor.org/rfc/rfc9530.html#section-3",
     note: "`Repr-Digest`: the same syntax over representation data rather than message content",
-};
-const RFC_9530_4: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9530",
-    section: Some("4"),
-    url: "https://www.rfc-editor.org/rfc/rfc9530.html#section-4",
-    note: "`Want-Content-Digest` / `Want-Repr-Digest`: a Dictionary whose values are Integers in the range 0 to 10 inclusive",
 };
 const RFC_3230_4_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 3230",
@@ -389,10 +394,10 @@ fn legacy_digest_defect(value: &str) -> Option<Defect> {
 
     for (algorithm, encoded) in members {
         if encoded.is_empty() {
-            return Some(Defect::unnamed(format!(
-                "Digest member '{}' has empty value",
-                algorithm
-            )));
+            return Some(Defect::named(
+                &DIGEST_VALUE_EMPTY,
+                format!("Digest member '{}' has empty value", algorithm),
+            ));
         }
 
         // The algorithm is a token. RFC 3230 also makes it case-insensitive,
@@ -407,14 +412,19 @@ fn legacy_digest_defect(value: &str) -> Option<Defect> {
             ));
         }
 
+        // Neither document restates a character of the encoding, so a value
+        // that does not decode is the same defect wherever it was carried.
         if base64::engine::general_purpose::STANDARD
             .decode(&encoded)
             .is_err()
         {
-            return Some(Defect::unnamed(format!(
-                "Digest value for algorithm '{}' is not valid base64",
-                algorithm
-            )));
+            return Some(Defect::named(
+                &BASE64_MALFORMED,
+                format!(
+                    "Digest value for algorithm '{}' is not valid base64",
+                    algorithm
+                ),
+            ));
         }
     }
     None
@@ -457,10 +467,13 @@ fn structured_digest_defect(value: &str) -> Option<Defect> {
         // same rule).
         // cite(RFC 9530 § 2): "value is a Byte Sequence (Section 3.3.5 of [STRUCTURED-FIELDS]) that conveys an encoded version of the byte output produced by the digest calculation."
         if !crate::helpers::structured_fields::is_byte_sequence(&encoded) {
-            return Some(Defect::unnamed(format!(
-                "Digest member '{}={}' value must be a byte sequence like ':b64:'",
-                algorithm, encoded
-            )));
+            return Some(Defect::named(
+                &DIGEST_VALUE_MALFORMED,
+                format!(
+                    "Digest member '{}={}' value must be a byte sequence like ':b64:'",
+                    algorithm, encoded
+                ),
+            ));
         }
 
         // Two deliberate strictnesses beyond the grammar, neither of which the
@@ -472,19 +485,22 @@ fn structured_digest_defect(value: &str) -> Option<Defect> {
         // accepted there.
         let inner = &encoded[1..encoded.len() - 1];
         if inner.is_empty() {
-            return Some(Defect::unnamed(format!(
-                "Digest member '{}' has empty byte sequence",
-                algorithm
-            )));
+            return Some(Defect::named(
+                &DIGEST_VALUE_EMPTY,
+                format!("Digest member '{}' has empty byte sequence", algorithm),
+            ));
         }
         if base64::engine::general_purpose::STANDARD
             .decode(inner)
             .is_err()
         {
-            return Some(Defect::unnamed(format!(
-                "Digest value for algorithm '{}' is not valid base64",
-                algorithm
-            )));
+            return Some(Defect::named(
+                &BASE64_MALFORMED,
+                format!(
+                    "Digest value for algorithm '{}' is not valid base64",
+                    algorithm
+                ),
+            ));
         }
     }
     None
@@ -519,16 +535,19 @@ fn want_preference_defect(value: &str) -> Option<Defect> {
         // Integer, so no decimal point.
         // cite(RFC 9530 § 4): "value is an Integer (Section 3.3.1 of [STRUCTURED-FIELDS]) that conveys an ascending, relative, weighted preference. It must be in the range 0 to 10 inclusive."
         let Ok(n) = weight.parse::<i64>() else {
-            return Some(Defect::unnamed(format!(
-                "Want-* weight '{}' is not an integer",
-                weight
-            )));
+            return Some(Defect::named(
+                &DIGEST_PREFERENCE_MALFORMED,
+                format!("Want-* weight '{}' is not an integer", weight),
+            ));
         };
+        // The two halves of one sentence, and they fail at two levels: a value
+        // deriving from no Integer stops a parser, and one deriving from an
+        // Integer is refused by the range printed beside the type.
         if !(0..=10).contains(&n) {
-            return Some(Defect::unnamed(format!(
-                "Want-* weight '{}' out of range 0..=10",
-                weight
-            )));
+            return Some(Defect::named(
+                &DIGEST_PREFERENCE_INVALID,
+                format!("Want-* weight '{}' out of range 0..=10", weight),
+            ));
         }
     }
     None
@@ -558,6 +577,7 @@ severity = "warn"
             RFC_7231_APPENDIX_B,
             RFC_9110_5_6_2,
             RFC_9651_4_2_3_3,
+            RFC_4648_3_3,
         ]
     }
 
@@ -697,7 +717,25 @@ mod tests {
         "structured_field_key_malformed"
     )]
     #[case::want_key_case("want-content-digest", "SHA-256=5", "structured_field_key_malformed")]
-    #[case::structured_not_a_byte_sequence("content-digest", "sha-256=YWJj", "")]
+    #[case::structured_not_a_byte_sequence(
+        "content-digest",
+        "sha-256=YWJj",
+        "digest_value_malformed"
+    )]
+    #[case::structured_empty_byte_sequence("content-digest", "sha-256=::", "digest_value_empty")]
+    #[case::legacy_empty_value("digest", "sha-256=", "digest_value_empty")]
+    #[case::legacy_bad_base64("digest", "sha-256=!!!", "base64_malformed")]
+    #[case::structured_bad_base64("content-digest", "sha-256=:YWJ:", "base64_malformed")]
+    #[case::want_weight_not_an_integer(
+        "want-content-digest",
+        "sha-256=1.5",
+        "digest_preference_malformed"
+    )]
+    #[case::want_weight_out_of_range(
+        "want-content-digest",
+        "sha-256=11",
+        "digest_preference_invalid"
+    )]
     #[case::structured_empty_member("content-digest", "sha-256=:YWJj:,", "")]
     fn only_the_legacy_algorithm_is_a_borrowed_production(
         #[case] field: &str,

--- a/lint-http-rules/src/violations/digest.rs
+++ b/lint-http-rules/src/violations/digest.rs
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! Digest defects — what a member of a digest field says about the bytes it
+//! stands for.
+//!
+//! One subject over two generations of fields, because the thing they carry is
+//! one thing: an algorithm and the digest it produced. RFC 3230 wrote it as a
+//! `#rule` of `token "=" <encoded digest>`; RFC 9530 obsoleted that and wrote
+//! the same pairing as a Structured Field Dictionary, whose keys are
+//! [`structured_fields`](crate::violations::structured_fields)' `key` and whose
+//! values are Byte Sequences and Integers. **What is shared is the claim, not
+//! the grammar**, so an entry here names the generation's sentence where one
+//! exists and the message names the field.
+//!
+//! **The encoding is [`base64`](crate::violations::base64)'s in both
+//! generations**, and neither document restates a character of it — a digest
+//! that does not decode is the same defect a mangled `Sec-WebSocket-Key` is,
+//! which is exactly what that subject was opened for.
+//!
+//! **One entry is uncited and it is the interesting one.** A digest of no bytes
+//! — the legacy `sha-256=` and the structured `sha-256=::` — is well formed in
+//! both documents: `::` is a Byte Sequence carrying zero octets, and RFC 3230
+//! bounds its encoded output nowhere. Neither document says a digest must
+//! identify something, so what refuses it is this crate's reading and the entry
+//! carries no reference.
+//
+// cite(RFC 9530 § 2, label: content-digest dictionary): "It is a Dictionary (see Section 3.2 of [STRUCTURED-FIELDS]), where each:"
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// `Content-Digest` and `Repr-Digest`: what a member's two halves must be.
+/// The two fields differ in *what* is hashed and not in syntax, so one section
+/// answers for both.
+pub const RFC_9530_2: SpecRef = SpecRef {
+    spec: "RFC 9530",
+    section: Some("2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9530.html#section-2",
+    note:
+        "`Content-Digest`: a Dictionary keyed by hashing algorithm whose values are Byte Sequences",
+};
+
+/// `Want-Content-Digest` and `Want-Repr-Digest`: the same Dictionary with a
+/// weight where the digest goes.
+pub const RFC_9530_4: SpecRef = SpecRef {
+    spec: "RFC 9530",
+    section: Some("4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9530.html#section-4",
+    note: "`Want-Content-Digest` / `Want-Repr-Digest`: a Dictionary whose values are Integers in the range 0 to 10 inclusive",
+};
+
+defects! {
+    /// A digest field member whose value is not a Byte Sequence:
+    /// `Content-Digest: sha-256=YWJj`, where the `:` delimiters are missing.
+    ///
+    /// The delimiters are the type. Without them the value parses as a Token
+    /// or a String or nothing at all, and § 2 says what a member's value *is*
+    /// — so a recipient reading this field against its definition finds a
+    /// member it cannot use, whatever a permissive parser would have made of
+    /// the characters.
+    ///
+    /// **The spelling this catches is the one a migration produces**: RFC
+    /// 3230's `Digest` carried bare base64 with no delimiters at all, so a
+    /// deployment that renamed the field and kept the value writes exactly
+    /// this.
+    ///
+    /// `warn`, with the rest of the subject: a field a recipient discards is
+    /// an integrity check that silently did not happen, and it is not the
+    /// exchange.
+    ///
+    // cite(RFC 9530 § 2): "value is a Byte Sequence (Section 3.3.5 of [STRUCTURED-FIELDS]) that conveys an encoded version of the byte output produced by the digest calculation."
+    DIGEST_VALUE_MALFORMED = {
+        id: "digest_value_malformed",
+        title: "Digest field member's value is not a Byte Sequence",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_9530_2],
+    }
+
+    /// A member that names an algorithm and carries no digest: the legacy
+    /// `Digest: sha-256=` and the structured `Content-Digest: sha-256=::`.
+    ///
+    /// **One entry for both generations, and it is uncited in both.** `::` is a
+    /// Byte Sequence carrying zero octets and derives perfectly; RFC 3230
+    /// bounds its encoded output nowhere. Neither document says that a digest
+    /// must identify something, so what refuses this is the reading that a
+    /// digest of no bytes distinguishes no content from any other — this
+    /// crate's, which is the first of the three reasons an entry carries no
+    /// reference.
+    ///
+    /// The two spellings are one defect because the sender's mistake is one
+    /// mistake — a hash that was never computed, or a variable that was empty
+    /// when the field was written — and the fix is the same in both.
+    ///
+    /// `warn`. What it costs is the whole point of the field: a recipient can
+    /// compare its own digest against nothing.
+    DIGEST_VALUE_EMPTY = {
+        id: "digest_value_empty",
+        title: "Digest field member carries no digest",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[],
+    }
+
+    /// A `Want-*` weight that is not an Integer: `sha-256=1.5`, `sha-256=high`.
+    ///
+    /// § 4 gives the value a type, and a Dictionary value that is not of the
+    /// type the field defines is a member a recipient cannot read. **Separate
+    /// from [`DIGEST_PREFERENCE_INVALID`] because the two fail at different
+    /// levels**: this one derives from no Integer, so a parser stops here and
+    /// the field goes with it, where a weight of `11` parses and is refused by
+    /// the sentence beside the type.
+    ///
+    /// `warn`, with the other entry that costs the field.
+    ///
+    // cite(RFC 9530 § 4, label: want-digest preference type): "value is an Integer (Section 3.3.1 of [STRUCTURED-FIELDS]) that conveys an ascending, relative, weighted preference. It must be in the range 0 to 10 inclusive."
+    DIGEST_PREFERENCE_MALFORMED = {
+        id: "digest_preference_malformed",
+        title: "Want-Digest preference is not an Integer",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_9530_4],
+    }
+
+    /// A `Want-*` weight outside 0 to 10: `sha-256=11`, `sha-256=-1`.
+    ///
+    /// Every octet is an Integer's and the field parses; what the value fails
+    /// is the range written in the same sentence that gives it its type. That
+    /// is `_invalid` exactly — grammatical, refused past the grammar.
+    ///
+    /// **`info`, alone in this subject, and the reason is that nothing is
+    /// lost.** A preference is an ordering: a recipient reading `11` beside a
+    /// `5` learns which algorithm the sender would rather have, which is the
+    /// whole content of the member. The field is not discarded, no digest is
+    /// unreadable, and what the sender wrote is still usable for the purpose it
+    /// was written for.
+    ///
+    // cite(RFC 9530 § 4): "value is an Integer (Section 3.3.1 of [STRUCTURED-FIELDS]) that conveys an ascending, relative, weighted preference. It must be in the range 0 to 10 inclusive."
+    DIGEST_PREFERENCE_INVALID = {
+        id: "digest_preference_invalid",
+        title: "Want-Digest preference is outside the range 0 to 10",
+        message: "",
+        default_severity: Severity::Info,
+        spec: &[RFC_9530_4],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The entry with no sentence, and why it may not gain one: both documents
+    /// derive a digest of no bytes without a word against it.
+    #[test]
+    fn the_digest_of_nothing_states_no_sentence() {
+        assert!(DIGEST_VALUE_EMPTY.spec.is_empty());
+    }
+
+    /// The two halves of § 4's one sentence are two entries, split by the
+    /// vocabulary rather than by the wording: a value deriving from no Integer
+    /// and a value deriving from one and refused past it.
+    #[test]
+    fn the_preference_fails_at_two_levels_under_one_sentence() {
+        assert_eq!(DIGEST_PREFERENCE_MALFORMED.spec, [RFC_9530_4]);
+        assert_eq!(DIGEST_PREFERENCE_INVALID.spec, [RFC_9530_4]);
+        assert_ne!(DIGEST_PREFERENCE_MALFORMED.id, DIGEST_PREFERENCE_INVALID.id);
+        // And they rank apart for the same reason they split: one costs the
+        // field, the other costs nothing a recipient was going to use.
+        assert!(
+            DIGEST_PREFERENCE_INVALID.default_severity
+                < DIGEST_PREFERENCE_MALFORMED.default_severity
+        );
+    }
+}

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -48,6 +48,7 @@ pub mod content_range;
 pub mod cookie;
 pub mod credentials;
 pub mod delta_seconds;
+pub mod digest;
 pub mod domain;
 pub mod etag;
 pub mod expect;
@@ -439,7 +440,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 266;
+        const FLOOR: usize = 269;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1163,15 +1163,15 @@ sources:
     snippet: All digest-algorithm values are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 402
+      line: 407
   - label: digest_header_syntax (2)
     section: § 4.1.1
     snippet: digest-algorithm = token
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 365
+      line: 370
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 401
+      line: 406
 - label: RFC 3986
   url: https://www.rfc-editor.org/rfc/rfc3986.html
   fragments:
@@ -3314,7 +3314,7 @@ sources:
     - file: lint-http-rules/src/rules/content_md5_vs_digest_preference.rs
       line: 103
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 201
+      line: 206
 - label: RFC 7234
   url: https://www.rfc-editor.org/rfc/rfc7234.html
   fragments:
@@ -11284,37 +11284,45 @@ sources:
     snippet: This document obsoletes RFC 3230 and the Digest and Want-Digest HTTP fields.
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 189
-  - label: digest_header_syntax (2)
+      line: 194
+  - label: content-digest dictionary
     section: § 2
     snippet: 'It is a Dictionary (see Section 3.2 of [STRUCTURED-FIELDS]), where each:'
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 148
-  - label: digest_header_syntax (3)
+      line: 153
+    - file: lint-http-rules/src/violations/digest.rs
+      line: 29
+  - label: digest_header_syntax (2)
     section: § 2
     snippet: key conveys the hashing algorithm (see Section 5) used to compute the digest;
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 443
-  - label: digest_header_syntax (4)
+      line: 453
+  - label: digest_header_syntax (3)
     section: § 2
     snippet: value is a Byte Sequence (Section 3.3.5 of [STRUCTURED-FIELDS]) that conveys an encoded version of the byte output produced by the digest calculation.
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 458
-  - label: digest_header_syntax (5)
+      line: 468
+    - file: lint-http-rules/src/violations/digest.rs
+      line: 74
+  - label: digest_header_syntax (4)
     section: § 4
     snippet: 'Want-Content-Digest and Want-Repr-Digest are of type Dictionary where each:'
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 152
-  - label: digest_header_syntax (6)
+      line: 157
+  - label: want-digest preference type
     section: § 4
     snippet: value is an Integer (Section 3.3.1 of [STRUCTURED-FIELDS]) that conveys an ascending, relative, weighted preference. It must be in the range 0 to 10 inclusive.
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 520
+      line: 536
+    - file: lint-http-rules/src/violations/digest.rs
+      line: 119
+    - file: lint-http-rules/src/violations/digest.rs
+      line: 141
 - label: RFC 9651
   url: https://www.rfc-editor.org/rfc/rfc9651.html
   fragments:


### PR DESCRIPTION
RFC 3230 wrote an algorithm and its digest as `token "=" <encoded output>`; RFC 9530 obsoleted that and wrote the same pairing as a Structured Field Dictionary. The grammars share nothing and the claim is identical, so the subject is the digest rather than either field, and an entry names the generation's sentence where one exists.

Four entries and a borrowing. A value that is not a Byte Sequence is the spelling a migration produces — the older field carried bare base64 with no delimiters, so a deployment that renamed the field and kept the value writes exactly it. The `Want-*` weight fails at two levels under one sentence: a value deriving from no Integer stops a parser and takes the field with it, and a value of `11` derives and is refused by the range printed beside the type. That is the vocabulary's line between `_malformed` and `_invalid`, and the two rank apart for the same reason they split — the second costs nothing a recipient was going to use, since a preference is an ordering and `11` beside `5` still says which algorithm is wanted.

A member with no digest in it is one entry across both generations and it names no sentence. `::` is a Byte Sequence carrying zero octets and RFC 3230 bounds its encoded output nowhere, so neither document says a digest must identify something; what refuses it is the reading that a digest of no bytes distinguishes no content from any other.

And the encoding is `base64`'s in both, which is what that subject was opened for: neither document restates a character of RFC 4648, so a digest that does not decode is the defect a mangled `Sec-WebSocket-Key` is.

Catalogue 281, spec floor 269.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
