### PR TITLE
One spelling, two grammars, two defects

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1303,6 +1303,10 @@ severity = "error"
 # Content-Length numeral is too large to represent
 severity = "warn"
 
+[violations.content_md5_obsolete]
+# Content-MD5 is a field HTTP removed
+severity = "warn"
+
 [violations.content_range_complete_length_conflicting]
 # Content-Range complete-length does not exceed its last-pos
 severity = "error"
@@ -1457,6 +1461,18 @@ severity = "warn"
 
 [violations.delta_seconds_empty]
 # A time in seconds is stated with no digits
+severity = "warn"
+
+[violations.digest_equals_missing]
+# Digest member is written without its '='
+severity = "warn"
+
+[violations.digest_field_obsolete]
+# Digest or Want-Digest is a field RFC 9530 retired
+severity = "warn"
+
+[violations.digest_member_empty]
+# Digest field writes a comma with no member beside it
 severity = "warn"
 
 [violations.digest_preference_invalid]
@@ -2005,6 +2021,10 @@ severity = "warn"
 
 [violations.structured_field_key_malformed]
 # Structured field key is not a key production
+severity = "warn"
+
+[violations.structured_field_member_empty]
+# Structured field writes a comma with no member beside it
 severity = "warn"
 
 [violations.te_chunked_forbidden]

--- a/docs/rules/digest_header_syntax.md
+++ b/docs/rules/digest_header_syntax.md
@@ -26,7 +26,10 @@ Algorithm names in the RFC 9530 fields are structured-field Dictionary keys and 
 - [RFC 7231 §Appendix B](https://www.rfc-editor.org/rfc/rfc7231.html#appendix-B): Where `Content-MD5` was removed from HTTP — RFC 9530 does not mention the field at all
 - [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 - [RFC 9651 §4.2.3.3](https://www.rfc-editor.org/rfc/rfc9651.html#section-4.2.3.3): Parsing a Key: a `key` opens with `lcalpha` or `*` and continues with `lcalpha`, DIGIT, `_`, `-`, `.` or `*` — the production every Dictionary member name and every parameter name is written in, and the one an uppercase letter fails
+- [RFC 9651 §4.2.2](https://www.rfc-editor.org/rfc/rfc9651.html#section-4.2.2): Parsing a Dictionary: a member is a key and, optionally, an `=` and a value — a bare key carries the Boolean true rather than being a member without one — and the loop fails on a comma with nothing after it
 - [RFC 4648 §3.3](https://www.rfc-editor.org/rfc/rfc4648.html#section-3.3): Interpretation of non-alphabet characters — a MUST to reject data outside the base alphabet, unless the referring specification says otherwise
+- [RFC 3230 §4.2](https://www.rfc-editor.org/rfc/rfc3230.html#section-4.2): Instance digests: `instance-digest = digest-algorithm "=" <encoded digest output>`, the production a legacy `Digest` member is written in — three parts with nothing bracketed, and an encoding the algorithm's own definition supplies
+- [RFC 9530](https://www.rfc-editor.org/rfc/rfc9530.html): Digest Fields, which obsoletes RFC 3230 and the `Digest` and `Want-Digest` fields with it — the sentence that makes a well-formed legacy field a finding rather than a style preference
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/digest_header_syntax.rs
+++ b/lint-http-rules/src/rules/digest_header_syntax.rs
@@ -6,12 +6,15 @@ use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
 use crate::violations::base64::{BASE64_MALFORMED, RFC_4648_3_3};
 use crate::violations::digest::{
+    CONTENT_MD5_OBSOLETE, DIGEST_EQUALS_MISSING, DIGEST_FIELD_OBSOLETE, DIGEST_MEMBER_EMPTY,
     DIGEST_PREFERENCE_INVALID, DIGEST_PREFERENCE_MALFORMED, DIGEST_VALUE_EMPTY,
-    DIGEST_VALUE_MALFORMED, RFC_9530_2, RFC_9530_4,
+    DIGEST_VALUE_MALFORMED, RFC_3230_4_2, RFC_7231_APPENDIX_B, RFC_9530, RFC_9530_2, RFC_9530_4,
 };
-use crate::violations::structured_fields::{RFC_9651_4_2_3_3, STRUCTURED_FIELD_KEY_MALFORMED};
+use crate::violations::structured_fields::{
+    RFC_9651_4_2_2, RFC_9651_4_2_3_3, STRUCTURED_FIELD_KEY_MALFORMED, STRUCTURED_FIELD_MEMBER_EMPTY,
+};
 use crate::violations::token::{
-    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
+    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN, TOKEN_EMPTY,
     TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
 };
 use crate::violations::ViolationDef;
@@ -19,8 +22,9 @@ use base64::Engine;
 
 pub struct DigestHeaderSyntax;
 
-/// Nine defects, four of them productions this rule borrows and five statements
-/// the two digest documents make about their own members.
+/// Sixteen defects, seven of them productions this rule borrows and nine
+/// statements the digest documents make — about their own members, and about
+/// the two fields that no longer exist.
 ///
 /// RFC 3230 § 4.1.1 writes `digest-algorithm = token` and takes `token` from
 /// RFC 2616, whose character set is § 5.6.2's — the fourth reading of that
@@ -48,19 +52,29 @@ pub struct DigestHeaderSyntax;
 /// document gives the value, which is why the Byte Sequence and the preference
 /// entries name RFC 9530's sections and the empty one names nothing.
 ///
-/// **The empty member is refused on both halves, for two different reasons.**
-/// On the legacy side the list is RFC 2616's `#rule`, which *permits* null
-/// elements — the judgment `Sec-WebSocket-Extensions` settled — so
-/// `list_member_empty` would report a requirement the field does not carry. On
-/// the structured side there is no `#rule` at all. Both findings are this
-/// rule's own strictness and stay at its severity.
+/// **The empty member is refused on both halves, for two different reasons, and
+/// that is why it is two entries.** On the legacy side the list is RFC 2616's
+/// `#rule`, which *permits* null elements — the judgment
+/// `Sec-WebSocket-Extensions` settled — so `list_member_empty` would report a
+/// requirement the field does not carry, and `digest_member_empty` carries no
+/// reference at all. On the structured side there is no `#rule`: a comma with
+/// nothing beside it fails RFC 9651's parsing loop, which costs the whole
+/// field, and that is `structured_field_member_empty`. **One spelling, two
+/// documents, two entries** — the same split the missing `=` and the empty name
+/// take one line further down.
 static DECLARED: &[&ViolationDef] = &[
+    &DIGEST_FIELD_OBSOLETE,
+    &CONTENT_MD5_OBSOLETE,
+    &DIGEST_MEMBER_EMPTY,
+    &DIGEST_EQUALS_MISSING,
     &DIGEST_VALUE_MALFORMED,
     &DIGEST_VALUE_EMPTY,
     &DIGEST_PREFERENCE_MALFORMED,
     &DIGEST_PREFERENCE_INVALID,
     &BASE64_MALFORMED,
     &STRUCTURED_FIELD_KEY_MALFORMED,
+    &STRUCTURED_FIELD_MEMBER_EMPTY,
+    &TOKEN_EMPTY,
     &TOKEN_CHARACTER_FORBIDDEN,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
 ];
@@ -71,23 +85,14 @@ static DECLARED: &[&ViolationDef] = &[
 /// Two of this rule's twenty-one findings are a borrowed production's; the rest
 /// are RFC 3230's list, RFC 9530's Dictionary, and four fields being obsolete.
 struct Defect {
-    def: Option<&'static ViolationDef>,
+    def: &'static ViolationDef,
     message: String,
 }
 
 impl Defect {
     /// A defect the catalogue names.
     fn named(def: &'static ViolationDef, message: String) -> Self {
-        Self {
-            def: Some(def),
-            message,
-        }
-    }
-
-    /// A defect no subject has claimed, reported at the rule's severity the way
-    /// every finding here was before the catalogue existed.
-    fn unnamed(message: String) -> Self {
-        Self { def: None, message }
+        Self { def, message }
     }
 
     /// The same defect with its message read from further out — which field it
@@ -114,12 +119,6 @@ const RFC_3230_4_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("4.1.1"),
     url: "https://www.rfc-editor.org/rfc/rfc3230.html#section-4.1.1",
     note: "Historical `Digest` / `Want-Digest`, obsoleted by RFC 9530: `digest-algorithm = token`, case-insensitive — which is why uppercase is valid there and not in the structured fields",
-};
-const RFC_7231_APPENDIX_B: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 7231",
-    section: Some("Appendix B"),
-    url: "https://www.rfc-editor.org/rfc/rfc7231.html#appendix-B",
-    note: "Where `Content-MD5` was removed from HTTP — RFC 9530 does not mention the field at all",
 };
 
 /// Which side of the exchange a field is read on.
@@ -190,22 +189,27 @@ struct Field {
     /// What a defect finding names as its authority, in parentheses.
     reference: &'static str,
     /// Set for a field that no longer exists: the finding a well-formed value
-    /// still earns.
-    // cite(RFC 9530): "This document obsoletes RFC 3230 and the Digest and Want-Digest HTTP fields."
-    obsolete: Option<&'static str>,
+    /// still earns, and the entry that says which document retired it.
+    obsolete: Option<MemberDefect>,
 }
 
-const OBSOLETE_DIGEST: &str =
-    "Digest header is obsoleted by RFC 9530; prefer Content-Digest or Repr-Digest";
-const OBSOLETE_WANT_DIGEST: &str =
-    "Want-Digest header is obsoleted by RFC 9530; prefer Want-Content-Digest or Want-Repr-Digest";
+const OBSOLETE_DIGEST: MemberDefect = MemberDefect {
+    def: &DIGEST_FIELD_OBSOLETE,
+    message: "Digest header is obsoleted by RFC 9530; prefer Content-Digest or Repr-Digest",
+};
+const OBSOLETE_WANT_DIGEST: MemberDefect = MemberDefect {
+    def: &DIGEST_FIELD_OBSOLETE,
+    message:
+        "Want-Digest header is obsoleted by RFC 9530; prefer Want-Content-Digest or Want-Repr-Digest",
+};
 /// Content-MD5 is obsolete, but RFC 9530 is not what obsoleted it — that
 /// document never mentions the field. It was removed from HTTP by RFC 7231,
-/// years earlier, and the sentence in the citation below is the whole
-/// provenance. RFC 9530 is named only as what to use instead.
-// cite(RFC 7231): "The Content-MD5 header field has been removed because it was inconsistently implemented with respect to partial responses."
-const OBSOLETE_CONTENT_MD5: &str =
-    "Content-MD5 was removed from HTTP by RFC 7231; use Content-Digest (RFC 9530) instead";
+/// years earlier, and the entry it reports as carries that sentence. RFC 9530
+/// is named only as what to use instead.
+const OBSOLETE_CONTENT_MD5: MemberDefect = MemberDefect {
+    def: &CONTENT_MD5_OBSOLETE,
+    message: "Content-MD5 was removed from HTTP by RFC 7231; use Content-Digest (RFC 9530) instead",
+};
 
 /// Every field this rule reads, in the order it reads them — which is the order
 /// findings are reported in, so it is the order the rule's tests pin.
@@ -318,6 +322,22 @@ const FIELDS: &[Field] = &[
     },
 ];
 
+/// One of the three things that can be wrong with a member before its value is
+/// read, as the entry and the wording its caller answers with.
+///
+/// The caller supplied the wording already; what it supplies now is the id, and
+/// it has to, because **the same spelling is a different defect in the two
+/// generations**. A comma with nothing beside it is this crate's strictness
+/// under RFC 2616's permissive `#rule` and a parse failure in a Dictionary; a
+/// bare name is a member missing its `=` in RFC 3230 and a member carrying the
+/// Boolean true in RFC 9651; an empty name is a `token` with no character in it
+/// and a `key` that starts where no key starts.
+#[derive(Clone, Copy)]
+struct MemberDefect {
+    def: &'static ViolationDef,
+    message: &'static str,
+}
+
 /// Split a comma-separated list of `key=value` members.
 ///
 /// Splitting on a bare comma is safe for every field routed through here: the
@@ -326,30 +346,33 @@ const FIELDS: &[Field] = &[
 /// in its alphabet either. A quote-aware split would find nothing extra.
 /// (Dictionary *parameters*, which could complicate this, are not defined for
 /// any of these fields.)
-/// **None of the three defects below is a subject's.** The legacy fields' list
-/// is RFC 2616's `#rule`, which permits the null element `list_member_empty`
-/// refuses, and the structured fields are Dictionaries with no list construct
-/// in them at all; the `=` and the algorithm in front of it are each document's
-/// own shape for a member. So this reader keeps its message templates and
-/// answers with an unnamed defect.
 fn key_value_members(
     value: &str,
-    empty_member: &str,
-    missing_eq: &str,
-    empty_algorithm: &str,
+    empty_member: MemberDefect,
+    missing_eq: MemberDefect,
+    empty_algorithm: MemberDefect,
 ) -> Result<Vec<(String, String)>, Defect> {
     let mut members = Vec::new();
     for member in value.split(',') {
         let member = member.trim();
         if member.is_empty() {
-            return Err(Defect::unnamed(empty_member.to_string()));
+            return Err(Defect::named(
+                empty_member.def,
+                empty_member.message.to_string(),
+            ));
         }
         let Some(eq) = member.find('=') else {
-            return Err(Defect::unnamed(missing_eq.replace("{}", member)));
+            return Err(Defect::named(
+                missing_eq.def,
+                missing_eq.message.replace("{}", member),
+            ));
         };
         let algorithm = member[..eq].trim();
         if algorithm.is_empty() {
-            return Err(Defect::unnamed(empty_algorithm.replace("{}", member)));
+            return Err(Defect::named(
+                empty_algorithm.def,
+                empty_algorithm.message.replace("{}", member),
+            ));
         }
         members.push((algorithm.to_string(), member[eq + 1..].trim().to_string()));
     }
@@ -362,7 +385,10 @@ fn token_list(value: &str, empty_member: &str, invalid_token: &str) -> Result<Ve
     for member in value.split(',') {
         let member = member.trim();
         if member.is_empty() {
-            return Err(Defect::unnamed(empty_member.to_string()));
+            return Err(Defect::named(
+                &DIGEST_MEMBER_EMPTY,
+                empty_member.to_string(),
+            ));
         }
         // `digest-algorithm = token`, and the caller supplies only the wording:
         // which of the two `token` ids answers is decided by the character, the
@@ -384,9 +410,21 @@ fn token_list(value: &str, empty_member: &str, invalid_token: &str) -> Result<Ve
 fn legacy_digest_defect(value: &str) -> Option<Defect> {
     let members = match key_value_members(
         value,
-        "Digest header contains empty member",
-        "Digest member '{}' missing '=' separator",
-        "Digest member '{}' has empty algorithm",
+        MemberDefect {
+            def: &DIGEST_MEMBER_EMPTY,
+            message: "Digest header contains empty member",
+        },
+        MemberDefect {
+            def: &DIGEST_EQUALS_MISSING,
+            message: "Digest member '{}' missing '=' separator",
+        },
+        // `digest-algorithm = token`, and `token = 1*tchar` derives no empty
+        // string -- the same id every other reader of that production answers
+        // with.
+        MemberDefect {
+            def: &TOKEN_EMPTY,
+            message: "Digest member '{}' has empty algorithm",
+        },
     ) {
         Err(defect) => return Some(defect),
         Ok(members) => members,
@@ -434,9 +472,21 @@ fn legacy_digest_defect(value: &str) -> Option<Defect> {
 fn structured_digest_defect(value: &str) -> Option<Defect> {
     let members = match key_value_members(
         value,
-        "Digest field contains empty member",
-        "Digest member '{}' missing '=' separator",
-        "Digest member '{}' has empty algorithm",
+        MemberDefect {
+            def: &STRUCTURED_FIELD_MEMBER_EMPTY,
+            message: "Digest field contains empty member",
+        },
+        // A bare key is not a member with no value: § 4.2.2 gives it the
+        // Boolean true, so what is wrong is the type of the value this field
+        // defines rather than a delimiter nobody wrote.
+        MemberDefect {
+            def: &DIGEST_VALUE_MALFORMED,
+            message: "Digest member '{}' missing '=' separator, so its value is the Boolean true and not a byte sequence",
+        },
+        MemberDefect {
+            def: &STRUCTURED_FIELD_KEY_MALFORMED,
+            message: "Digest member '{}' has empty algorithm",
+        },
     ) {
         Err(defect) => return Some(defect),
         Ok(members) => members,
@@ -510,9 +560,20 @@ fn structured_digest_defect(value: &str) -> Option<Defect> {
 fn want_preference_defect(value: &str) -> Option<Defect> {
     let members = match key_value_members(
         value,
-        "Want-* header contains empty member",
-        "Want member '{}' missing '=' separator",
-        "Want member '{}' has empty algorithm",
+        MemberDefect {
+            def: &STRUCTURED_FIELD_MEMBER_EMPTY,
+            message: "Want-* header contains empty member",
+        },
+        // The same Boolean true, measured against the type *this* field
+        // defines: § 4 asks for an Integer.
+        MemberDefect {
+            def: &DIGEST_PREFERENCE_MALFORMED,
+            message: "Want member '{}' missing '=' separator, so its value is the Boolean true and not an integer",
+        },
+        MemberDefect {
+            def: &STRUCTURED_FIELD_KEY_MALFORMED,
+            message: "Want member '{}' has empty algorithm",
+        },
     ) {
         Err(defect) => return Some(defect),
         Ok(members) => members,
@@ -577,7 +638,10 @@ severity = "warn"
             RFC_7231_APPENDIX_B,
             RFC_9110_5_6_2,
             RFC_9651_4_2_3_3,
+            RFC_9651_4_2_2,
             RFC_4648_3_3,
+            RFC_3230_4_2,
+            RFC_9530,
         ]
     }
 
@@ -653,16 +717,15 @@ impl Rule for DigestHeaderSyntax {
                                 field.display, field.side, message, field.reference
                             )
                         });
-                        return Some(match defect.def {
-                            Some(def) => ctx.report_with(def, defect.message),
-                            None => self.violation(ctx.severity, defect.message),
-                        });
+                        return Some(ctx.report_with(defect.def, defect.message));
                     }
 
                     // A well-formed obsolete field is still a finding: the field
-                    // itself is gone, not merely discouraged.
+                    // itself is gone, not merely discouraged. Which entry says so
+                    // is the field's, because the two were retired by two
+                    // documents for two reasons.
                     if let Some(obsolete) = field.obsolete {
-                        return Some(self.violation(ctx.severity, obsolete.into()));
+                        return Some(ctx.report_with(obsolete.def, obsolete.message.into()));
                     }
                 }
             }
@@ -709,8 +772,8 @@ mod tests {
     #[rstest]
     #[case::legacy_digest_algorithm("digest", "sha@1=YWJj", "token_character_forbidden")]
     #[case::legacy_want_digest_algorithm("want-digest", "sha@1", "token_character_forbidden")]
-    #[case::legacy_empty_member("digest", "sha-256=YWJj,", "")]
-    #[case::legacy_no_equals("digest", "sha-256", "")]
+    #[case::legacy_empty_member("digest", "sha-256=YWJj,", "digest_member_empty")]
+    #[case::legacy_no_equals("digest", "sha-256", "digest_equals_missing")]
     #[case::structured_key_case(
         "content-digest",
         "SHA-256=:YWJj:",
@@ -736,7 +799,17 @@ mod tests {
         "sha-256=11",
         "digest_preference_invalid"
     )]
-    #[case::structured_empty_member("content-digest", "sha-256=:YWJj:,", "")]
+    #[case::structured_empty_member(
+        "content-digest",
+        "sha-256=:YWJj:,",
+        "structured_field_member_empty"
+    )]
+    #[case::legacy_empty_algorithm("digest", "=YWJj", "token_empty")]
+    #[case::structured_empty_key("content-digest", "=:YWJj:", "structured_field_key_malformed")]
+    #[case::structured_bare_key("content-digest", "sha-256", "digest_value_malformed")]
+    #[case::legacy_field_is_obsolete("digest", "sha-256=YWJj", "digest_field_obsolete")]
+    #[case::content_md5_is_obsolete("content-md5", "YWJj", "content_md5_obsolete")]
+    #[case::want_bare_key("want-content-digest", "sha-256", "digest_preference_malformed")]
     fn only_the_legacy_algorithm_is_a_borrowed_production(
         #[case] field: &str,
         #[case] value: &str,

--- a/lint-http-rules/src/violations/digest.rs
+++ b/lint-http-rules/src/violations/digest.rs
@@ -52,7 +52,129 @@ pub const RFC_9530_4: SpecRef = SpecRef {
     note: "`Want-Content-Digest` / `Want-Repr-Digest`: a Dictionary whose values are Integers in the range 0 to 10 inclusive",
 };
 
+/// The legacy `instance-digest`: an algorithm, an `=`, and the encoded output
+/// of the digest.
+pub const RFC_3230_4_2: SpecRef = SpecRef {
+    spec: "RFC 3230",
+    section: Some("4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc3230.html#section-4.2",
+    note: "Instance digests: `instance-digest = digest-algorithm \"=\" <encoded digest output>`, the production a legacy `Digest` member is written in — three parts with nothing bracketed, and an encoding the algorithm's own definition supplies",
+};
+
+/// Where RFC 3230's two fields stopped existing.
+pub const RFC_9530: SpecRef = SpecRef {
+    spec: "RFC 9530",
+    section: None,
+    url: "https://www.rfc-editor.org/rfc/rfc9530.html",
+    note: "Digest Fields, which obsoletes RFC 3230 and the `Digest` and `Want-Digest` fields with it — the sentence that makes a well-formed legacy field a finding rather than a style preference",
+};
+
+/// Where `Content-MD5` was removed from HTTP, which is neither RFC 9530 nor
+/// recent.
+pub const RFC_7231_APPENDIX_B: SpecRef = SpecRef {
+    spec: "RFC 7231",
+    section: Some("Appendix B"),
+    url: "https://www.rfc-editor.org/rfc/rfc7231.html#appendix-B",
+    note: "Where `Content-MD5` was removed from HTTP — RFC 9530 does not mention the field at all",
+};
+
 defects! {
+    /// A well-formed `Digest` or `Want-Digest`.
+    ///
+    /// **The field is gone, not discouraged.** RFC 9530 obsoletes RFC 3230 and
+    /// names both fields while doing it, so what a sender writes here is a
+    /// field no current specification defines — and a recipient that
+    /// implements only the current one computes no integrity check at all.
+    /// That is the whole finding: the value can be perfect.
+    ///
+    /// `_obsolete`, and one entry for the two fields because one sentence
+    /// retired both and the fix is the same pair of replacements.
+    ///
+    /// `warn`, with `Via`'s obsolete spelling rather than with
+    /// [`http_date`](crate::violations::http_date)'s: an RFC 850 timestamp is a
+    /// form every recipient is *obliged* to read, and nothing obliges anyone to
+    /// implement a field that was removed.
+    ///
+    // cite(RFC 9530): "This document obsoletes RFC 3230 and the Digest and Want-Digest HTTP fields."
+    DIGEST_FIELD_OBSOLETE = {
+        id: "digest_field_obsolete",
+        title: "Digest or Want-Digest is a field RFC 9530 retired",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_9530],
+    }
+
+    /// A `Content-MD5`.
+    ///
+    /// **Its own entry, because its own document retired it and the sentence
+    /// says why.** RFC 9530 never mentions the field — it cannot be what
+    /// removed it — and RFC 7231 took it out of HTTP years earlier for being
+    /// inconsistently implemented with respect to partial responses. An id
+    /// folded into [`DIGEST_FIELD_OBSOLETE`] would send an operator to the
+    /// wrong document for the reason.
+    ///
+    /// `warn`, with its sibling.
+    ///
+    // cite(RFC 7231): "The Content-MD5 header field has been removed because it was inconsistently implemented with respect to partial responses."
+    CONTENT_MD5_OBSOLETE = {
+        id: "content_md5_obsolete",
+        title: "Content-MD5 is a field HTTP removed",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_7231_APPENDIX_B],
+    }
+
+    /// A comma with no member beside it in a legacy `Digest` or `Want-Digest`:
+    /// a trailing comma, or two commas in a row.
+    ///
+    /// **Uncited, and the reason is that the list permits it.** These fields
+    /// are RFC 2616's `#rule`, whose expansion generates null elements — the
+    /// reading `Sec-WebSocket-Extensions` settled — so
+    /// [`list_member_empty`](crate::violations::list), whose sentence is RFC
+    /// 9110 § 5.6.1.1's *sender MUST NOT*, would report a requirement these
+    /// fields do not carry. What refuses it here is this crate's reading that a
+    /// member naming no algorithm says nothing about any bytes.
+    ///
+    /// **Not the structured fields' emptiness either.** A Dictionary has no
+    /// list construct in it at all, and a comma with nothing beside it there is
+    /// a parse failure that costs the whole field — which is
+    /// [`structured_field_member_empty`](crate::violations::structured_fields),
+    /// a different sentence and a different consequence.
+    ///
+    /// `warn`, with the subject.
+    DIGEST_MEMBER_EMPTY = {
+        id: "digest_member_empty",
+        title: "Digest field writes a comma with no member beside it",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[],
+    }
+
+    /// A legacy `Digest` member written without its `=`: `Digest: sha-256`.
+    ///
+    /// `instance-digest` prints three parts and brackets none of them, so a
+    /// member that is an algorithm and nothing else names a computation and
+    /// none of its output.
+    ///
+    /// **This entry is the legacy generation's alone**, and the structured
+    /// fields are the reason it has to be said. In a Dictionary a bare key is
+    /// not a member missing its value: § 4.2.2 gives it the Boolean true, so
+    /// what is wrong there is a value of the wrong type — reported as
+    /// [`DIGEST_VALUE_MALFORMED`] and [`DIGEST_PREFERENCE_MALFORMED`], each
+    /// against the type its own field defines. **The same spelling is two
+    /// defects because two grammars read it two ways.**
+    ///
+    /// `warn`, with the subject.
+    ///
+    // cite(RFC 3230 § 4.2): "instance-digest = digest-algorithm "=" <encoded digest output>"
+    DIGEST_EQUALS_MISSING = {
+        id: "digest_equals_missing",
+        title: "Digest member is written without its '='",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_3230_4_2],
+    }
+
     /// A digest field member whose value is not a Byte Sequence:
     /// `Content-Digest: sha-256=YWJj`, where the `:` delimiters are missing.
     ///

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -440,7 +440,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 269;
+        const FLOOR: usize = 273;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/structured_fields.rs
+++ b/lint-http-rules/src/violations/structured_fields.rs
@@ -36,7 +36,43 @@ pub const RFC_9651_4_2_3_3: SpecRef = SpecRef {
     note: "Parsing a Key: a `key` opens with `lcalpha` or `*` and continues with `lcalpha`, DIGIT, `_`, `-`, `.` or `*` — the production every Dictionary member name and every parameter name is written in, and the one an uppercase letter fails",
 };
 
+/// Parsing a Dictionary: the loop that reads member after member, and the two
+/// steps a comma with nothing beside it fails.
+pub const RFC_9651_4_2_2: SpecRef = SpecRef {
+    spec: "RFC 9651",
+    section: Some("4.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9651.html#section-4.2.2",
+    note: "Parsing a Dictionary: a member is a key and, optionally, an `=` and a value — a bare key carries the Boolean true rather than being a member without one — and the loop fails on a comma with nothing after it",
+};
+
 defects! {
+    /// A Dictionary written with a comma and no member beside it:
+    /// `a=1,,b=2`, or a value ending on its separator.
+    ///
+    /// The parsing loop fails twice over: a trailing comma is named in a step
+    /// of its own, and a comma in the middle leaves the *next* iteration
+    /// reading a key that does not start where a key starts. **One entry,
+    /// because what the sender wrote is one thing** — a separator with nothing
+    /// to separate — and because the outcome is identical: the field is not
+    /// parsed, so it is not there.
+    ///
+    /// **This is not [`list_member_empty`](crate::violations::list).** That
+    /// entry carries RFC 9110 § 5.6.1.1's requirement on a sender writing a
+    /// `#rule` list, and a Dictionary is not a list construct: it has no
+    /// `#element` expansion to generate a null element and no leniency to
+    /// spend. The two look alike on the wire and answer to different documents.
+    ///
+    /// `warn`, with the key: what it costs is the field.
+    ///
+    // cite(RFC 9651 § 4.2.2): "If input_string is empty, there is a trailing comma; fail parsing."
+    STRUCTURED_FIELD_MEMBER_EMPTY = {
+        id: "structured_field_member_empty",
+        title: "Structured field writes a comma with no member beside it",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_9651_4_2_2],
+    }
+
     /// A Dictionary member name or a parameter name that is not a `key`:
     /// `SHA-256`, `Report-To`, `2fa`.
     ///
@@ -53,11 +89,13 @@ defects! {
     /// failure and not a name outside some registry.
     ///
     /// **`warn`, and the ceiling is what keeps it there.** What a bad key costs
-    /// is the whole field — § 4.2 has a recipient ignore a field it cannot
-    /// parse, so the members written correctly go with the one that was not —
-    /// and that is more than any octet-level entry costs. It is still not the
-    /// exchange: a request or a response missing a field it meant to send is
-    /// answerable, so `error` would claim something the finding cannot show.
+    /// is the whole field — § 4.2 offers a recipient the choice of ignoring the
+    /// field value entirely or treating the message as malformed, so the
+    /// members written correctly go with the one that was not — and that is
+    /// more than any octet-level entry costs. The lenient answer is the one
+    /// deployments take, and under it a request or a response missing a field
+    /// it meant to send is still answerable, so `error` would claim something
+    /// the finding cannot show.
     ///
     // cite(RFC 9651 § 3.1.2): "Note that parameters are ordered, and parameter keys cannot contain uppercase letters."
     STRUCTURED_FIELD_KEY_MALFORMED = {

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1158,20 +1158,26 @@ sources:
 - label: RFC 3230
   url: https://www.rfc-editor.org/rfc/rfc3230.html
   fragments:
+  - label: digest
+    section: § 4.2
+    snippet: instance-digest = digest-algorithm "=" <encoded digest output>
+    cited_by:
+    - file: lint-http-rules/src/violations/digest.rs
+      line: 169
   - label: digest_header_syntax
     section: § 4.1.1
     snippet: All digest-algorithm values are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 407
+      line: 445
   - label: digest_header_syntax (2)
     section: § 4.1.1
     snippet: digest-algorithm = token
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 370
+      line: 396
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 406
+      line: 444
 - label: RFC 3986
   url: https://www.rfc-editor.org/rfc/rfc3986.html
   fragments:
@@ -3313,8 +3319,8 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/content_md5_vs_digest_preference.rs
       line: 103
-    - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 206
+    - file: lint-http-rules/src/violations/digest.rs
+      line: 118
 - label: RFC 7234
   url: https://www.rfc-editor.org/rfc/rfc7234.html
   fragments:
@@ -11280,49 +11286,49 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/content_md5_vs_digest_preference.rs
       line: 86
-  - label: digest_header_syntax
+  - label: digest
     snippet: This document obsoletes RFC 3230 and the Digest and Want-Digest HTTP fields.
     cited_by:
-    - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 194
+    - file: lint-http-rules/src/violations/digest.rs
+      line: 98
   - label: content-digest dictionary
     section: § 2
     snippet: 'It is a Dictionary (see Section 3.2 of [STRUCTURED-FIELDS]), where each:'
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 153
+      line: 152
     - file: lint-http-rules/src/violations/digest.rs
       line: 29
-  - label: digest_header_syntax (2)
+  - label: digest_header_syntax
     section: § 2
     snippet: key conveys the hashing algorithm (see Section 5) used to compute the digest;
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 453
-  - label: digest_header_syntax (3)
+      line: 503
+  - label: digest_header_syntax (2)
     section: § 2
     snippet: value is a Byte Sequence (Section 3.3.5 of [STRUCTURED-FIELDS]) that conveys an encoded version of the byte output produced by the digest calculation.
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 468
+      line: 518
     - file: lint-http-rules/src/violations/digest.rs
-      line: 74
-  - label: digest_header_syntax (4)
+      line: 196
+  - label: digest_header_syntax (3)
     section: § 4
     snippet: 'Want-Content-Digest and Want-Repr-Digest are of type Dictionary where each:'
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 157
+      line: 156
   - label: want-digest preference type
     section: § 4
     snippet: value is an Integer (Section 3.3.1 of [STRUCTURED-FIELDS]) that conveys an ascending, relative, weighted preference. It must be in the range 0 to 10 inclusive.
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 536
+      line: 597
     - file: lint-http-rules/src/violations/digest.rs
-      line: 119
+      line: 241
     - file: lint-http-rules/src/violations/digest.rs
-      line: 141
+      line: 263
 - label: RFC 9651
   url: https://www.rfc-editor.org/rfc/rfc9651.html
   fragments:
@@ -11341,7 +11347,7 @@ sources:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 228
     - file: lint-http-rules/src/violations/structured_fields.rs
-      line: 62
+      line: 100
   - label: lint-http-rules/src/helpers/structured_fields.rs (2)
     section: § 3.1.2
     snippet: The keys are unique within the scope of the Parameters they occur within, and the values are bare items (i.e., they themselves cannot be parameterized; see Section 3.3).
@@ -11474,6 +11480,8 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 468
+    - file: lint-http-rules/src/violations/structured_fields.rs
+      line: 67
   - label: lint-http-rules/src/helpers/structured_fields.rs (23)
     section: § 4.2.2
     snippet: 'If the first character of input_string is "=":'


### PR DESCRIPTION
The reader that splits `key=value` members serves both digest generations and already took its wording from each caller. It now takes the entry too, because the same spelling is a different defect depending on which grammar the value was written in.

A comma with nothing beside it: this crate's strictness under RFC 2616's `#rule`, which permits null elements, against a parse failure under RFC 9651, which costs the whole field. A bare name: a member missing its `=` in RFC 3230, against a member carrying the Boolean true in RFC 9651 — so the structured half reports the value type its own field defines, a Byte Sequence for the digest fields and an Integer for the preferences. An empty name: `token_empty`, since `digest-algorithm = token` derives no empty string, against `structured_field_key_malformed`, since a key starts where no key started.

Three sites, six entries, and two of the six are borrowings the reading found. The id follows the grammar the value was written in, never the code path that read it.

The two obsolete fields split for the same kind of reason. RFC 9530 retired `Digest` and `Want-Digest` in one sentence and RFC 7231 removed `Content-MD5` years earlier for a different one, so folding them into a single id would send an operator to the wrong document for the reason.

The rule converts whole; its `Defect` drops the `Option`.

Catalogue 286, spec floor 273. Every quote in the tree was re-verified against its source before this landed.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
