### PR TITLE
Two separators, two documents

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1623,6 +1623,22 @@ severity = "warn"
 # Language tag holds whitespace or a control character
 severity = "error"
 
+[violations.link_member_malformed]
+# Link member carries content the production does not continue with
+severity = "warn"
+
+[violations.link_param_empty]
+# Link member writes a semicolon with no link-param behind it
+severity = "warn"
+
+[violations.link_param_value_empty]
+# Link parameter writes an '=' with no value after it
+severity = "warn"
+
+[violations.link_target_delimiter_missing]
+# Link member's target is not inside angle brackets
+severity = "warn"
+
 [violations.list_member_empty]
 # List holds an empty element
 severity = "warn"

--- a/lint-http-rules/src/rules/link_header_valid.rs
+++ b/lint-http-rules/src/rules/link_header_valid.rs
@@ -15,6 +15,10 @@ use crate::violations::language::{
     LANGUAGE_TAG_EMPTY, LANGUAGE_TAG_LEADING_LETTER_MISSING, LANGUAGE_TAG_SUBTAG_EMPTY,
     LANGUAGE_TAG_SUBTAG_LENGTH_INVALID, LANGUAGE_TAG_WHITESPACE_OR_CONTROL_FORBIDDEN, RFC_5646_2_1,
 };
+use crate::violations::link::{
+    LINK_MEMBER_MALFORMED, LINK_PARAM_EMPTY, LINK_PARAM_VALUE_EMPTY, LINK_TARGET_DELIMITER_MISSING,
+    RFC_8288_3,
+};
 use crate::violations::list::{LIST_MEMBER_EMPTY, RFC_9110_5_6_1_1};
 use crate::violations::quoted_pair::QUOTED_PAIR_MALFORMED;
 use crate::violations::quoted_string::{
@@ -33,7 +37,8 @@ use crate::violations::ViolationDef;
 
 pub struct LinkHeaderValid;
 
-/// Every production this field is assembled from, and none of its assembly.
+/// Every production this field is assembled from, and the first four entries of
+/// its assembly.
 ///
 /// `Link = #link-value` with `link-value = "<" URI-Reference ">" *( OWS ";"
 /// OWS link-param )` and `link-param = token BWS [ "=" BWS ( token /
@@ -45,13 +50,24 @@ pub struct LinkHeaderValid;
 /// are imported the same way: an `hreflang` is RFC 5646's `Language-Tag`, the
 /// same production `Content-Language` carries.
 ///
-/// What stays this rule's own is everything the *serialisation* says about how
-/// those parts go together — a target with no brackets around it, content
-/// after the one that closed, a `;` owing a parameter, `rel` missing or
-/// written twice, a relation type deriving from neither of § 3.3's
-/// alternatives — and the two findings HTML states about a `preload`, which no
-/// RFC asks for at all.
+/// What is this document's own is everything the *serialisation* says about how
+/// those parts go together, and four of it are written: the angle brackets as
+/// one entry for two delimiters, a member continuing with something the
+/// production does not, a `;` owing a parameter, and an `=` written with no
+/// value after it. **The `;` is the entry to read twice** — § 5.6.1.1's
+/// sentence about empty elements is about the `#` construct's commas, and this
+/// repetition is RFC 8288's own, so the two separators of one field answer to
+/// two documents.
+///
+/// **What is still unnamed** is what the parameters *mean*: `rel` missing,
+/// empty, written twice or naming a relation type deriving from neither of
+/// § 3.3's alternatives, a `type` value that is no media type — and the two
+/// findings HTML states about a `preload`, which no RFC asks for at all.
 static DECLARED: &[&ViolationDef] = &[
+    &LINK_TARGET_DELIMITER_MISSING,
+    &LINK_MEMBER_MALFORMED,
+    &LINK_PARAM_EMPTY,
+    &LINK_PARAM_VALUE_EMPTY,
     &LIST_MEMBER_EMPTY,
     &TOKEN_EMPTY,
     &TOKEN_CHARACTER_FORBIDDEN,
@@ -115,16 +131,6 @@ impl Defect {
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_8288_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 8288",
-    section: Some("3"),
-    url: "https://www.rfc-editor.org/rfc/rfc8288.html#section-3",
-    note: "The serialisation: `Link = #link-value`, the angle-bracketed \
-           `URI-Reference`, and `link-param = token BWS [ \"=\" BWS ( token / \
-           quoted-string ) ]` — whose optional group is what makes a valueless \
-           parameter conforming. Also the sentence equating the token and \
-           quoted-string forms, which is why a value is judged after unquoting",
-};
 const RFC_8288_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 8288",
     section: Some("3.1"),
@@ -722,20 +728,26 @@ const AT_MOST_ONCE: &[&str] = &["rel", "media", "title", "title*", "type"];
 // cite(RFC 8288 § 3): "link-value = "<" URI-Reference ">" *( OWS ";" OWS link-param )"
 fn validate_link_value(member: &str, is_response: bool) -> Result<(), Defect> {
     let Some(rest) = member.strip_prefix('<') else {
-        return Err(Defect::unnamed(format!(
-            "'{}' does not open with the '<' the production prints before its URI-Reference",
-            shown_in_finding(member)
-        )));
+        return Err(Defect::named(
+            &LINK_TARGET_DELIMITER_MISSING,
+            format!(
+                "'{}' does not open with the '<' the production prints before its URI-Reference",
+                shown_in_finding(member)
+            ),
+        ));
     };
 
     // `<` and `>` are neither of them URI characters, so the first `>` is the
     // one that closes the target -- there is no component of a `URI-Reference`
     // it could be sitting inside.
     let Some(close) = rest.find('>') else {
-        return Err(Defect::unnamed(format!(
-            "'{}' has no '>' closing its URI-Reference",
-            shown_in_finding(member)
-        )));
+        return Err(Defect::named(
+            &LINK_TARGET_DELIMITER_MISSING,
+            format!(
+                "'{}' has no '>' closing its URI-Reference",
+                shown_in_finding(member)
+            ),
+        ));
     };
     let (target, after) = rest.split_at(close);
 
@@ -769,11 +781,14 @@ fn validate_link_value(member: &str, is_response: bool) -> Result<(), Defect> {
         return missing_rel(member);
     }
     let Some(params_src) = after.strip_prefix(';') else {
-        return Err(Defect::unnamed(format!(
-            "'{}' has '{}' after its '>', where the production admits only ';'-delimited parameters",
-            shown_in_finding(member),
-            shown_in_finding(after)
-        )));
+        return Err(Defect::named(
+            &LINK_MEMBER_MALFORMED,
+            format!(
+                "'{}' has '{}' after its '>', where the production admits only ';'-delimited parameters",
+                shown_in_finding(member),
+                shown_in_finding(after)
+            ),
+        ));
     };
 
     let mut seen: Vec<String> = Vec::new();
@@ -788,10 +803,13 @@ fn validate_link_value(member: &str, is_response: bool) -> Result<(), Defect> {
         // carries nothing. So the missing parameter is this serialisation's
         // finding and the missing member above is the shared one.
         if segment.is_empty() {
-            return Err(Defect::unnamed(format!(
-                "'{}' has a ';' with no link-param after it",
-                shown_in_finding(member)
-            )));
+            return Err(Defect::named(
+                &LINK_PARAM_EMPTY,
+                format!(
+                    "'{}' has a ';' with no link-param after it",
+                    shown_in_finding(member)
+                ),
+            ));
         }
 
         // cite(RFC 8288 § 3): "link-param = token BWS [ "=" BWS ( token / quoted-string ) ]"
@@ -811,9 +829,12 @@ fn validate_link_value(member: &str, is_response: bool) -> Result<(), Defect> {
                 shown_in_finding(segment),
                 defect.message(segment)
             );
+            // The `None` is the empty value, which the shared mapping leaves
+            // to the field: here the optional group makes the `=` itself
+            // optional, so a member that writes one owes a `word` after it.
             match token_bws_word_defect(&defect) {
                 Some(def) => Defect::named(def, message),
-                None => Defect::unnamed(message),
+                None => Defect::named(&LINK_PARAM_VALUE_EMPTY, message),
             }
         })?;
 
@@ -1517,11 +1538,12 @@ mod tests {
     // the one that closed, a `;` owing a parameter, `rel` absent, empty,
     // repeated, or naming a value neither of §3.3's alternatives generates —
     // and the two findings HTML states about a preload.
-    #[case(b"https://example/; rel=next", None)]
-    #[case(b"</a> junk; rel=next", None)]
-    #[case(b"</a>; rel=next;", None)]
+    #[case(b"https://example/; rel=next", Some("link_target_delimiter_missing"))]
+    #[case(b"</a; rel=next", Some("link_target_delimiter_missing"))]
+    #[case(b"</a> junk; rel=next", Some("link_member_malformed"))]
+    #[case(b"</a>; rel=next;", Some("link_param_empty"))]
     #[case(b"</a>; title=\"Home\"", None)]
-    #[case(b"</a>; rel=", None)]
+    #[case(b"</a>; rel=", Some("link_param_value_empty"))]
     #[case(b"</a>; rel=next; rel=prev", None)]
     #[case(b"</a>; rel=Next", None)]
     #[case(b"</a>; rel=alternate; type=text", None)]

--- a/lint-http-rules/src/violations/link.rs
+++ b/lint-http-rules/src/violations/link.rs
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `Link` defects — how a `link-value` is put together, and what its
+//! parameters say.
+//!
+//! `link-value = "<" URI-Reference ">" *( OWS ";" OWS link-param )` names four
+//! things and defines two of them. The list around the members is
+//! [`list`](crate::violations::list)'s, a parameter's name is a
+//! [`token`](crate::violations::token) and its value a `token` or a
+//! [`quoted_string`](crate::violations::quoted_string), the whitespace beside
+//! the `=` is [`bws`](crate::violations::bws)'s, and what goes between the
+//! angle brackets is a [`uri`](crate::violations::uri). **What is RFC 8288's
+//! own is the brackets, the repetition, and everything the parameters mean.**
+//!
+//! **The brackets are one entry for two delimiters**, which is the answer
+//! [`quoted_string`](crate::violations::quoted_string) gives for its DQUOTEs: a
+//! production written as a delimiter, a value and a delimiter is broken the
+//! same way whichever end is missing, and the message says which.
+//!
+//! **The repetition is not the list**, and the distinction is the one this
+//! field is most likely to be read wrong on. § 5.6.1.1's sentence about empty
+//! elements is about the `#` construct and its commas; the parameters hang off
+//! `*( OWS ";" OWS link-param )`, which RFC 8288 writes itself with no bracket
+//! around the `link-param` inside it. So a comma with nothing beside it is
+//! `list_member_empty` and a semicolon with nothing beside it is this
+//! subject's — two sentences from two documents about two separators.
+//!
+//! **Flat at `warn`.** A `Link` is metadata about relationships: a member a
+//! recipient cannot read costs a link it would have followed, and no exchange
+//! turns on it. Nothing here is `error`, and nothing is `info` either, because
+//! every one of these leaves a member that does not derive at all.
+//
+// cite(RFC 8288 § 3, label: link-value assembly): "link-value = "<" URI-Reference ">" *( OWS ";" OWS link-param )"
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// The serialisation: the member, its brackets, and the parameter repetition.
+pub const RFC_8288_3: SpecRef = SpecRef {
+    spec: "RFC 8288",
+    section: Some("3"),
+    url: "https://www.rfc-editor.org/rfc/rfc8288.html#section-3",
+    note: "The serialisation: `Link = #link-value`, the angle-bracketed \
+           `URI-Reference`, and `link-param = token BWS [ \"=\" BWS ( token / \
+           quoted-string ) ]` — whose optional group is what makes a valueless \
+           parameter conforming. Also the sentence equating the token and \
+           quoted-string forms, which is why a value is judged after unquoting",
+};
+
+defects! {
+    /// A member whose target is not between angle brackets: `http://x>`, or
+    /// `<http://x` with nothing closing it.
+    ///
+    /// **One entry for both delimiters.** The production writes `"<"
+    /// URI-Reference ">"`, and a member missing either one is the same member:
+    /// a recipient has no way to tell where the target begins or ends, so the
+    /// whole `link-value` is unreadable rather than partly wrong. That is the
+    /// answer `quoted_string_delimiter_missing` gives for its DQUOTEs, and the
+    /// message says which bracket was the missing one.
+    ///
+    /// `warn`, with the subject: the member is dropped and the exchange is
+    /// untouched.
+    ///
+    // cite(RFC 8288 § 3.1): "Each link-value conveys one target IRI as a URI-Reference (after conversion to one, if necessary; see [RFC3987], Section 3.1) inside angle brackets ("<>")."
+    LINK_TARGET_DELIMITER_MISSING = {
+        id: "link_target_delimiter_missing",
+        title: "Link member's target is not inside angle brackets",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_8288_3],
+    }
+
+    /// A member that goes on past its target with something other than the
+    /// parameters' `;`: `<http://x> rel=next`, where the semicolon was never
+    /// written.
+    ///
+    /// After the closing bracket the production admits exactly one thing, and
+    /// it is a repetition that opens on a `;`. Anything else derives from
+    /// nothing — and, as with a `Via` member that does not end where the
+    /// production ends it, the catalogue cannot say whether the sender lost a
+    /// delimiter or ran two members together. **What the finding claims is the
+    /// only thing both readings share**: from here on the member is not
+    /// derivable.
+    ///
+    // cite(RFC 8288 § 3, label: link-param repetition): "link-value = "<" URI-Reference ">" *( OWS ";" OWS link-param )"
+    LINK_MEMBER_MALFORMED = {
+        id: "link_member_malformed",
+        title: "Link member carries content the production does not continue with",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_8288_3],
+    }
+
+    /// A semicolon with no parameter behind it: `<http://x>; rel=next;;`.
+    ///
+    /// `*( OWS ";" OWS link-param )` repeats a group holding one parameter and
+    /// brackets nothing inside it, so every semicolon the repetition generates
+    /// owes a `link-param`. **Not
+    /// [`list_member_empty`](crate::violations::list)**: that entry carries RFC
+    /// 9110 § 5.6.1.1's requirement about a `#rule`'s commas, and this
+    /// repetition is RFC 8288's own — the same distinction `Prefer` draws from
+    /// the other side, where `*( OWS ";" [ OWS parameter ] )` brackets the
+    /// parameter and a bare `;` conforms.
+    ///
+    /// `_empty` rather than `_missing`: the semicolon is the repetition's
+    /// delimiter, so a sender that wrote one knew a parameter was due.
+    ///
+    // cite(RFC 8288 § 3, label: link-param repetition group): "link-value = "<" URI-Reference ">" *( OWS ";" OWS link-param )"
+    LINK_PARAM_EMPTY = {
+        id: "link_param_empty",
+        title: "Link member writes a semicolon with no link-param behind it",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_8288_3],
+    }
+
+    /// A parameter whose `=` is written with nothing after it: `rel=`.
+    ///
+    /// **The optional group is what makes this a finding rather than the
+    /// opposite.** `link-param = token BWS [ "=" BWS ( token / quoted-string )
+    /// ]` brackets the `=` *and* the value together, so a bare `rel` derives
+    /// perfectly well — it is a parameter with no value, which this field
+    /// admits. A member that writes the `=` has entered the group and owes a
+    /// `token` or a `quoted-string`, neither of which derives the empty string.
+    ///
+    /// **This entry is the field's answer to a `None` in a mapping.** The
+    /// shared reader of `token BWS [ "=" BWS word ]` returns no id for an empty
+    /// value, because what one means is the field's to say and its readers
+    /// answered differently; here it means a parameter that opened its value
+    /// and wrote none.
+    ///
+    // cite(RFC 8288 § 3, label: link-param optional group): "link-param = token BWS [ "=" BWS ( token / quoted-string ) ]"
+    LINK_PARAM_VALUE_EMPTY = {
+        id: "link_param_value_empty",
+        title: "Link parameter writes an '=' with no value after it",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_8288_3],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::violations::list::LIST_MEMBER_EMPTY;
+
+    /// The subject is flat and every entry names the section that prints the
+    /// production it fails.
+    #[test]
+    fn every_entry_ranks_with_its_siblings() {
+        for def in [
+            &LINK_TARGET_DELIMITER_MISSING,
+            &LINK_MEMBER_MALFORMED,
+            &LINK_PARAM_EMPTY,
+            &LINK_PARAM_VALUE_EMPTY,
+        ] {
+            assert_eq!(def.default_severity, Severity::Warn, "{}", def.id);
+            assert_eq!(def.spec.len(), 1, "{}", def.id);
+        }
+    }
+
+    /// The two separators a `Link` writes answer to two documents: the comma to
+    /// the list construct's sentence, the semicolon to this field's own
+    /// repetition. They look alike on the wire and are not one entry.
+    #[test]
+    fn the_semicolon_is_not_the_lists_comma() {
+        assert_ne!(LINK_PARAM_EMPTY.id, LIST_MEMBER_EMPTY.id);
+        assert_ne!(
+            LINK_PARAM_EMPTY.spec[0].spec,
+            LIST_MEMBER_EMPTY.spec[0].spec
+        );
+    }
+}

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -56,6 +56,7 @@ pub mod field;
 pub mod http_date;
 pub mod keep_alive;
 pub mod language;
+pub mod link;
 pub mod list;
 pub mod mailbox;
 pub mod media_type;
@@ -440,7 +441,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 273;
+        const FLOOR: usize = 277;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -166,13 +166,13 @@ sources:
     snippet: A preload destination is "fetch", "font", "image", "script", "style", or "track".
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1003
+      line: 1024
   - label: link_header_valid (2)
     section: § 4.6.8.20
     snippet: If destination is not a preload destination, then return null.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1004
+      line: 1025
 - label: HTML Speculative Loading
   url: https://html.spec.whatwg.org/multipage/speculative-loading.html
   type: text/html
@@ -236,37 +236,37 @@ sources:
     snippet: Apply link options from parsed header attributes to options given attribs
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 959
+      line: 980
   - label: link_header_valid (2)
     section: § 4.2.4.4
     snippet: If attribs["as"] does not exist, then return false.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 960
+      line: 981
   - label: link_header_valid (3)
     section: § 4.2.4.4
     snippet: If attribs["crossorigin"] exists and is an ASCII case-insensitive match for one of the CORS settings attribute keywords
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 980
+      line: 1001
   - label: link_header_valid (4)
     section: § 4.2.4.4
     snippet: If destination is null, then return false.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 979
+      line: 1000
   - label: link_header_valid (5)
     section: § 4.2.4.4
     snippet: Let destination be the result of translating attribs["as"].
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 978
+      line: 999
   - label: link_header_valid (6)
     section: § 4.2.4.4
     snippet: To process link headers given a Document doc, a response response, and a "pre-media" or "media" phase
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 958
+      line: 979
   - label: refresh_header_syntax
     section: § 4.2.5.3
     snippet: 'For meta elements with an http-equiv attribute in the Refresh state, the content attribute must have a value consisting either of:'
@@ -1310,7 +1310,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 357
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 662
+      line: 668
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 272
   - label: lint-http-rules/src/helpers/uri.rs (9)
@@ -1370,7 +1370,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1069
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1077
+      line: 1098
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 393
     - file: lint-http-rules/src/violations/uri.rs
@@ -3262,7 +3262,7 @@ sources:
     snippet: 'Type and subtype names MUST conform to the following ABNF:'
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1172
+      line: 1193
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
       line: 188
   - label: link_header_valid (2)
@@ -3270,7 +3270,7 @@ sources:
     snippet: restricted-name = restricted-name-first *126restricted-name-chars restricted-name-first  = ALPHA / DIGIT
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1173
+      line: 1194
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
       line: 202
   - label: link_header_valid (3)
@@ -3278,13 +3278,13 @@ sources:
     snippet: restricted-name-chars = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "-" / "^" / "_"
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1174
+      line: 1195
   - label: link_header_valid (4)
     section: § 4.2
     snippet: restricted-name-chars =/ "+" ; Characters after last plus always ; specify a structured syntax suffix
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1176
+      line: 1197
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
       line: 196
   - label: link_header_valid (5)
@@ -3292,13 +3292,13 @@ sources:
     snippet: restricted-name-chars =/ "." ; Characters before first dot always ; specify a facet name
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1175
+      line: 1196
   - label: link_header_valid (6)
     section: § 4.2
     snippet: type-name = restricted-name subtype-name = restricted-name
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1149
+      line: 1170
   - label: media_type_suffix_valid
     section: § 4.2.8
     snippet: '"+suffix" constructs for as-yet unregistered structured syntaxes SHOULD NOT be used, given the possibility of conflicts with future suffix definitions.'
@@ -4307,175 +4307,185 @@ sources:
     snippet: 'This document uses the Augmented Backus-Naur Form (ABNF) [RFC5234] notation of [RFC7230], including the #rule, and explicitly includes the following rules from it'
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 800
+      line: 818
   - label: link_header_valid (2)
     section: § 1.2
     snippet: The requirements regarding conformance and error handling highlighted in [RFC7230], Section 2.5 apply to this document.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 589
+      line: 595
   - label: link_header_valid (3)
     section: § 2.1.1
     snippet: Registered relation type names MUST conform to the reg-rel-type rule (see Section 3.3) and MUST be compared character by character in a case-insensitive fashion.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 945
+      line: 966
   - label: link_header_valid (4)
     section: § 2.1.2
     snippet: When extension relation types are compared, they MUST be compared as strings (after converting to URIs if serialised in a different format) in a case-insensitive fashion, character by character.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1067
+      line: 1088
   - label: link_header_valid (5)
     section: § 2.2
     snippet: The names of target attributes SHOULD conform to the token rule, but SHOULD NOT include any of the characters "%", "'", or "*", for portability across serialisations and MUST be compared in a case-insensitive fashion.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 837
+      line: 858
   - label: link_header_valid (6)
     section: § 3
     snippet: Individual link-params specify their syntax in terms of the value after any necessary unquoting
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 799
+      line: 817
   - label: link_header_valid (7)
     section: § 3
     snippet: 'Link       = #link-value link-value = "<" URI-Reference ">" *( OWS ";" OWS link-param )'
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 591
+      line: 597
   - label: link_header_valid (8)
     section: § 3
     snippet: Note that any link-param can be generated with values using either the token or the quoted-string syntax; therefore, recipients MUST be able to parse both forms.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 798
+      line: 816
   - label: link_header_valid (9)
     section: § 3
     snippet: The Link header field provides a means for serialising one or more links into HTTP headers.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 521
-  - label: link_header_valid (10)
+      line: 527
+  - label: link-param optional group
     section: § 3
     snippet: link-param = token BWS [ "=" BWS ( token / quoted-string ) ]
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 797
-  - label: link_header_valid (11)
+      line: 815
+    - file: lint-http-rules/src/violations/link.rs
+      line: 135
+  - label: link-value assembly
     section: § 3
     snippet: link-value = "<" URI-Reference ">" *( OWS ";" OWS link-param )
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 661
+      line: 667
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 722
-  - label: link_header_valid (12)
+      line: 728
+    - file: lint-http-rules/src/violations/link.rs
+      line: 35
+    - file: lint-http-rules/src/violations/link.rs
+      line: 88
+    - file: lint-http-rules/src/violations/link.rs
+      line: 111
+  - label: link_header_valid (10)
     section: § 3.1
     snippet: Each link-value conveys one target IRI as a URI-Reference (after conversion to one, if necessary; see [RFC3987], Section 3.1) inside angle brackets ("<>").
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 750
-  - label: link_header_valid (13)
+      line: 762
+    - file: lint-http-rules/src/violations/link.rs
+      line: 67
+  - label: link_header_valid (11)
     section: § 3.3
     snippet: Note that extension relation types are REQUIRED to be absolute URIs in Link header fields and MUST be quoted when they contain characters not allowed in tokens
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1066
-  - label: link_header_valid (14)
+      line: 1087
+  - label: link_header_valid (12)
     section: § 3.3
     snippet: The rel parameter MUST be present but MUST NOT appear more than once in a given link-value; occurrences after the first MUST be ignored by parsers.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 714
+      line: 720
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1012
-  - label: link_header_valid (15)
+      line: 1033
+  - label: link_header_valid (13)
     section: § 3.3
     snippet: The rel parameter can, however, contain multiple link relation types.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1028
-  - label: link_header_valid (16)
+      line: 1049
+  - label: link_header_valid (14)
     section: § 3.3
     snippet: The relation type of a link conveyed in the Link header field is conveyed in the "rel" parameter's value.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1011
-  - label: link_header_valid (17)
+      line: 1032
+  - label: link_header_valid (15)
     section: § 3.3
     snippet: ext-rel-type   = URI ; Section 3 of [RFC3986]
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1065
-  - label: link_header_valid (18)
+      line: 1086
+  - label: link_header_valid (16)
     section: § 3.3
     snippet: reg-rel-type   = LOALPHA *( LOALPHA / DIGIT / "." / "-" )
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1064
+      line: 1085
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1126
-  - label: link_header_valid (19)
+      line: 1147
+  - label: link_header_valid (17)
     section: § 3.3
     snippet: relation-type  = reg-rel-type / ext-rel-type
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1063
-  - label: link_header_valid (20)
+      line: 1084
+  - label: link_header_valid (18)
     section: § 3.3
     snippet: relation-type *( 1*SP relation-type )
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1027
-  - label: link_header_valid (21)
+      line: 1048
+  - label: link_header_valid (19)
     section: § 3.4.1
     snippet: Its value MUST be quoted if it contains a semicolon (";") or comma (",").
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 923
-  - label: link_header_valid (22)
+      line: 944
+  - label: link_header_valid (20)
     section: § 3.4.1
     snippet: 'The ABNF for the hreflang parameter''s value is:'
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 888
-  - label: link_header_valid (23)
+      line: 909
+  - label: link_header_valid (21)
     section: § 3.4.1
     snippet: 'The ABNF for the media parameter''s value is:'
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 922
-  - label: link_header_valid (24)
+      line: 943
+  - label: link_header_valid (22)
     section: § 3.4.1
     snippet: 'The ABNF for the type parameter''s value is:'
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 902
-  - label: link_header_valid (25)
+      line: 923
+  - label: link_header_valid (23)
     section: § 3.4.1
     snippet: The title attribute MUST NOT appear more than once in a given link; occurrences after the first MUST be ignored by parsers.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 716
-  - label: link_header_valid (26)
+      line: 722
+  - label: link_header_valid (24)
     section: § 3.4.1
     snippet: The title* link-param MUST NOT appear more than once in a given link-value; occurrences after the first MUST be ignored by parsers.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 717
-  - label: link_header_valid (27)
+      line: 723
+  - label: link_header_valid (25)
     section: § 3.4.1
     snippet: The type attribute MUST NOT appear more than once in a given link-value; occurrences after the first MUST be ignored by parsers.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 718
-  - label: link_header_valid (28)
+      line: 724
+  - label: link_header_valid (26)
     section: § 3.4.1
     snippet: There MUST NOT be more than one media attribute in a link-value; occurrences after the first MUST be ignored by parsers.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 715
+      line: 721
 - label: RFC 8297
   url: https://www.rfc-editor.org/rfc/rfc8297.html
   fragments:
@@ -5365,7 +5375,7 @@ sources:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
       line: 521
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 590
+      line: 596
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
       line: 211
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
@@ -6457,7 +6467,7 @@ sources:
     snippet: A recipient MUST parse for such bad whitespace and remove it before interpreting the protocol element.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 826
+      line: 847
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
       line: 400
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
@@ -6469,7 +6479,7 @@ sources:
     snippet: A sender MUST NOT generate BWS in messages.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 825
+      line: 846
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
       line: 399
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
@@ -6847,7 +6857,7 @@ sources:
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
       line: 173
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 609
+      line: 615
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
       line: 186
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
@@ -7075,7 +7085,7 @@ sources:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
       line: 524
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 593
+      line: 599
     - file: lint-http-rules/src/rules/refresh_header_syntax.rs
       line: 324
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
@@ -7351,7 +7361,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 775
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 601
+      line: 607
   - label: lint-http-rules/src/helpers/list.rs (2)
     section: § 5.6.1.2
     snippet: 'A recipient MUST parse and ignore a reasonable number of empty list elements:'
@@ -7391,7 +7401,7 @@ sources:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 542
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 682
+      line: 688
     - file: lint-http-rules/src/violations/quoted_pair.rs
       line: 38
   - label: lint-http-rules/src/helpers/list.rs (5)


### PR DESCRIPTION
A `Link` writes a comma between its members and a semicolon between a member's parameters, and the two answer to different sentences. RFC 9110 §5.6.1.1 is about the `#` construct and its commas; the parameters hang off `*( OWS ";" OWS link-param )`, which RFC 8288 writes itself with no bracket around the `link-param` inside it. So a comma with nothing beside it is `list_member_empty` and a semicolon with nothing beside it is this field's own — the same distinction `Prefer` draws from the other side, where the parameter is bracketed and a bare `;` conforms.

Three more entries with it. The angle brackets are one entry for two delimiters, which is the answer `quoted_string_delimiter_missing` gives for its DQUOTEs: a member missing either one leaves a recipient unable to say where the target begins or ends. A member that goes on past its target with something other than a `;` is the member that stopped deriving, and the catalogue does not say whether a delimiter was lost or two members ran together. And an `=` with nothing after it is a finding because the optional group brackets the `=` and the value together — a bare `rel` derives perfectly well, so writing the delimiter is what owes a value.

That last one is the field's answer to a `None` in a shared mapping, which is the third field to answer it and the third different answer.

Catalogue 291, spec floor 277.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
