### PR TITLE
What a link says it is a link to

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1635,6 +1635,22 @@ severity = "warn"
 # Link parameter writes an '=' with no value after it
 severity = "warn"
 
+[violations.link_rel_empty]
+# Link member writes a rel with no relation type in it
+severity = "warn"
+
+[violations.link_rel_malformed]
+# Link rel value opens or closes on a space
+severity = "warn"
+
+[violations.link_rel_missing]
+# Link member carries no rel parameter
+severity = "warn"
+
+[violations.link_relation_type_malformed]
+# Link names a relation type that is neither registered-shaped nor a URI
+severity = "warn"
+
 [violations.link_target_delimiter_missing]
 # Link member's target is not inside angle brackets
 severity = "warn"

--- a/lint-http-rules/src/rules/link_header_valid.rs
+++ b/lint-http-rules/src/rules/link_header_valid.rs
@@ -16,8 +16,9 @@ use crate::violations::language::{
     LANGUAGE_TAG_SUBTAG_LENGTH_INVALID, LANGUAGE_TAG_WHITESPACE_OR_CONTROL_FORBIDDEN, RFC_5646_2_1,
 };
 use crate::violations::link::{
-    LINK_MEMBER_MALFORMED, LINK_PARAM_EMPTY, LINK_PARAM_VALUE_EMPTY, LINK_TARGET_DELIMITER_MISSING,
-    RFC_8288_3,
+    LINK_MEMBER_MALFORMED, LINK_PARAM_EMPTY, LINK_PARAM_VALUE_EMPTY, LINK_RELATION_TYPE_MALFORMED,
+    LINK_REL_EMPTY, LINK_REL_MALFORMED, LINK_REL_MISSING, LINK_TARGET_DELIMITER_MISSING,
+    RFC_8288_3, RFC_8288_3_3,
 };
 use crate::violations::list::{LIST_MEMBER_EMPTY, RFC_9110_5_6_1_1};
 use crate::violations::quoted_pair::QUOTED_PAIR_MALFORMED;
@@ -37,8 +38,8 @@ use crate::violations::ViolationDef;
 
 pub struct LinkHeaderValid;
 
-/// Every production this field is assembled from, and the first four entries of
-/// its assembly.
+/// Every production this field is assembled from, and everything the
+/// serialisation says about `rel`.
 ///
 /// `Link = #link-value` with `link-value = "<" URI-Reference ">" *( OWS ";"
 /// OWS link-param )` and `link-param = token BWS [ "=" BWS ( token /
@@ -59,12 +60,22 @@ pub struct LinkHeaderValid;
 /// repetition is RFC 8288's own, so the two separators of one field answer to
 /// two documents.
 ///
-/// **What is still unnamed** is what the parameters *mean*: `rel` missing,
-/// empty, written twice or naming a relation type deriving from neither of
-/// § 3.3's alternatives, a `type` value that is no media type — and the two
-/// findings HTML states about a `preload`, which no RFC asks for at all.
+/// **The `rel` family is written too**: the parameter absent, present and
+/// saying nothing, arranged around a space the production admits nowhere, or
+/// naming a relation type that derives from neither of § 3.3's alternatives.
+/// The last of those is reached only where the value has no `:`, because a
+/// colon commits it to the URI half and every octet after that is
+/// `uri`'s to judge.
+///
+/// **What is still unnamed** is a parameter this serialisation admits at most
+/// once and written twice, a `type` value that is no media type, and the two
+/// findings HTML states about a `preload` — which no RFC asks for at all.
 static DECLARED: &[&ViolationDef] = &[
     &LINK_TARGET_DELIMITER_MISSING,
+    &LINK_REL_MISSING,
+    &LINK_REL_EMPTY,
+    &LINK_REL_MALFORMED,
+    &LINK_RELATION_TYPE_MALFORMED,
     &LINK_MEMBER_MALFORMED,
     &LINK_PARAM_EMPTY,
     &LINK_PARAM_VALUE_EMPTY,
@@ -138,16 +149,6 @@ const RFC_8288_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
     note: "The link target: one IRI converted to a `URI-Reference` and written inside \
            angle brackets. The conversion is why an octet no URI admits is a finding \
            rather than an encoding question",
-};
-const RFC_8288_3_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 8288",
-    section: Some("3.3"),
-    url: "https://www.rfc-editor.org/rfc/rfc8288.html#section-3.3",
-    note: "`rel` MUST be present and MUST NOT appear more than once; its value is \
-           `relation-type *( 1*SP relation-type )`; `relation-type = reg-rel-type / \
-           ext-rel-type` with `ext-rel-type = URI`, required to be absolute. The \
-           section that makes a URI-shaped relation type conforming and a capital \
-           letter in a registered one not",
 };
 const RFC_8288_3_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 8288",
@@ -1032,10 +1033,13 @@ const PRELOAD_DESTINATIONS: &[&str] = &["fetch", "font", "image", "script", "sty
 // cite(RFC 8288 § 3.3): "The relation type of a link conveyed in the Link header field is conveyed in the "rel" parameter's value."
 // cite(RFC 8288 § 3.3): "The rel parameter MUST be present but MUST NOT appear more than once in a given link-value; occurrences after the first MUST be ignored by parsers."
 fn missing_rel(member: &str) -> Result<(), Defect> {
-    Err(Defect::unnamed(format!(
-        "'{}' carries no 'rel' parameter, and a link-value must have one",
-        shown_in_finding(member)
-    )))
+    Err(Defect::named(
+        &LINK_REL_MISSING,
+        format!(
+            "'{}' carries no 'rel' parameter, and a link-value must have one",
+            shown_in_finding(member)
+        ),
+    ))
 }
 
 /// Split a `rel` value into its relation types and judge each one.
@@ -1049,15 +1053,19 @@ fn missing_rel(member: &str) -> Result<(), Defect> {
 // cite(RFC 8288 § 3.3): "The rel parameter can, however, contain multiple link relation types."
 fn validate_rel_value(value: &str) -> Result<Vec<&str>, Defect> {
     if value.is_empty() {
-        return Err(Defect::unnamed(
+        return Err(Defect::named(
+            &LINK_REL_EMPTY,
             "writes 'rel' with no value, where §3.3 asks it for one or more relation types".into(),
         ));
     }
     if value.starts_with(' ') || value.ends_with(' ') {
-        return Err(Defect::unnamed(format!(
-            "writes rel='{}', which opens or closes on a space the production does not admit",
-            shown_in_finding(value)
-        )));
+        return Err(Defect::named(
+            &LINK_REL_MALFORMED,
+            format!(
+                "writes rel='{}', which opens or closes on a space the production does not admit",
+                shown_in_finding(value)
+            ),
+        ));
     }
 
     let types: Vec<&str> = value.split(' ').filter(|t| !t.is_empty()).collect();
@@ -1110,7 +1118,10 @@ fn relation_type_defect(t: &str) -> Result<(), Defect> {
         Some(colon) => validate_scheme_name(&t[..colon])
             .err()
             .map(|defect| Defect::named(scheme_name(defect), defect.message())),
-        None => Some(Defect::unnamed("it has no scheme".to_string())),
+        None => Some(Defect::named(
+            &LINK_RELATION_TYPE_MALFORMED,
+            "it has no scheme".to_string(),
+        )),
     };
 
     if let Some(defect) = scheme_defect {
@@ -1542,10 +1553,14 @@ mod tests {
     #[case(b"</a; rel=next", Some("link_target_delimiter_missing"))]
     #[case(b"</a> junk; rel=next", Some("link_member_malformed"))]
     #[case(b"</a>; rel=next;", Some("link_param_empty"))]
-    #[case(b"</a>; title=\"Home\"", None)]
+    #[case(b"</a>; title=\"Home\"", Some("link_rel_missing"))]
+    #[case(b"</a>", Some("link_rel_missing"))]
     #[case(b"</a>; rel=", Some("link_param_value_empty"))]
     #[case(b"</a>; rel=next; rel=prev", None)]
-    #[case(b"</a>; rel=Next", None)]
+    #[case(b"</a>; rel=Next", Some("link_relation_type_malformed"))]
+    #[case(b"</a>; rel=\"\"", Some("link_rel_empty"))]
+    #[case(b"</a>; rel", Some("link_rel_empty"))]
+    #[case(b"</a>; rel=\" next\"", Some("link_rel_malformed"))]
     #[case(b"</a>; rel=alternate; type=text", None)]
     #[case(b"</a>; rel=preload", None)]
     #[case(b"</a>; rel=preload; as=document", None)]

--- a/lint-http-rules/src/violations/link.rs
+++ b/lint-http-rules/src/violations/link.rs
@@ -50,7 +50,111 @@ pub const RFC_8288_3: SpecRef = SpecRef {
            quoted-string forms, which is why a value is judged after unquoting",
 };
 
+/// The `rel` parameter: that a member has one, and what its value derives from.
+pub const RFC_8288_3_3: SpecRef = SpecRef {
+    spec: "RFC 8288",
+    section: Some("3.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc8288.html#section-3.3",
+    note: "`rel` MUST be present and MUST NOT appear more than once; its value is \
+           `relation-type *( 1*SP relation-type )`; `relation-type = reg-rel-type / \
+           ext-rel-type` with `ext-rel-type = URI`, required to be absolute. The \
+           section that makes a URI-shaped relation type conforming and a capital \
+           letter in a registered one not",
+};
+
 defects! {
+    /// A `link-value` with no `rel` parameter at all: `</a>; title="Home"`.
+    ///
+    /// **The one parameter this serialisation requires**, and the reason is
+    /// what a link *is*: a target, a context and a relation type. A member
+    /// naming a target and no relation says which document is there and
+    /// nothing about why, so a recipient has nothing to file it under.
+    ///
+    /// Reached by two paths that are one defect — a member with no parameters
+    /// at all, and a member whose parameters do not include this one — because
+    /// what is absent is the same thing and the fix is the same.
+    ///
+    // cite(RFC 8288 § 3.3, label: rel presence): "The rel parameter MUST be present but MUST NOT appear more than once in a given link-value; occurrences after the first MUST be ignored by parsers."
+    LINK_REL_MISSING = {
+        id: "link_rel_missing",
+        title: "Link member carries no rel parameter",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_8288_3_3],
+    }
+
+    /// A `rel` that is present and says nothing: a bare `rel`, or `rel=""`.
+    ///
+    /// **Distinct from a parameter with an open `=` and nothing after it**,
+    /// which is [`LINK_PARAM_VALUE_EMPTY`] and is about the *grammar* of any
+    /// parameter. This entry is about `rel` in particular: the optional group
+    /// makes a valueless parameter derive, and `""` is a `quoted-string` that
+    /// derives too, so both spellings are conforming `link-param`s carrying no
+    /// relation type — which § 3.3's own value production does not admit,
+    /// since it opens on a `relation-type`.
+    ///
+    /// **Two spellings, one entry**: a sender that wrote `rel` and one that
+    /// wrote `rel=""` both named a link with no relation, and a recipient
+    /// cannot tell the two apart once the value is unquoted.
+    ///
+    // cite(RFC 8288 § 3.3, label: rel value production): "relation-type *( 1*SP relation-type )"
+    LINK_REL_EMPTY = {
+        id: "link_rel_empty",
+        title: "Link member writes a rel with no relation type in it",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_8288_3_3],
+    }
+
+    /// A `rel` value that opens or closes on a space: `rel=" next"`.
+    ///
+    /// The value is `relation-type *( 1*SP relation-type )` — it opens on a
+    /// type, closes on a type, and prints the separator only between two of
+    /// them. A leading or trailing space is admitted nowhere, and a recipient
+    /// splitting on `1*SP` finds an element that is not a relation type at all.
+    ///
+    /// **The value's shape rather than a value's**: what fails here is how the
+    /// types are arranged, where
+    /// [`LINK_RELATION_TYPE_MALFORMED`] is one of them failing on its own.
+    ///
+    // cite(RFC 8288 § 3.3, label: rel value separator): "relation-type *( 1*SP relation-type )"
+    LINK_REL_MALFORMED = {
+        id: "link_rel_malformed",
+        title: "Link rel value opens or closes on a space",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_8288_3_3],
+    }
+
+    /// A relation type deriving from neither alternative: `Next`, `foo bar` —
+    /// anything that is not a `reg-rel-type` and has no scheme to be a URI
+    /// with.
+    ///
+    /// **The alternation is the whole of the check, and each half is stricter
+    /// and looser than a `token` at once.** `reg-rel-type` admits less — a
+    /// leading lowercase letter, then lowercase letters, digits, `.` and `-`,
+    /// so no capital and no `_` — and `ext-rel-type` admits far more, since a
+    /// URI holds `:` and `/`. A scan against `tchar` would pass `Next` and
+    /// report `http://example.net/foo`, which the section prints as a
+    /// conforming example.
+    ///
+    /// **The `:` is what commits a value to one half**, which is why this entry
+    /// is reached only where there is none: once a colon is written, the value
+    /// can only have been meant as a URI, and every octet of it is
+    /// [`uri`](crate::violations::uri)'s to judge — the scheme's spelling and
+    /// the alphabet both. **A value with no colon is neither production's, and
+    /// that is this entry**: the verdict belongs to `relation-type` itself,
+    /// which is what an alternation can own when the reading cannot commit.
+    ///
+    // cite(RFC 8288 § 3.3, label: relation-type alternation): "relation-type  = reg-rel-type / ext-rel-type"
+    LINK_RELATION_TYPE_MALFORMED = {
+        id: "link_relation_type_malformed",
+        title: "Link names a relation type that is neither registered-shaped nor a URI",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_8288_3_3],
+    }
+
     /// A member whose target is not between angle brackets: `http://x>`, or
     /// `<http://x` with nothing closing it.
     ///

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -441,7 +441,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 277;
+        const FLOOR: usize = 281;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -166,13 +166,13 @@ sources:
     snippet: A preload destination is "fetch", "font", "image", "script", "style", or "track".
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1024
+      line: 1025
   - label: link_header_valid (2)
     section: § 4.6.8.20
     snippet: If destination is not a preload destination, then return null.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1025
+      line: 1026
 - label: HTML Speculative Loading
   url: https://html.spec.whatwg.org/multipage/speculative-loading.html
   type: text/html
@@ -236,37 +236,37 @@ sources:
     snippet: Apply link options from parsed header attributes to options given attribs
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 980
+      line: 981
   - label: link_header_valid (2)
     section: § 4.2.4.4
     snippet: If attribs["as"] does not exist, then return false.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 981
+      line: 982
   - label: link_header_valid (3)
     section: § 4.2.4.4
     snippet: If attribs["crossorigin"] exists and is an ASCII case-insensitive match for one of the CORS settings attribute keywords
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1001
+      line: 1002
   - label: link_header_valid (4)
     section: § 4.2.4.4
     snippet: If destination is null, then return false.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1000
+      line: 1001
   - label: link_header_valid (5)
     section: § 4.2.4.4
     snippet: Let destination be the result of translating attribs["as"].
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 999
+      line: 1000
   - label: link_header_valid (6)
     section: § 4.2.4.4
     snippet: To process link headers given a Document doc, a response response, and a "pre-media" or "media" phase
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 979
+      line: 980
   - label: refresh_header_syntax
     section: § 4.2.5.3
     snippet: 'For meta elements with an http-equiv attribute in the Refresh state, the content attribute must have a value consisting either of:'
@@ -1310,7 +1310,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 357
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 668
+      line: 669
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 272
   - label: lint-http-rules/src/helpers/uri.rs (9)
@@ -1370,7 +1370,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1069
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1098
+      line: 1106
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 393
     - file: lint-http-rules/src/violations/uri.rs
@@ -3262,7 +3262,7 @@ sources:
     snippet: 'Type and subtype names MUST conform to the following ABNF:'
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1193
+      line: 1204
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
       line: 188
   - label: link_header_valid (2)
@@ -3270,7 +3270,7 @@ sources:
     snippet: restricted-name = restricted-name-first *126restricted-name-chars restricted-name-first  = ALPHA / DIGIT
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1194
+      line: 1205
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
       line: 202
   - label: link_header_valid (3)
@@ -3278,13 +3278,13 @@ sources:
     snippet: restricted-name-chars = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "-" / "^" / "_"
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1195
+      line: 1206
   - label: link_header_valid (4)
     section: § 4.2
     snippet: restricted-name-chars =/ "+" ; Characters after last plus always ; specify a structured syntax suffix
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1197
+      line: 1208
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
       line: 196
   - label: link_header_valid (5)
@@ -3292,13 +3292,13 @@ sources:
     snippet: restricted-name-chars =/ "." ; Characters before first dot always ; specify a facet name
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1196
+      line: 1207
   - label: link_header_valid (6)
     section: § 4.2
     snippet: type-name = restricted-name subtype-name = restricted-name
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1170
+      line: 1181
   - label: media_type_suffix_valid
     section: § 4.2.8
     snippet: '"+suffix" constructs for as-yet unregistered structured syntaxes SHOULD NOT be used, given the possibility of conflicts with future suffix definitions.'
@@ -4307,185 +4307,193 @@ sources:
     snippet: 'This document uses the Augmented Backus-Naur Form (ABNF) [RFC5234] notation of [RFC7230], including the #rule, and explicitly includes the following rules from it'
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 818
+      line: 819
   - label: link_header_valid (2)
     section: § 1.2
     snippet: The requirements regarding conformance and error handling highlighted in [RFC7230], Section 2.5 apply to this document.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 595
+      line: 596
   - label: link_header_valid (3)
     section: § 2.1.1
     snippet: Registered relation type names MUST conform to the reg-rel-type rule (see Section 3.3) and MUST be compared character by character in a case-insensitive fashion.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 966
+      line: 967
   - label: link_header_valid (4)
     section: § 2.1.2
     snippet: When extension relation types are compared, they MUST be compared as strings (after converting to URIs if serialised in a different format) in a case-insensitive fashion, character by character.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1088
+      line: 1096
   - label: link_header_valid (5)
     section: § 2.2
     snippet: The names of target attributes SHOULD conform to the token rule, but SHOULD NOT include any of the characters "%", "'", or "*", for portability across serialisations and MUST be compared in a case-insensitive fashion.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 858
+      line: 859
   - label: link_header_valid (6)
     section: § 3
     snippet: Individual link-params specify their syntax in terms of the value after any necessary unquoting
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 817
+      line: 818
   - label: link_header_valid (7)
     section: § 3
     snippet: 'Link       = #link-value link-value = "<" URI-Reference ">" *( OWS ";" OWS link-param )'
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 597
+      line: 598
   - label: link_header_valid (8)
     section: § 3
     snippet: Note that any link-param can be generated with values using either the token or the quoted-string syntax; therefore, recipients MUST be able to parse both forms.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 816
+      line: 817
   - label: link_header_valid (9)
     section: § 3
     snippet: The Link header field provides a means for serialising one or more links into HTTP headers.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 527
+      line: 528
   - label: link-param optional group
     section: § 3
     snippet: link-param = token BWS [ "=" BWS ( token / quoted-string ) ]
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 815
+      line: 816
     - file: lint-http-rules/src/violations/link.rs
-      line: 135
+      line: 239
   - label: link-value assembly
     section: § 3
     snippet: link-value = "<" URI-Reference ">" *( OWS ";" OWS link-param )
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 667
+      line: 668
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 728
+      line: 729
     - file: lint-http-rules/src/violations/link.rs
       line: 35
     - file: lint-http-rules/src/violations/link.rs
-      line: 88
+      line: 192
     - file: lint-http-rules/src/violations/link.rs
-      line: 111
+      line: 215
   - label: link_header_valid (10)
     section: § 3.1
     snippet: Each link-value conveys one target IRI as a URI-Reference (after conversion to one, if necessary; see [RFC3987], Section 3.1) inside angle brackets ("<>").
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 762
+      line: 763
     - file: lint-http-rules/src/violations/link.rs
-      line: 67
+      line: 171
   - label: link_header_valid (11)
     section: § 3.3
     snippet: Note that extension relation types are REQUIRED to be absolute URIs in Link header fields and MUST be quoted when they contain characters not allowed in tokens
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1087
-  - label: link_header_valid (12)
+      line: 1095
+  - label: rel presence
     section: § 3.3
     snippet: The rel parameter MUST be present but MUST NOT appear more than once in a given link-value; occurrences after the first MUST be ignored by parsers.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 720
+      line: 721
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1033
-  - label: link_header_valid (13)
+      line: 1034
+    - file: lint-http-rules/src/violations/link.rs
+      line: 77
+  - label: link_header_valid (12)
     section: § 3.3
     snippet: The rel parameter can, however, contain multiple link relation types.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1049
-  - label: link_header_valid (14)
+      line: 1053
+  - label: link_header_valid (13)
     section: § 3.3
     snippet: The relation type of a link conveyed in the Link header field is conveyed in the "rel" parameter's value.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1032
-  - label: link_header_valid (15)
+      line: 1033
+  - label: link_header_valid (14)
     section: § 3.3
     snippet: ext-rel-type   = URI ; Section 3 of [RFC3986]
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1086
-  - label: link_header_valid (16)
+      line: 1094
+  - label: link_header_valid (15)
     section: § 3.3
     snippet: reg-rel-type   = LOALPHA *( LOALPHA / DIGIT / "." / "-" )
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1085
+      line: 1093
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1147
-  - label: link_header_valid (17)
+      line: 1158
+  - label: relation-type alternation
     section: § 3.3
     snippet: relation-type  = reg-rel-type / ext-rel-type
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1084
-  - label: link_header_valid (18)
+      line: 1092
+    - file: lint-http-rules/src/violations/link.rs
+      line: 149
+  - label: rel value production
     section: § 3.3
     snippet: relation-type *( 1*SP relation-type )
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1048
-  - label: link_header_valid (19)
+      line: 1052
+    - file: lint-http-rules/src/violations/link.rs
+      line: 100
+    - file: lint-http-rules/src/violations/link.rs
+      line: 120
+  - label: link_header_valid (16)
     section: § 3.4.1
     snippet: Its value MUST be quoted if it contains a semicolon (";") or comma (",").
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 944
-  - label: link_header_valid (20)
+      line: 945
+  - label: link_header_valid (17)
     section: § 3.4.1
     snippet: 'The ABNF for the hreflang parameter''s value is:'
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 909
-  - label: link_header_valid (21)
+      line: 910
+  - label: link_header_valid (18)
     section: § 3.4.1
     snippet: 'The ABNF for the media parameter''s value is:'
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 943
-  - label: link_header_valid (22)
+      line: 944
+  - label: link_header_valid (19)
     section: § 3.4.1
     snippet: 'The ABNF for the type parameter''s value is:'
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 923
-  - label: link_header_valid (23)
+      line: 924
+  - label: link_header_valid (20)
     section: § 3.4.1
     snippet: The title attribute MUST NOT appear more than once in a given link; occurrences after the first MUST be ignored by parsers.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 722
-  - label: link_header_valid (24)
+      line: 723
+  - label: link_header_valid (21)
     section: § 3.4.1
     snippet: The title* link-param MUST NOT appear more than once in a given link-value; occurrences after the first MUST be ignored by parsers.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 723
-  - label: link_header_valid (25)
+      line: 724
+  - label: link_header_valid (22)
     section: § 3.4.1
     snippet: The type attribute MUST NOT appear more than once in a given link-value; occurrences after the first MUST be ignored by parsers.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 724
-  - label: link_header_valid (26)
+      line: 725
+  - label: link_header_valid (23)
     section: § 3.4.1
     snippet: There MUST NOT be more than one media attribute in a link-value; occurrences after the first MUST be ignored by parsers.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 721
+      line: 722
 - label: RFC 8297
   url: https://www.rfc-editor.org/rfc/rfc8297.html
   fragments:
@@ -5375,7 +5383,7 @@ sources:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
       line: 521
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 596
+      line: 597
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
       line: 211
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
@@ -6467,7 +6475,7 @@ sources:
     snippet: A recipient MUST parse for such bad whitespace and remove it before interpreting the protocol element.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 847
+      line: 848
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
       line: 400
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
@@ -6479,7 +6487,7 @@ sources:
     snippet: A sender MUST NOT generate BWS in messages.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 846
+      line: 847
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
       line: 399
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
@@ -6857,7 +6865,7 @@ sources:
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
       line: 173
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 615
+      line: 616
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
       line: 186
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
@@ -7085,7 +7093,7 @@ sources:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
       line: 524
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 599
+      line: 600
     - file: lint-http-rules/src/rules/refresh_header_syntax.rs
       line: 324
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
@@ -7361,7 +7369,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 775
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 607
+      line: 608
   - label: lint-http-rules/src/helpers/list.rs (2)
     section: § 5.6.1.2
     snippet: 'A recipient MUST parse and ignore a reasonable number of empty list elements:'
@@ -7401,7 +7409,7 @@ sources:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 542
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 688
+      line: 689
     - file: lint-http-rules/src/violations/quoted_pair.rs
       line: 38
   - label: lint-http-rules/src/helpers/list.rs (5)


### PR DESCRIPTION
Four entries for the one parameter this serialisation requires and the value it carries.

`rel` absent is one entry reached by two paths — a member with no parameters at all and a member whose parameters do not include this one — because what is missing is the same thing either way. `rel` present and saying nothing is another, and it is distinct from a parameter with an open `=` and nothing after it: a bare `rel` and `rel=""` are both conforming `link-param`s, since the optional group derives the first and a `quoted-string` derives the second, and what they fail is §3.3's own value production, which opens on a relation type. Two spellings, one entry, because a recipient cannot tell them apart once the value is unquoted.

The value's arrangement and a value in it are the last two. A leading or trailing space is admitted nowhere in `relation-type *( 1*SP relation-type )`, and a relation type deriving from neither `reg-rel-type` nor `ext-rel-type` is the alternation's own verdict — reached only where the value has no `:`, because a colon commits it to the URI half and every octet after that belongs to the `uri` subject. An alternation owns no defect until the reading cannot commit; this is the case where it cannot.

Catalogue 295, spec floor 281. Four findings are left in this rule.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
