### PR TITLE
Two fields, one weight, three defects

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -2247,6 +2247,18 @@ severity = "warn"
 # Warning member carries no warn-text
 severity = "warn"
 
+[violations.weight_duplicated]
+# Member carries more than one weight
+severity = "warn"
+
 [violations.weight_equals_whitespace_forbidden]
 # Whitespace is written beside the weight's '='
+severity = "warn"
+
+[violations.weight_malformed]
+# Something other than a weight follows the member's ';'
+severity = "warn"
+
+[violations.weight_missing]
+# Member writes the weight's ';' and no weight after it
 severity = "warn"

--- a/lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
+++ b/lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
@@ -4,7 +4,9 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
-use crate::violations::qvalue::{QVALUE_MALFORMED, RFC_9110_12_4_2};
+use crate::violations::qvalue::{
+    QVALUE_MALFORMED, RFC_9110_12_4_2, WEIGHT_DUPLICATED, WEIGHT_MALFORMED, WEIGHT_MISSING,
+};
 use crate::violations::token::{
     token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
     TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
@@ -25,13 +27,20 @@ pub struct AcceptEncodingParameterValid;
 /// `codings [ weight ]` owns all of it: a separator introducing a weight that
 /// is not there, two of something there may be at most one of, a member whose
 /// non-optional half is missing, and a `name=value` pair no derivation of the
-/// field produces. That is the residue every borrowed construct leaves — what
-/// a construct says about its own assembly — and it is the whole of what this
-/// rule is named for.
+/// field produces. Three of those four are the *weight's* residue rather than
+/// this field's, which is why they now draw the ids
+/// `accept_language_weight_valid` draws: `#( codings [ weight ] )` and
+/// `#( language-range [ weight ] )` put `[ weight ]` after the primary and stop,
+/// so in both fields the only construct that can be malformed after the `;` is
+/// the weight. What is left as this rule's own is the fourth — a member that is
+/// all weight and no coding.
 static DECLARED: &[&ViolationDef] = &[
     &TOKEN_CHARACTER_FORBIDDEN,
     &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
     &QVALUE_MALFORMED,
+    &WEIGHT_MISSING,
+    &WEIGHT_MALFORMED,
+    &WEIGHT_DUPLICATED,
 ];
 
 /// The specification references this rule declares, each named so a finding
@@ -263,7 +272,7 @@ impl Rule for AcceptEncodingParameterValid {
                                 // — whether it sits at the end of the member or
                                 // between two others.
                                 if param.is_empty() {
-                                    return Some(self.violation(ctx.severity, format!(
+                                    return Some(ctx.report_with(&WEIGHT_MISSING, format!(
                                         "Accept-Encoding member '{}' has a ';' with no weight after it",
                                         part
                                     )));
@@ -279,25 +288,35 @@ impl Rule for AcceptEncodingParameterValid {
                                 let val = nv.next();
 
                                 if !name.eq_ignore_ascii_case("q") {
-                                    return Some(self.cited(&RFC_9110_12_4_2, ctx.severity, format!(
+                                    return Some(ctx.report_with(&WEIGHT_MALFORMED, format!(
                                         "'{}' is not a weight, and a weight is the only thing an Accept-Encoding coding may carry (member '{}')",
                                         param, part
                                     )));
                                 }
+                                // §12.5.3 brackets one `[ weight ]` after the
+                                // codings, and the message names it because the
+                                // entry cannot: the same bracket is written once
+                                // per field, and a shared entry may only cite a
+                                // sentence every rule declaring it states.
                                 if weight_seen {
-                                    return Some(self.violation(
-                                        ctx.severity,
+                                    return Some(ctx.report_with(
+                                        &WEIGHT_DUPLICATED,
                                         format!(
-                                            "More than one weight in Accept-Encoding member '{}'",
+                                            "More than one weight in Accept-Encoding member '{}': §12.5.3 brackets one",
                                             part
                                         ),
                                     ));
                                 }
                                 weight_seen = true;
 
+                                // The name matched and the `=` did not, which is
+                                // one literal short of a weight rather than a
+                                // parameter missing its value: `"q="` is written
+                                // as a single string, so there is no `=` here to
+                                // be absent from a pair this field never had.
                                 let Some(v) = val else {
-                                    return Some(self.violation(ctx.severity, format!(
-                                        "Missing parameter value for '{}' in Accept-Encoding member '{}'",
+                                    return Some(ctx.report_with(&WEIGHT_MALFORMED, format!(
+                                        "'{}' is not a weight in Accept-Encoding member '{}': the production writes \"q=\" as one literal and this member stops at the name",
                                         name, part
                                     )));
                                 };

--- a/lint-http-rules/src/rules/accept_language_weight_valid.rs
+++ b/lint-http-rules/src/rules/accept_language_weight_valid.rs
@@ -4,18 +4,28 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
-use crate::violations::qvalue::{QVALUE_MALFORMED, RFC_9110_12_4_2};
+use crate::violations::qvalue::{
+    QVALUE_MALFORMED, RFC_9110_12_4_2, WEIGHT_DUPLICATED, WEIGHT_MALFORMED, WEIGHT_MISSING,
+};
 use crate::violations::ViolationDef;
 
-/// The one defect this rule reports that is not about `Accept-Language`.
+/// Nothing this rule reports is about `Accept-Language` alone.
 ///
 /// A weight is § 12.4.2's number and four fields carry it, so a `q=1.5` here
-/// and a `q=1.5` in an `Accept` are one defect with one severity. Everything
-/// else the rule says is about the *assembly* this field admits — a `;` with
-/// no weight after it, a second weight, a parameter that is not `q` at a field
-/// whose grammar has no parameter list — and each of those is read by this
-/// rule alone, so no subject holds them.
-static DECLARED: &[&ViolationDef] = &[&QVALUE_MALFORMED];
+/// and a `q=1.5` in an `Accept` are one defect with one severity. The rest of
+/// what the rule says was filed under "the *assembly* this field admits" and
+/// read by this rule alone — a `;` with no weight after it, a second weight, a
+/// parameter that is not `q` at a field whose grammar has no parameter list.
+/// `accept_encoding_parameter_valid` says all three about its own field, in
+/// the same order and for the same reason: `#( language-range [ weight ] )`
+/// and `#( codings [ weight ] )` put `[ weight ]` after the primary and stop,
+/// so the only construct that can be malformed there is the weight.
+static DECLARED: &[&ViolationDef] = &[
+    &QVALUE_MALFORMED,
+    &WEIGHT_MISSING,
+    &WEIGHT_MALFORMED,
+    &WEIGHT_DUPLICATED,
+];
 
 pub struct AcceptLanguageWeightValid;
 
@@ -180,8 +190,8 @@ impl Rule for AcceptLanguageWeightValid {
                         // parameter slots, and `weight` brackets nothing, so a `;`
                         // with nothing after it introduces a weight that is absent.
                         if param.is_empty() {
-                            return Some(self.violation(
-                                ctx.severity,
+                            return Some(ctx.report_with(
+                                &WEIGHT_MISSING,
                                 format!(
                                     "Accept-Language member '{}' has a ';' with no weight after it",
                                     member
@@ -197,25 +207,35 @@ impl Rule for AcceptLanguageWeightValid {
                         let val_opt = nv.next();
 
                         if !name.eq_ignore_ascii_case("q") {
-                            return Some(self.cited(&RFC_9110_12_4_2, ctx.severity, format!(
+                            return Some(ctx.report_with(&WEIGHT_MALFORMED, format!(
                                     "'{}' is not a weight, and a weight is the only thing an Accept-Language range may carry (member '{}')",
                                     param, member
                                 )));
                         }
+                        // §12.5.4 brackets one `[ weight ]` after the range,
+                        // and the message names it because the entry cannot: the
+                        // same bracket is written once per field, and a shared
+                        // entry may only cite a sentence every rule declaring it
+                        // states.
                         if weight_seen {
-                            return Some(self.violation(
-                                ctx.severity,
+                            return Some(ctx.report_with(
+                                &WEIGHT_DUPLICATED,
                                 format!(
-                                    "More than one weight in Accept-Language member '{}'",
+                                    "More than one weight in Accept-Language member '{}': §12.5.4 brackets one",
                                     member
                                 ),
                             ));
                         }
                         weight_seen = true;
 
+                        // The name matched and the `=` did not, which is one
+                        // literal short of a weight rather than a parameter
+                        // missing its value: `"q="` is written as a single
+                        // string, so there is no `=` here to be absent from a
+                        // pair this field never had.
                         let Some(val) = val_opt else {
-                            return Some(self.violation(ctx.severity, format!(
-                                    "Missing parameter value for '{}' in Accept-Language member '{}'",
+                            return Some(ctx.report_with(&WEIGHT_MALFORMED, format!(
+                                    "'{}' is not a weight in Accept-Language member '{}': the production writes \"q=\" as one literal and this member stops at the name",
                                     name, member
                                 )));
                         };
@@ -305,6 +325,43 @@ mod tests {
         .expect("a finding");
         assert_eq!(found.violation, "qvalue_malformed", "{field}: {value}");
         assert!(found.message.contains("1.5"), "{}", found.message);
+    }
+
+    /// The assembly around the weight, which this rule's `DECLARED` used to
+    /// call its own. Two fields whose production puts `[ weight ]` after the
+    /// primary and stops, so the only construct that can go wrong after the
+    /// `;` is the weight — and the pair of values in each row is one defect
+    /// written twice, not two defects that resemble each other.
+    #[rstest]
+    #[case("accept-language", "en;", "weight_missing")]
+    #[case("accept-encoding", "gzip;", "weight_missing")]
+    #[case("accept-language", "en;charset=utf-8", "weight_malformed")]
+    #[case("accept-encoding", "gzip;charset=utf-8", "weight_malformed")]
+    // `"q="` is one literal, so a member stopping at the name has not written
+    // it — the same defect as writing another name entirely.
+    #[case("accept-language", "en;q", "weight_malformed")]
+    #[case("accept-encoding", "gzip;q", "weight_malformed")]
+    #[case("accept-language", "en;q=0.5;q=0.8", "weight_duplicated")]
+    #[case("accept-encoding", "gzip;q=0.5;q=0.8", "weight_duplicated")]
+    fn the_weights_assembly_is_the_same_defect_in_both_fields(
+        #[case] field: &str,
+        #[case] value: &str,
+        #[case] expected: &str,
+    ) {
+        let rule: &dyn crate::rules::Rule = if field == "accept-language" {
+            &AcceptLanguageWeightValid
+        } else {
+            &super::super::accept_encoding_parameter_valid::AcceptEncodingParameterValid
+        };
+        let tx = crate::test_helpers::make_test_transaction_with_headers(&[(field, value)]);
+        let found = crate::test_helpers::run_rule(
+            rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_severity(rule.id(), "warn"),
+        )
+        .expect("a finding");
+        assert_eq!(found.violation, expected, "{field}: {value}");
     }
 
     #[rstest]

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1396,7 +1396,15 @@ severity = "warn"
         /// carries the reference, and `alt_svc_header_syntax` — a rule with
         /// fourteen findings this document writes about its own field — now has
         /// no cited site left to lose.
-        const FLOOR: usize = 103;
+        /// **The `qvalue` subject took two at once, and they were the same
+        /// site in two files.** `accept_encoding_parameter_valid` and
+        /// `accept_language_weight_valid` each cited § 12.4.2 from the arm
+        /// reporting that what follows a member's `;` is not a weight — one
+        /// sentence, quoted twice, for a defect neither rule owns alone. The
+        /// entry that replaced them names the same section, so both findings
+        /// are still cited; what the count lost is the *duplication*, which is
+        /// the one thing this floor cannot tell apart from a regression.
+        const FLOOR: usize = 101;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -434,14 +434,26 @@ mod tests {
     /// a specification nor this crate, and a reference on it would dress a
     /// deployment's policy as a requirement.
     ///
-    /// **What is left uncited is those three reasons only** — every one of them
+    /// **A fourth reason arrived with `weight_duplicated`, and it is the first
+    /// that is not about a missing sentence.** `[ weight ]` is bracketed once
+    /// per field — RFC 9110 § 10.1.4, § 12.5.1, § 12.5.3 and § 12.5.4 each
+    /// print it for their own — and one entry is declared by the rules that
+    /// read those fields. `every_violation_spec_is_declared_by_its_rule`
+    /// compares a def's references against *each* declaring rule's, so a
+    /// shared entry may only name a sentence every declarer states, and no
+    /// rule here states another field's production. **The slice answers a def
+    /// whose sections are all stated by one rule and cannot answer a def whose
+    /// sections are stated one per rule** — so this is the shape to look for
+    /// next time an entry has too many sentences rather than none.
+    ///
+    /// **What is left uncited is those four reasons only** — three of them
     /// about sentences that do not exist. An entry naming two is still the exception
     /// rather than a licence: no finding of one carries a citation, because
     /// none of the sentences governs the message on its own.
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 286;
+        const FLOOR: usize = 288;
         let cited = VIOLATIONS.iter().filter(|d| !d.spec.is_empty()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/qvalue.rs
+++ b/lint-http-rules/src/violations/qvalue.rs
@@ -13,11 +13,26 @@
 //! four severities — one per rule, whichever the operator had configured for
 //! everything else that rule says.
 //!
-//! **What the subject does not hold is the *assembly* around the weight.** A
-//! `;` with no weight after it, a second weight in one member, a parameter that
-//! is not `q` at a field admitting no other: those are statements about how a
-//! member is put together, they belong to the fields that make them, and each
-//! is read by one rule.
+//! **The assembly around the weight is here too, and the paragraph this
+//! replaces said it was not.** That paragraph reasoned that a `;` with no
+//! weight after it, a second weight in one member and a parameter that is not
+//! `q` are statements about how a *member* is put together, so they belong to
+//! the fields that make them — "and each is read by one rule". The second half
+//! was asserted and never counted. `Accept-Encoding` and `Accept-Language`
+//! report all three apiece, in code that reads the same because the grammar
+//! does: `#( codings [ weight ] )` and `#( language-range [ weight ] )` admit
+//! exactly one thing after the primary, and it is this production. A
+//! `gzip;q=0.5;q=0.8` and an `en;q=0.5;q=0.8` are one defect with one fix.
+//!
+//! **What keeps `Accept` and `TE` out of it is the same reading from the other
+//! side.** A `media-range` carries `parameters = *( OWS ";" OWS [ parameter ] )`
+//! and a `transfer-coding` carries `*( OWS ";" OWS transfer-parameter )`, so a
+//! `;` in those two fields may introduce something that is not a weight at all:
+//! a trailing one is a bracketed empty repetition and conforms, and a
+//! `charset=utf-8` after a media-range is a parameter the production prints.
+//! The three assembly entries here are for the fields where nothing but a
+//! weight can stand in that position — which is why they are the weight's
+//! defects and not the member's.
 //!
 //! **The weight's own spelling is a different question and is here**, under a
 //! `weight_` prefix rather than a `qvalue_` one — the file stem groups a
@@ -98,6 +113,92 @@ defects! {
         default_severity: Severity::Warn,
         spec: &[RFC_9110_12_4_2],
     }
+
+    /// A `;` with nothing after it, in a field where the `;` can only be the
+    /// weight's own: `en;`, `gzip;;q=0.5`.
+    ///
+    /// The production brackets nothing inside itself. The separator, the
+    /// literal and the number are one alternative-free sequence, so writing the
+    /// `;` is what owes the rest of it — a member ending there has begun a
+    /// weight and abandoned it.
+    ///
+    /// `_missing` and not `_empty`: the `;` is the weight's own first
+    /// character, not a container a sender filled with nothing, so what is
+    /// absent is `"q=" qvalue` — a thing never written where the separator
+    /// requires it.
+    ///
+    /// **The same octet conforms in an `Accept` and in a `TE`**, and that is
+    /// the whole reason this entry can be shared by only two fields.
+    /// `parameters = *( OWS ";" OWS [ parameter ] )` brackets the parameter, so
+    /// `text/plain;` is a zero-parameter repetition and derives; a
+    /// `transfer-coding` prints the same repetition. Only where the field's own
+    /// production puts `[ weight ]` and nothing else after the primary is a
+    /// dangling `;` a defect, and then it is this one.
+    ///
+    // cite(RFC 9110 § 12.4.2, label: the weight production): "weight = OWS ";" OWS "q=" qvalue"
+    WEIGHT_MISSING = {
+        id: "weight_missing",
+        title: "Member writes the weight's ';' and no weight after it",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_9110_12_4_2],
+    }
+
+    /// Something stands where the weight must and is not one: `en;charset=utf-8`,
+    /// `gzip;foo="a;b"`, `en;q`.
+    ///
+    /// **Two spellings, one entry, because the production draws no line between
+    /// them.** `"q="` is a single ABNF string literal with nothing optional
+    /// inside it, so a segment naming any other parameter and a segment naming
+    /// `q` without the `=` both fail to write it — and a recipient that matched
+    /// the literal found no weight either way. The message names which was
+    /// written.
+    ///
+    /// **Not [`PARAMETER_EQUALS_MISSING`](crate::violations::parameter::PARAMETER_EQUALS_MISSING),
+    /// and the difference is which field is being read.** `te_header_valid`
+    /// reports a segment with no `=` under that id, correctly: a `TE` member may
+    /// carry `transfer-parameter`s, so § 5.6.6's `name "=" value` is a
+    /// production the segment could have been trying to write. These two fields
+    /// have no parameter list at all — nothing but a weight derives here — so
+    /// naming a `parameter` requirement would cite a construct the field does
+    /// not have.
+    ///
+    /// Ranked with [`QVALUE_MALFORMED`] rather than above it: in both cases the
+    /// member arrives and the preference does not.
+    ///
+    // cite(RFC 9110 § 12.4.2): "The content negotiation fields defined by this specification use a common parameter, named "q" (case-insensitive), to assign a relative "weight" to the preference for that associated kind of content."
+    WEIGHT_MALFORMED = {
+        id: "weight_malformed",
+        title: "Something other than a weight follows the member's ';'",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[RFC_9110_12_4_2],
+    }
+
+    /// Two weights in one member: `en;q=0.5;q=0.8`.
+    ///
+    /// `[ weight ]` is a single optional repetition, so the second one derives
+    /// from nothing, and a recipient that reads the first and a recipient that
+    /// reads the last disagree about a preference the sender wrote twice.
+    ///
+    /// **Uncited, and for a reason none of the other uncited entries has.** The
+    /// bracket is written once per field — RFC 9110 § 10.1.4, § 12.5.1, § 12.5.3
+    /// and § 12.5.4 each print it for their own — and one entry is declared by
+    /// the rules that read those fields.
+    /// `every_violation_spec_is_declared_by_its_rule` compares a def's
+    /// references against *each* declaring rule's, so a shared entry may only
+    /// name a sentence every declarer states, and no rule here states another
+    /// field's production. A `spec` that is a slice answers a def whose sections
+    /// are all stated by one rule; it cannot answer a def whose sections are
+    /// stated one per rule, so the finding names its own section in its message
+    /// as it already did.
+    WEIGHT_DUPLICATED = {
+        id: "weight_duplicated",
+        title: "Member carries more than one weight",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: &[],
+    }
 }
 
 #[cfg(test)]
@@ -109,5 +210,45 @@ mod tests {
     #[test]
     fn a_weight_that_is_not_one_is_a_warning() {
         assert_eq!(QVALUE_MALFORMED.default_severity, Severity::Warn);
+    }
+
+    /// Every way a member can fail to carry one readable weight leaves the
+    /// member itself standing and the preference unread, so nothing here
+    /// outranks anything else. The flat rank is the claim; do not split it to
+    /// make the subject look finer than the defects are.
+    #[test]
+    fn every_way_of_losing_the_preference_sits_at_one_level() {
+        for def in [
+            &QVALUE_MALFORMED,
+            &WEIGHT_MISSING,
+            &WEIGHT_MALFORMED,
+            &WEIGHT_DUPLICATED,
+            &WEIGHT_EQUALS_WHITESPACE_FORBIDDEN,
+        ] {
+            assert_eq!(def.default_severity, Severity::Warn, "{}", def.id);
+        }
+    }
+
+    /// The separator written with nothing after it and the separator written
+    /// with the wrong thing after it are two ids. `docs/development.md` reads
+    /// `_missing` as a thing never written where it is required and
+    /// `_malformed` as one written and not deriving, which is exactly the line
+    /// between `en;` and `en;charset=utf-8` — different senders, different
+    /// fixes.
+    #[test]
+    fn the_absent_weight_and_the_underived_one_are_two_ids() {
+        assert_eq!(WEIGHT_MISSING.id, "weight_missing");
+        assert_eq!(WEIGHT_MALFORMED.id, "weight_malformed");
+    }
+
+    /// The one entry in this subject that names no sentence, and the assertion
+    /// is what keeps the reason honest: four sections print `[ weight ]`, one
+    /// per field, and a shared entry may only cite what every declarer states.
+    /// If a single sentence is ever found that bounds the repetition for all of
+    /// them, this is the test that has to change first.
+    #[test]
+    fn the_bracket_is_written_once_per_field_so_the_entry_names_none_of_them() {
+        assert!(WEIGHT_DUPLICATED.spec.is_empty());
+        assert!(!WEIGHT_MISSING.spec.is_empty());
     }
 }

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -4921,19 +4921,21 @@ sources:
     snippet: The content negotiation fields defined by this specification use a common parameter, named "q" (case-insensitive), to assign a relative "weight" to the preference for that associated kind of content.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 276
+      line: 285
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 404
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
-      line: 194
+      line: 204
+    - file: lint-http-rules/src/violations/qvalue.rs
+      line: 169
   - label: the weight production
     section: § 12.4.2
     snippet: weight = OWS ";" OWS "q=" qvalue
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 179
+      line: 188
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
-      line: 149
+      line: 159
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
       line: 238
     - file: lint-http-rules/src/rules/te_header_valid.rs
@@ -4941,25 +4943,27 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 319
     - file: lint-http-rules/src/violations/qvalue.rs
-      line: 93
+      line: 108
+    - file: lint-http-rules/src/violations/qvalue.rs
+      line: 138
   - label: accept_encoding_parameter_valid (2)
     section: § 12.5.3
     snippet: 'Accept-Encoding  = #( codings [ weight ] ) codings          = content-coding / "identity" / "*"'
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 178
+      line: 187
   - label: accept_encoding_parameter_valid (3)
     section: § 12.5.3
     snippet: An "identity" token is used as a synonym for "no encoding" in order to communicate when no encoding is preferred.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 222
+      line: 231
   - label: accept_encoding_parameter_valid (4)
     section: § 12.5.3
     snippet: An Accept-Encoding header field with a field value that is empty implies that the user agent does not want any content coding in response.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 200
+      line: 209
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
       line: 127
   - label: accept_encoding_parameter_valid (5)
@@ -4967,13 +4971,13 @@ sources:
     snippet: Each codings value MAY be given an associated quality value (weight) representing the preference for that encoding, as defined in Section 12.4.2.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 255
+      line: 264
   - label: accept_encoding_parameter_valid (6)
     section: § 12.5.3
     snippet: The asterisk "*" symbol in an Accept-Encoding field matches any available content coding not explicitly listed in the field.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 221
+      line: 230
     - file: lint-http-rules/src/violations/content_coding.rs
       line: 66
   - label: accept_encoding_parameter_valid (7)
@@ -4981,13 +4985,13 @@ sources:
     snippet: The field value is evaluated the same way as in a request.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 161
+      line: 170
   - label: accept_encoding_parameter_valid (8)
     section: § 12.5.3
     snippet: When sent by a user agent in a request, Accept-Encoding indicates the content codings acceptable in a response.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 159
+      line: 168
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
       line: 119
   - label: accept_encoding_parameter_valid (9)
@@ -4995,13 +4999,13 @@ sources:
     snippet: When the Accept-Encoding header field is present in a response, it indicates what content codings the resource was willing to accept in the associated request.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 160
+      line: 169
   - label: accept_encoding_parameter_valid (10)
     section: § 8.4.1
     snippet: content-coding   = token
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 220
+      line: 229
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 147
   - label: accept_encoding_present
@@ -5087,19 +5091,19 @@ sources:
     snippet: 'Accept-Language = #( language-range [ weight ] )'
     cited_by:
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
-      line: 148
+      line: 158
   - label: accept_language_weight_valid (2)
     section: § 12.5.4
     snippet: Each language-range can be given an associated quality value representing an estimate of the user's preference for the languages specified by that range, as defined in Section 12.4.2.
     cited_by:
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
-      line: 176
+      line: 186
   - label: accept_language_weight_valid (3)
     section: § 12.5.4
     snippet: The "Accept-Language" header field can be used by user agents to indicate the set of natural languages that are preferred in the response.
     cited_by:
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
-      line: 132
+      line: 142
   - label: accept_patch_header_valid
     section: § 10.2.1
     snippet: The "Allow" header field lists the set of methods advertised as supported by the target resource.
@@ -7371,11 +7375,11 @@ sources:
     - file: lint-http-rules/src/helpers/list.rs
       line: 84
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 201
+      line: 210
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 207
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
-      line: 155
+      line: 165
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 775
     - file: lint-http-rules/src/rules/link_header_valid.rs
@@ -7695,11 +7699,11 @@ sources:
     - file: lint-http-rules/src/helpers/qvalue.rs
       line: 34
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 305
+      line: 324
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
-      line: 223
+      line: 243
     - file: lint-http-rules/src/violations/qvalue.rs
-      line: 61
+      line: 76
   - label: 3xx redirection class
     section: § 15.4
     snippet: The 3xx (Redirection) class of status code indicates that further action needs to be taken by the user agent in order to fulfill the request.


### PR DESCRIPTION
`violations/qvalue.rs` said the assembly around a weight was not its business — a `;` with no weight after it, a second weight, a parameter that is not `q` are statements about how a member is put together, "and each is read by one rule". The second half was asserted and never counted. `Accept-Encoding` and `Accept-Language` report all three apiece, in code that reads the same because the grammar does: `#( codings [ weight ] )` and `#( language-range [ weight ] )` put `[ weight ]` after the primary and stop, so the only construct that can be wrong after the `;` is the weight. A `gzip;q=0.5;q=0.8` and an `en;q=0.5;q=0.8` are one defect with one fix, and were two ids with two severities.

`Accept` and `TE` stay out of it for the same reason from the other side. A `media-range` carries `parameters = *( OWS ";" OWS [ parameter ] )` and a `transfer-coding` carries `*( OWS ";" OWS transfer-parameter )`, so in those fields a `;` may introduce something that is not a weight at all: a trailing one is a bracketed empty repetition and conforms. That is also why a segment with no `=` is `parameter_equals_missing` in a `TE` and `weight_malformed` here — only one of the two fields has a parameter production for it to fail.

The separator with nothing after it and the separator with the wrong thing after it are `_missing` and `_malformed`. A member naming another parameter and a member stopping at `q` are one entry between them, because `"q="` is a single literal with nothing optional inside it and a recipient matching it finds no weight either way.

`weight_duplicated` names no sentence, and the reason is new. The bracket is written once per field — §10.1.4, §12.5.1, §12.5.3 and §12.5.4 each print it for their own — while the entry is declared by the rules that read those fields, and `every_violation_spec_is_declared_by_its_rule` compares a def's references against each declaring rule's. So a shared entry may only cite a sentence every declarer states. A slice answers a def whose sections are all stated by one rule; it cannot answer a def whose sections are stated one per rule, so the finding names its section in its message.

Catalogue 302, spec floor 288, citation floor 103 to 101 — both rules cited §12.4.2 from the arm that reported a segment that is not a weight, which is one sentence quoted twice for a defect neither owns alone.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
